### PR TITLE
docs: finalize Concord conceptual data contracts

### DIFF
--- a/docs/concord-conceptual-design-revised.md
+++ b/docs/concord-conceptual-design-revised.md
@@ -1,47 +1,77 @@
 # pds-concord Conceptual Design
 
-**Status:** Draft for review  
+**Status:** Draft for foundation review  
 **Project:** Paper Data Suite  
 **Module:** `pds-concord`  
-**Date:** July 11, 2026  
-**Revision:** 2 — aligned with current `pds-core` contracts
+**Date:** July 23, 2026  
+**Revision:** 3 — aligned with `pds-core` 0.5/PDS2 and ADR 0014
 
 ## 1. Purpose
 
-`pds-concord` is a Paper Data Suite module for creating, organizing, printing, scanning, filing, reviewing, and scoring paper artifacts used during collaborative classroom activities.
+`pds-concord` is a Paper Data Suite module for creating, organizing, printing, scanning, filing, reviewing, moderating, and scoring paper artifacts used during collaborative classroom activities.
 
-The module exists because collaborative learning produces evidence that is often difficult to preserve. A teacher cannot observe every group continuously, and important evidence may be distributed across discussion notes, group organizers, peer observations, contribution records, rubrics, and teacher annotations.
+The module exists because collaborative learning produces evidence that is often difficult to preserve. A teacher cannot observe every Group continuously, and important evidence may be distributed across discussion notes, shared organizers, peer observations, contribution records, teacher trackers, attached project work, and scoring forms.
 
-Concord provides a paper-first workflow for turning those temporary classroom records into organized, reviewable evidence.
+Concord provides a paper-first workflow for turning those temporary classroom records into organized, reviewable evidence and teacher-approved judgments.
 
-Concord is not a lesson-planning system. It begins after the teacher has already decided what activity students will complete and what evidence would be useful.
+Paper Data Suite is predominantly standards-based. Concord therefore uses standards-based scoring as its primary academic scoring model while retaining legitimate local Criteria for collaborative procedures, roles, responsibilities, and Activity-specific expectations.
+
+Concord is not a lesson-planning system. It begins after the teacher has already decided what Activity students will complete, what evidence would be useful, and—when the Activity is intended to produce academic judgments—which standards the Activity will evaluate.
+
+This document defines Concord’s conceptual scope and architecture. More detailed record-level requirements are governed by:
+
+- `docs/design/initial-concord-domain-model.md`;
+- `docs/design/conceptual-data-contracts.md`;
+- the accepted Concord ADRs, including ADR 0014;
+- and the released `pds-core` 0.5/PDS2 contracts.
+
+When this document conflicts with an accepted ADR or a later finalized conceptual contract, the accepted ADR or later contract governs.
 
 ## 2. Core Definition
 
-> Concord is a paper-based collaborative-evidence system.
+> Concord is a paper-based collaborative-evidence and standards-scoring system.
 
-It helps teachers create and manage scannable paper templates that document what happened during group activities, discussions, seminars, projects, laboratories, and other collaborative work.
+It helps teachers create and manage scannable paper templates that document what happened during discussions, seminars, laboratories, projects, design activities, and other collaborative work.
 
-The scanned artifact remains the primary evidence. Concord may attach metadata and scores to that artifact, but it does not attempt to interpret handwriting, transcribe discussion, or infer student behavior automatically.
+The retained source scan remains the canonical evidence record. Concord may attach metadata, Review decisions, Moderation decisions, evidence links, and teacher-approved Scores to that source, but it does not attempt to interpret handwriting, transcribe discussion, infer student behavior, or assign Scores automatically.
+
+For academic scoring, Concord normally organizes judgment through:
+
+```text
+collaborative evidence
+    -> standard-backed Criterion
+    -> teacher-approved Score
+    -> future standards-based grading and reporting
+```
+
+Concord also supports local Criteria when an Activity needs to record or score an expectation that is not a direct standards judgment.
 
 ## 3. Scope
 
 Concord is responsible for:
 
+- configuring an already-planned collaborative Activity;
+- declaring whether the Activity is evidence-only, standards-based, mixed, or local-criteria-only;
+- selecting a Core-owned standards profile and ordered Focus Standards when standards-based scoring is used;
 - generating printable collaborative-learning templates;
-- combining related templates into activity packets;
-- assigning artifact instances to activities, sessions, groups, or students;
-- adding page-level QR codes and human-readable identifiers;
-- receiving scanned pages or PDFs;
-- identifying and filing scanned artifacts;
+- combining related templates into versioned Activity packets;
+- assigning generated Artifact Instances to Activities, Sessions, Groups, participants, or other supported contexts;
+- creating an Artifact Page identity before printing each returnable page;
+- registering page-level PDS2 routes and adding QR codes and human-readable fallback identifiers;
+- receiving scanned pages or PDFs through Core’s source-retention and dispatch infrastructure;
+- resolving routed pages to existing Artifact Page records;
 - preserving the original scan as the source record;
-- supporting teacher review of scanned evidence;
-- recording criterion-level or component-level scores;
-- distinguishing individual, group, and activity-level evidence;
-- recording who completed, observed, reviewed, or scored an artifact;
-- linking Concord artifacts to related Paper Data Suite records;
-- exporting scores or evidence references for use by other modules; and
-- supporting paper-first and offline classroom workflows.
+- supporting teacher Review of scanned evidence;
+- supporting Moderation when evidence requires a reliability, fairness, or permitted-use judgment;
+- defining standard-backed and local Criteria;
+- recording criterion-level teacher-approved Scores;
+- distinguishing individual, Group, Artifact, Session, Activity, and component targets;
+- recording who completed, observed, reviewed, moderated, corrected, or scored a record;
+- linking Concord evidence to related Paper Data Suite records;
+- preserving standards identity, scale identity, evidence provenance, and supersession history;
+- making approved standard-backed Scores available through a future standards-result handoff contract;
+- making local Scores and evidence references distinguishable from direct standards results;
+- and supporting paper-first, local-first, and offline classroom workflows.
 
 ## 4. Non-Goals
 
@@ -52,109 +82,219 @@ Concord does not:
 - recognize or interpret handwriting;
 - evaluate extended written responses;
 - replace `pds-quillan`;
-- reimplement PDS Core workspace, roster, identifier, QR-contract, source-retention, routing-metadata, or standards infrastructure;
+- reimplement PDS Core workspace, roster, identifier, PDS2, route-registration, source-retention, dispatch, or standards infrastructure;
+- create a competing standards library or standards-profile system;
 - transcribe audio or video;
 - create automated or AI-generated records of classroom discussion;
 - perform automated scoring of collaborative behavior;
+- infer a standards Score from the presence of evidence or standards metadata;
+- infer mastery, proficiency, growth, or a course Grade from one Concord Score;
+- convert ScoreForm or Quillan results into Concord Scores automatically;
+- require every Activity to select standards or produce Scores;
+- force every useful collaborative Criterion to be a standard;
 - plan lessons or design units;
-- calculate marking-period or course grades;
-- generate report cards or parent reports;
-- infer engagement, leadership, collaboration, or understanding from behavior;
-- require audio, video, cloud services, or continuous connectivity; or
-- function as a public participation leaderboard.
+- calculate marking-period or course Grades;
+- aggregate results across Activities, modules, courses, terms, or years;
+- normalize or convert Scoring Scales automatically;
+- generate report cards, parent reports, or longitudinal standards reports;
+- manage formal safety, disciplinary, medical, disability, or counseling records;
+- infer engagement, leadership, collaboration, or understanding from behavior alone;
+- require audio, video, cloud services, or continuous connectivity;
+- or function as a public participation leaderboard.
 
 ## 5. Relationship to Other Paper Data Suite Modules
 
 ### 5.1 `pds-core`
 
-PDS Core owns, or is designated to own, shared infrastructure used across Paper Data Suite modules. Concord should consume that infrastructure rather than create parallel workspace, identity, QR, routing, scan-retention, or standards systems.
+PDS Core owns shared infrastructure used across Paper Data Suite modules. Concord consumes that infrastructure rather than creating parallel workspace, identity, routing, source-retention, or standards systems.
 
-The intended dependency direction is:
+The dependency direction is:
 
 ```text
 pds-concord -> pds-core
 ```
 
-Concord should not depend directly on ScoreForm or Quillan merely to access shared behavior. Cross-module relationships should use shared Paper Data Suite identifiers and contracts wherever possible.
+Concord does not depend directly on ScoreForm or Quillan merely to access shared behavior. Cross-module relationships use public module-qualified identifiers and contracts.
 
 PDS Core responsibilities relevant to Concord include:
 
 - resolving and validating the Paper Data Suite workspace root;
-- maintaining shared baseline workspace paths;
-- validating durable identifiers and constructing safe paths;
-- owning canonical class, assignment, roster, and student identity conventions;
-- providing canonical student display helpers while preserving `student_id` as the durable identity;
-- defining shared `PDS1` QR construction, parsing, validation, and routing contracts;
+- owning canonical class, roster, and student identity conventions;
+- validating durable identifiers and constructing safe module-qualified paths;
+- defining the PDS2 locator grammar;
+- parsing and serializing PDS2 locators;
+- owning Route Registration records;
+- resolving a route to a module-owned record reference;
 - retaining active source scans before module-specific processing;
-- preserving provenance from routed evidence back to retained source scans;
-- defining shared scan-routing failure and resolution metadata;
-- owning the shared standards library, standards profiles, and durable `standard_id` and `profile_id` references;
-- providing shared teacher-facing menu navigation behavior; and
-- opening existing local files or folders through the operating system without giving modules separate platform-specific implementations.
+- preserving provenance from routed derivatives to retained source scans and source pages;
+- defining generic routing-failure and resolution metadata;
+- dispatching a successful route to the registered module profile;
+- owning the shared standards library;
+- owning standards profiles and durable `standard_id` and `profile_id` references;
+- validating standards and profile membership at workflow boundaries;
+- and exposing shared contract-version information.
 
-Concord should use PDS Core for these concerns. Concord should continue to own:
+Concord owns:
 
-- Concord packet, template, and artifact schemas;
-- collaborative artifact PDF layouts;
-- activity-specific groups and group membership;
-- sessions, participant roles, artifact authors, and artifact subjects;
-- Concord-specific criteria and rubrics;
-- Concord-specific artifact review and moderation behavior;
-- score-entry and scoring workflows;
-- module-specific routed evidence and result formats; and
-- Concord's teacher-facing workflow and interface.
+- Concord Activities and Sessions;
+- Activity-specific Groups, Memberships, Roles, and Responsibilities;
+- Activity scoring orientation;
+- selection of Core standards profiles and Focus Standards for Concord Activities;
+- Template Definitions and immutable Template Versions;
+- Packet Definitions, immutable Packet Versions, and Packet Components;
+- generated Packet, Artifact, and Artifact Page records;
+- Artifact Authors and Artifact Subjects;
+- Concord-specific Scan References;
+- Review, Moderation, correction, and supersession behavior;
+- standard-backed and local Criteria;
+- Concord Scoring Scales and Score Records;
+- Score Evidence Links;
+- Concord-specific standards-result handoff projections;
+- and Concord’s teacher-facing workflow and interface.
 
-PDS Core's active-scan contract separates shared retention from module-specific processing. Concord should use Core to retain source scans and preserve provenance before processing them. Concord remains responsible for QR extraction, PDF or image splitting, Concord-specific routing, teacher review, scoring, and routed evidence assembly.
+#### PDS2 work identity
 
-PDS Core also establishes two important constraints for Concord's future contract work:
+For Core routing and workspace identity:
 
-1. The current shared `PDS1` QR contract recognizes ScoreForm and Quillan but does not yet register Concord.
-2. The current `PDS1` contract requires a `student_id`, while Concord must support group-level, teacher-level, session-level, and activity-level artifacts that may have no single student subject.
+```text
+module_id = concord
+class_id  = <Core class identifier>
+work_id   = <Concord activity_id>
+```
 
-Concord must not work around those constraints by inventing a separate QR grammar, placing group identifiers in `student_id`, or creating synthetic students. Before implementation, the shared Core QR contract should be extended deliberately to register `module=concord` and represent non-student artifact subjects.
+For Concord:
 
-Similarly, PDS Core owns canonical class and assignment routes, while Concord will need module-specific storage for group and activity artifacts. The contract phase must determine which new route helpers belong in Core and which Concord-specific subdirectories may safely live inside the canonical assignment structure.
+```text
+work_id = activity_id
+```
 
-Relevant Core contracts include:
+The effective module work identity is:
 
-- [`README.md`](https://github.com/Paper-Data-Suite/pds-core/blob/main/README.md)
-- [`docs/qr_payload_and_routing_contract.md`](https://github.com/Paper-Data-Suite/pds-core/blob/main/docs/qr_payload_and_routing_contract.md)
-- [`docs/roster_workspace_contract.md`](https://github.com/Paper-Data-Suite/pds-core/blob/main/docs/roster_workspace_contract.md)
-- [`docs/active_scan_contract.md`](https://github.com/Paper-Data-Suite/pds-core/blob/main/docs/active_scan_contract.md)
-- [`docs/module_standards_integration.md`](https://github.com/Paper-Data-Suite/pds-core/blob/main/docs/module_standards_integration.md)
+```text
+module_id + class_id + work_id
+```
+
+Concord does not need a second Core-versus-Concord assignment identity for PDS2 routing.
+
+The canonical Concord work root is conceptually:
+
+```text
+classes/<class_id>/modules/concord/work/<activity_id>/
+```
+
+Concord must use Core helpers rather than construct this path from unvalidated strings.
+
+#### PDS2 route target
+
+A normal Concord Route Registration targets an existing Artifact Page:
+
+```text
+module_id: concord
+record_kind: artifact_page
+record_id: <artifact_page_id>
+```
+
+The Artifact Page must exist before its Route Registration and QR code are generated.
+
+The normal resolution chain is:
+
+```text
+PDS2 locator
+    -> Core Route Registration
+    -> Concord Artifact Page
+    -> Concord Artifact Instance
+    -> optional Packet Instance
+    -> Activity
+    -> optional Session and Group context
+    -> Artifact Authors
+    -> Artifact Subjects
+```
+
+The QR code identifies the expected physical route. It does not encode the complete semantic graph.
 
 ### 5.2 `pds-scoreform`
 
-ScoreForm owns machine-readable OMR workflows.
+ScoreForm owns machine-readable selected-response and OMR workflows.
 
 Examples include:
 
 - multiple-choice assessments;
 - bubble-based ratings;
 - structured response grids;
-- machine-readable accountability checks; and
-- OMR-based checklists.
+- machine-readable accountability checks;
+- and OMR-based checklists.
 
-Concord may link to a ScoreForm assignment or include a packet instruction directing students to complete one. Concord must not implement a competing OMR system.
+ScoreForm may attach durable standards metadata to individual questions while preserving answer-key-based scoring.
+
+Concord may reference a ScoreForm assignment or result as:
+
+- an individual accountability check;
+- a pre- or post-Activity content check;
+- supporting evidence for a standard-backed Concord Score;
+- contextual evidence;
+- or a packet instruction.
+
+Concord must not:
+
+- implement a competing OMR system;
+- copy ScoreForm answer keys or result ownership;
+- treat question-level alignment as a Concord Score;
+- convert percentage correct automatically into a Concord Scoring Scale value;
+- or infer a standards judgment without explicit teacher approval.
+
+When a ScoreForm result supports a Concord Score, the conceptual relationship is:
+
+```text
+ScoreForm result
+    -> Concord External Reference
+    -> Concord Evidence Reference
+    -> Concord Score Evidence Link
+    -> explicit Concord Score Record
+```
 
 ### 5.3 `pds-quillan`
 
-Quillan owns focused written-response workflows.
+Quillan owns focused and extended written-response workflows.
 
 Examples include:
 
 - individual reflections;
 - extended peer feedback;
-- written defenses of group decisions;
+- written defenses of Group decisions;
 - analytical exit responses;
-- explanations of learning; and
-- substantial written self-assessment.
+- explanations of learning;
+- and substantial written self-assessment.
 
-Concord may link a collaborative activity to a Quillan response. Concord may also generate short labels, prompts, captions, or structured note areas, but it should not become a written-response evaluation system.
+Quillan makes Focus Standards the organizing unit for its teacher review and standards-based result records.
+
+Concord may reference a Quillan assignment, response, or standards result as:
+
+- an individual reflection;
+- supporting evidence;
+- complementary written evidence;
+- a follow-up explanation;
+- or contextual evidence for a Concord judgment.
+
+Concord must not:
+
+- recreate Quillan’s review-unit workflow;
+- copy Quillan-owned result records;
+- assume a Quillan rating determines a Concord Score;
+- or convert a Quillan result without an explicit Concord teacher judgment.
+
+When a Quillan record supports a Concord Score, the conceptual relationship is:
+
+```text
+Quillan record
+    -> Concord External Reference
+    -> Concord Evidence Reference
+    -> Concord Score Evidence Link
+    -> explicit Concord Score Record
+```
 
 ### 5.4 Future lesson-planning module
 
-A future Paper Data Suite module may manage:
+A future Paper Data Suite planning module may manage:
 
 - objectives;
 - instructional sequencing;
@@ -162,102 +302,208 @@ A future Paper Data Suite module may manage:
 - materials;
 - timing;
 - differentiation;
-- lesson plans; and
-- unit plans.
+- lesson plans;
+- and unit plans.
 
-Concord begins after the teacher has already planned the collaborative activity. It creates the paper instrumentation used to enact, observe, document, and assess the activity.
+Concord begins after the teacher has already planned the collaborative Activity.
 
-### 5.5 Future reporting or gradebook modules
+A planning module may later propose:
 
-A future reporting or gradebook module may combine:
+- Activity title;
+- class;
+- Sessions;
+- Groups;
+- scoring orientation;
+- standards profile;
+- ordered Focus Standards;
+- packet recommendation;
+- Criteria;
+- or linked ScoreForm and Quillan work.
 
-- Concord scores;
-- ScoreForm scores;
-- Quillan scores;
-- teacher-entered scores;
-- project results; and
-- grading policies.
+Concord remains capable of operating independently.
 
-Concord records scores and evidence. It does not determine final grades.
+### 5.5 Future grading and reporting module
+
+A future Paper Data Suite grading and reporting module may combine:
+
+- Concord standard-backed Scores;
+- Concord local Scores under an explicit policy;
+- ScoreForm results;
+- Quillan standards results;
+- teacher-entered results;
+- project results;
+- Scoring Scale semantics;
+- grading policies;
+- and reporting policies.
+
+Concord records contextual evidence and teacher-approved judgments. It does not determine final Grades, mastery, growth, or longitudinal standards status.
+
+A future standards-result handoff from Concord must make the following meaning available without reverse-engineering generic Criterion metadata:
+
+- module, class, and Activity identity;
+- optional Session identity;
+- Score Record identity;
+- target identity and target kind;
+- governing `standard_id` for a standard-backed Score;
+- Criterion identity;
+- exact Scoring Scale revision;
+- Score disposition;
+- Score value when applicable;
+- scorer and scoring time;
+- evidence-link references;
+- Moderation state;
+- and supersession state.
+
+Local Scores must remain distinguishable from direct standards results.
 
 ## 6. Design Principles
 
 ### 6.1 Paper-first
 
-Printed artifacts are central, not fallback exports from a digital system.
+Printed Artifacts are central, not fallback exports from a digital system.
 
-The workflow should remain useful when students have no devices and when the teacher chooses to conduct the activity entirely on paper.
+The workflow should remain useful when students have no devices and when the teacher chooses to conduct the Activity entirely on paper.
 
-### 6.2 Human-reviewed
+### 6.2 Human-reviewed and teacher-approved
 
 Concord files and presents evidence for human interpretation.
 
-The system does not decide what handwriting means, whether a contribution was valuable, or whether a peer judgment is fair.
+The system does not decide:
 
-### 6.3 Preserve the source artifact
+- what handwriting means;
+- whether a contribution was valuable;
+- whether a peer judgment was fair;
+- whether evidence proves a standard;
+- or which Score value should be assigned.
 
-The scan is the canonical evidence record.
+A consequential Score is created only through an authorized teacher or scorer judgment.
 
-Metadata, notes, transcriptions entered manually, reviews, and scores are linked records. They do not replace or silently alter the original scan.
+### 6.3 Preserve the source Artifact
+
+The Core-retained source scan is canonical evidence.
+
+Metadata, notes, derived images, Reviews, Moderation Records, evidence links, and Scores are linked records. They do not replace or silently alter the retained source.
 
 ### 6.4 Clear module boundaries
 
-Concord must not duplicate OMR, written-response evaluation, lesson planning, grading, or reporting functionality owned by other modules.
+Concord must not duplicate OMR, written-response evaluation, lesson planning, grading, reporting, identity, standards-library, or PDS2 infrastructure owned elsewhere.
 
-### 6.5 Activity-specific evidence
+### 6.5 Predominantly standards-based, not standards-exclusive
 
-A Socratic seminar, laboratory group, design challenge, debate, and programming team should not be forced into one universal rubric.
+Standards-based scoring is Concord’s primary academic scoring model.
 
-Teachers should be able to select or adapt templates appropriate to the activity.
+Activities intended to produce academic performance judgments should normally select:
 
-### 6.6 Separate evidence, review, score, grade, and report
+- one Core standards profile;
+- one or more ordered Focus Standards;
+- standard-backed Criteria;
+- and exact Scoring Scale revisions.
+
+Concord also preserves local Criteria for legitimate Activity-specific, procedural, organizational, or collaborative expectations.
+
+A local Criterion may be useful and scoreable without becoming a direct standards judgment.
+
+### 6.6 Standards selection is not standards performance
+
+Selecting a profile or Focus Standard establishes intended Activity scope.
+
+It does not prove that the standard was:
+
+- taught;
+- practiced;
+- assessed;
+- demonstrated;
+- mastered;
+- or included in a final Grade.
+
+A direct Concord standards result exists only through an explicit standard-backed Score Record.
+
+### 6.7 One governing standard per direct standards judgment
+
+A standard-backed Criterion has exactly one governing `standard_id`.
+
+Therefore:
+
+```text
+one standard-backed Score
+    -> one immutable Criterion
+    -> one governing standard_id
+```
+
+When evidence is relevant to two standards, Concord should ordinarily use two Criteria and two Score Records.
+
+A holistic multi-standard Criterion may exist as a local Criterion with non-governing alignment metadata, but one holistic Score must not be duplicated across several standards automatically.
+
+### 6.8 Activity-specific evidence and Criteria
+
+A Socratic seminar, laboratory Group, design challenge, debate, and programming team should not be forced into one universal rubric.
+
+Teachers should be able to select or adapt:
+
+- templates appropriate to the Activity;
+- standard-backed Criteria that describe the Focus Standard in that context;
+- local Criteria that capture legitimate non-standard expectations;
+- and Scoring Scales appropriate to the judgment.
+
+### 6.9 Separate evidence, Review, Moderation, Score, Grade, and report
 
 These are distinct concepts:
 
-- **Evidence:** the completed paper artifact or teacher record;
-- **Review:** a human interpretation or moderation step;
-- **Score:** a judgment about a criterion or activity component;
-- **Grade:** a broader academic calculation that may combine many scores;
+- **Evidence:** a completed Artifact, teacher record, external result, Event, Attachment, or rationale that may support a judgment;
+- **Review:** a human determination of filing, readability, attribution, relevance, completeness, privacy, and readiness;
+- **Moderation:** a human determination of whether and how evidence may be used consequentially;
+- **Score:** one teacher-approved judgment about one Criterion for one target;
+- **Grade:** a broader academic calculation that may combine many judgments;
 - **Report:** a presentation or communication of selected results.
 
-Concord handles evidence, review, and scoring. Grade calculation and reporting belong elsewhere.
+Concord handles evidence, Review, Moderation, and Scoring. Grade calculation and cross-Activity or cross-module reporting belong elsewhere.
 
-### 6.7 Provenance
+### 6.10 Provenance
 
-Every artifact and score should preserve enough context to answer:
+Every Artifact and Score should preserve enough context to answer:
 
-- who completed it;
+- who completed or represented it;
 - whom or what it concerns;
-- which activity and session produced it;
-- which template version was used;
-- who reviewed or scored it;
+- which Activity and Session produced it;
+- which Group or component supplied context;
+- which Template and Packet revisions were used;
+- which standard and Criterion governed a direct standards Score;
+- which Scoring Scale revision governed the value;
+- who reviewed, moderated, corrected, or scored it;
+- which evidence was deliberately used;
 - and when those actions occurred.
 
-### 6.8 Minimal classroom burden
+### 6.11 Historical preservation
+
+Printed, distributed, scanned, reviewed, moderated, scored, exported, or reported records must not be silently rewritten in ways that change their historical meaning.
+
+Corrections and replacements preserve the earlier record and identify the superseding record.
+
+### 6.12 Minimal classroom burden
 
 Evidence collection should not interfere with the collaboration being documented.
 
-Forms should be as short and focused as the activity permits.
+Forms should be as short and focused as the Activity permits. A standards-based architecture does not require printing full standard text on every page or asking students to complete administrative metadata that Concord can resolve from linked records.
 
-### 6.9 Privacy by default
+### 6.13 Privacy by default
 
-Peer observations, contribution disputes, and teacher judgments may be sensitive.
+Peer observations, contribution disputes, Moderation rationales, and teacher judgments may be sensitive.
 
-Concord should avoid public rankings and should support restricted visibility for peer- and teacher-generated records.
+Concord should avoid public rankings and should support record-specific restricted visibility.
 
-### 6.10 Local-first
+### 6.14 Local-first
 
 Concord should work within the Paper Data Suite local workspace model and should not require third-party cloud processing.
 
 ## 7. Core Domain Concepts
 
-This section defines conceptual terms. It does not prescribe final classes, JSON schemas, or database tables.
+This section defines conceptual terms. It does not prescribe final Python classes, JSON schemas, filesystem records, or database tables.
 
 ### 7.1 Activity
 
-An already-planned collaborative classroom task.
+An **Activity** is one already-planned collaborative classroom undertaking and Concord’s top-level module-owned work unit.
 
-Examples:
+Examples include:
 
 - Socratic seminar;
 - science laboratory;
@@ -265,274 +511,433 @@ Examples:
 - literature circle;
 - group research project;
 - debate;
-- engineering challenge; and
-- peer review workshop.
+- engineering challenge;
+- and peer-review workshop.
 
-An activity may occur in one or more sessions.
+For PDS2 routing:
 
-### 7.2 Session
+```text
+work_id = activity_id
+```
 
-One occurrence or work period within an activity.
+An Activity occurs in one or more Sessions.
 
-A multi-day project may have several sessions, each with different groups, roles, or artifacts.
+An Activity declares one scoring orientation:
 
-### 7.3 Template
+- `evidence_only`;
+- `standards_based`;
+- `mixed`;
+- or `local_criteria_only`.
 
-A reusable printable design.
+A standards-based or mixed Activity selects one Core standards profile and one or more ordered Focus Standards.
 
-Examples:
+### 7.2 Scoring orientation
+
+**Scoring orientation** states what kind of judgments an Activity is configured to produce.
+
+#### `evidence_only`
+
+The Activity collects, organizes, Reviews, or moderates evidence without creating Concord Score Records.
+
+#### `standards_based`
+
+The Activity’s scored judgments are direct judgments against selected Focus Standards through standard-backed Criteria.
+
+#### `mixed`
+
+The Activity uses both direct standard-backed Criteria and local Criteria.
+
+#### `local_criteria_only`
+
+The Activity produces local Score Records but no direct standards judgments.
+
+Scoring orientation prevents later consumers from guessing whether generic Criteria represent standards performance.
+
+### 7.3 Focus Standard
+
+A **Focus Standard** is a durable Core-owned `standard_id` deliberately selected for a standards-based or mixed Activity.
+
+An Activity’s ordered `focus_standard_ids`:
+
+- define intended standards-scoring scope;
+- belong to the selected Core standards profile;
+- are ordered for teacher-facing workflow and later handoff;
+- and do not by themselves create standards evidence or Scores.
+
+### 7.4 Session
+
+A **Session** is one occurrence or work period within an Activity.
+
+A multi-day project may have several Sessions, each with different Groups, Memberships, Roles, Responsibilities, Artifacts, or evidence.
+
+Even a single-period Activity has one explicit Session.
+
+### 7.5 Group
+
+A **Group** is an Activity-specific collaborative unit.
+
+Groups are Concord-owned and are not added to the Core roster.
+
+A Group may have a parent Group when a bounded subteam identity is needed.
+
+### 7.6 Group Membership
+
+A **Group Membership** associates one participant with one Group for a defined Activity context.
+
+Membership is contextual and historical. A participant may belong to different Groups in different Sessions without rewriting earlier Membership records.
+
+Membership does not establish:
+
+- Artifact authorship;
+- contribution;
+- Role fulfillment;
+- or a Score.
+
+### 7.7 Role Assignment
+
+A **Role Assignment** records a contextual function held by a participant.
+
+Examples include:
+
+- peer observer;
+- discussion mapper;
+- facilitator;
+- recorder;
+- materials manager;
+- tester;
+- debugger;
+- or integration coordinator.
+
+Roles are contextual functions, not personality labels or permanent classifications.
+
+### 7.8 Responsibility Assignment
+
+A **Responsibility Assignment** records a specific obligation assigned to a participant, Group, or child Group.
+
+It records what was assigned. It does not prove completion, quality, contribution, or Role fulfillment.
+
+### 7.9 Template Definition
+
+A **Template Definition** is the stable lineage of one reusable printable design.
+
+Examples include:
 
 - discussion map;
 - peer observation form;
 - group process rubric;
 - contribution record;
-- teacher observation sheet;
-- project retrospective; and
-- artifact cover sheet.
+- teacher observation tracker;
+- standards-scoring rubric;
+- or Artifact cover sheet.
 
-A template is not yet assigned to a specific class, group, or student.
+A Template Definition is not assigned to a specific class, Group, participant, or Activity.
 
-### 7.4 Template version
+### 7.10 Template Version
 
-A fixed revision of a template.
+A **Template Version** is one immutable revision of a Template Definition.
 
-Versioning is necessary because layout, prompts, QR placement, scoring criteria, or page structure may change over time.
+Versioning is required because layout, prompts, page structure, QR placement, authorship expectations, subject expectations, supported Criteria, or return behavior may change.
 
-A scanned artifact must remain linked to the exact template version that generated it.
+A generated Artifact remains linked to the exact Template Version that produced it.
 
-### 7.5 Packet definition
+### 7.11 Packet Definition
 
-A reusable collection of templates assembled for one kind of activity.
+A **Packet Definition** is the stable lineage of a reusable packet design.
+
+It identifies the packet’s name, purpose, and revision family. Ordered composition belongs to Packet Version.
+
+### 7.12 Packet Version
+
+A **Packet Version** is one immutable ordered composition of Template Versions and optional external components.
 
 Example:
 
 ```text
-Socratic Seminar Packet
-├── Discussion map
-├── Peer observer sheet
-├── Group process rubric
-└── Teacher scoring rubric
+Socratic Seminar Packet — Version 3
+├── Discussion map — Template Version 2
+├── Peer observer sheet — Template Version 4
+├── Teacher observation tracker — Template Version 3
+├── Focus Standards scoring rubric — Template Version 1
+└── Optional Quillan reflection reference
 ```
 
-A packet definition is reusable and unassigned.
+A Packet Version becomes immutable after it generates a Packet Instance.
 
-### 7.6 Packet instance
+### 7.13 Packet Component
 
-A generated packet tied to a specific classroom context.
+A **Packet Component** is one ordered element of a Packet Version.
 
-A packet instance may be associated with:
+It may identify:
 
-- course or class;
-- activity;
-- session;
-- group;
-- student;
-- teacher; and
-- generation date.
+- an exact Concord Template Version;
+- or an external component owned by another module or system.
 
-### 7.7 Artifact instance
+Physical packet assembly does not transfer record ownership.
 
-A particular generated copy of one template.
+### 7.14 Packet Instance
 
-Examples:
+A **Packet Instance** is one generated packet tied to a specific Activity context.
+
+It may be associated with:
+
+- Activity;
+- Session;
+- Group;
+- participant;
+- series or checkpoint;
+- generator;
+- and generation date.
+
+### 7.15 Artifact Instance
+
+An **Artifact Instance** is one generated copy of one Template Version.
+
+Examples include:
 
 - the discussion map generated for Group 3;
-- the peer observation sheet assigned to Student A;
+- one peer observation sheet assigned to a student observer;
 - the teacher observation page for Period 2;
-- the retrospective sheet for the laboratory group.
+- or one project retrospective generated for a milestone.
 
-Each artifact instance must have a stable identifier.
+Each Artifact Instance has stable identity and one or more Artifact Pages.
 
-### 7.8 Artifact author
+### 7.16 Artifact Page
 
-The person or group that completed the artifact.
+An **Artifact Page** is one expected physical page within an Artifact Instance.
 
-Examples:
+Every returned scannable page has stable identity before rendering.
 
-- an individual student;
-- a peer observer;
-- a group recorder;
-- the full group;
-- the teacher; or
-- another authorized adult.
+When routing is required, the Artifact Page receives one immutable `route_id`, and Core stores a Route Registration targeting that Artifact Page.
 
-The author is not necessarily the subject.
+### 7.17 Artifact Author
 
-### 7.9 Artifact subject
+An **Artifact Author** is a durable association between an Artifact Instance and the person or collective that completed, produced, recorded, or formally represented it.
 
-The person, group, session, or activity described by the artifact.
+Examples include:
 
-Examples:
+- individual student;
+- co-authors;
+- peer observer;
+- Group recorder;
+- collective Group;
+- teacher;
+- or another authorized adult.
 
-- Student B;
-- Group 4;
-- the whole-class seminar;
-- one project session; or
-- one group product.
+The Author is not necessarily the Subject or Score target.
 
-### 7.10 Scan
+### 7.18 Artifact Subject
 
-A digital image or PDF representation of the completed paper artifact.
+An **Artifact Subject** is a durable association between an Artifact Instance and the person, Group, Session, Activity, Event, component, or object that the Artifact concerns.
 
-A scan may contain:
+One Artifact may have several Subjects.
 
-- one artifact page;
-- several pages;
-- an entire packet;
-- a mixed batch from multiple groups; or
-- an attachment paired with a Concord cover sheet.
+Subject does not establish authorship and does not automatically create a Score.
 
-### 7.11 Filing metadata
+### 7.19 Scan Reference
 
-The information used to associate a scan with its proper context.
+A **Scan Reference** is Concord’s durable association between one Artifact Page and one page or region of a Core-retained source scan.
 
-Typical metadata may include:
+A Scan Reference preserves routing, readability, filing, Review, duplicate, rescan, conflict, and supersession semantics without replacing the retained source.
 
-- artifact instance ID;
-- packet instance ID;
-- template ID and version;
-- activity ID;
-- session ID;
-- class ID;
-- group ID;
-- student ID;
-- author role;
-- subject type;
-- page number; and
-- privacy classification.
+### 7.20 Review
 
-### 7.12 Review
+A **Review** is a human examination of an Artifact Instance and its available routed evidence.
 
-A human examination of a scanned artifact.
+A Review may:
 
-A review may:
+- confirm readability and completeness;
+- confirm or correct filing;
+- confirm or correct Authors and Subjects;
+- confirm privacy;
+- determine relevance;
+- identify whether Moderation is required;
+- and determine readiness for possible scoring.
 
-- confirm that the scan is complete;
-- correct filing metadata;
-- identify the author or subject;
-- note missing or unreadable sections;
-- accept or reject peer evidence;
-- add a teacher note;
-- flag the artifact for follow-up; or
-- approve it for scoring.
+Review does not determine performance and does not create a Score.
 
-### 7.13 Criterion
+### 7.21 Moderation
 
-A defined aspect of performance or evidence.
+A **Moderation Record** documents an authorized judgment about whether and how evidence may be used consequentially.
 
-Examples:
-
-- responds to peers' ideas;
-- supports claims with evidence;
-- fulfills assigned responsibilities;
-- advances group decision-making;
-- contributes to the shared product; and
-- helps the group revise its approach.
-
-Criteria may be qualitative or scored.
-
-### 7.14 Score
-
-A teacher-approved judgment attached to a criterion or activity component.
-
-A score may apply to:
-
-- an individual;
-- a group;
-- an artifact;
-- a session;
-- an activity component; or
-- a final collaborative outcome.
-
-A score is not a grade.
-
-### 7.15 Moderation
-
-A review step in which the teacher evaluates the reliability or relevance of evidence before it affects a score.
-
-Moderation may be especially important for:
+Moderation is especially important for:
 
 - peer observations;
-- disputed contribution records;
-- conflicting group accounts;
-- incomplete artifacts; and
-- evidence created by students about other students.
+- disputed contribution claims;
+- conflicting Group accounts;
+- student-generated claims about other students;
+- and incomplete or questionable evidence.
 
-### 7.16 External reference
+Moderation does not select the Criterion, Score target, standard, or Score value.
 
-A link to a related record owned by another Paper Data Suite module.
+### 7.22 Criterion Set
 
-Examples:
+A **Criterion Set** is one immutable revision of an ordered collection of related Criteria.
 
-- ScoreForm individual accountability check;
-- Quillan written reflection;
-- shared roster record;
-- standards record;
-- future lesson-plan record;
-- future report or gradebook record.
+A Criterion Set is classified as:
+
+- `standard_backed`;
+- `local`;
+- or `mixed`.
+
+A standard-backed Set contains only standard-backed Criteria. A local Set contains only local Criteria. A mixed Set contains both.
+
+### 7.23 Standard-backed Criterion
+
+A **standard-backed Criterion** defines how one selected Focus Standard will be judged in the Concord Activity context.
+
+It has exactly one governing `standard_id`.
+
+Example:
+
+```text
+Focus Standard:
+njsls-ela:SL.PE.9-10.1
+
+Activity-specific Criterion:
+Builds on peers’ ideas and responds substantively during collaborative discussion
+```
+
+The Criterion contextualizes the standard. It does not redefine the Core-owned standard.
+
+### 7.24 Local Criterion
+
+A **local Criterion** evaluates an Activity-specific, procedural, organizational, product, or collaborative expectation that is not a direct standards rating.
+
+Examples include:
+
+- performs the assigned observer rotation;
+- returns shared materials to the agreed location;
+- records a component handoff;
+- maintains the Group version log;
+- or follows a locally defined procedure.
+
+A local Criterion may carry optional non-governing standards-alignment metadata.
+
+A Score against a local Criterion is not a direct standards result.
+
+### 7.25 Scoring Scale
+
+A **Scoring Scale** is one immutable revision of the values permitted for Score Records.
+
+A scale may be:
+
+- ordinal;
+- categorical;
+- numeric;
+- binary;
+- rubric-based;
+- or teacher-defined.
+
+Concord does not assume that similarly numbered scales are semantically equivalent.
+
+### 7.26 Score Record
+
+A **Score Record** is one teacher-approved judgment about one Criterion for one target in one Activity context using one exact Scoring Scale revision.
+
+A Score Record is classified as:
+
+- `standard_backed` when its immutable Criterion has one governing standard;
+- or `local` when its Criterion is local.
+
+A standard-backed Score preserves or exposes one unambiguous governing `standard_id`.
+
+A Score is not a course Grade, final mastery determination, or longitudinal proficiency claim.
+
+### 7.27 Score Evidence Link
+
+A **Score Evidence Link** records the deliberate use of one evidence source in one Score judgment.
+
+One Score may use several evidence sources. One evidence source may support several Scores.
+
+Evidence reuse does not make the resulting Scores equivalent.
+
+### 7.28 Standards Result Handoff Projection
+
+A **Standards Result Handoff Projection** is a future derived interoperability view of a canonical standard-backed Concord Score Record.
+
+It makes standards meaning available to the future grading and reporting module without changing ownership of the Score Record.
+
+It does not perform aggregation, weighting, scale conversion, mastery determination, or Grade calculation.
+
+### 7.29 External Reference
+
+An **External Reference** is a Concord-owned relationship to a record owned by another module or external system.
+
+Examples include:
+
+- ScoreForm result;
+- Quillan response or standards result;
+- external project Artifact;
+- source-control record;
+- cloud document;
+- or future grading and reporting record.
+
+The external owner remains authoritative.
 
 ## 8. Artifact Model
 
-Concord artifacts fall into three conceptual classes.
+Concord Artifacts fall into three conceptual classes.
 
-### 8.1 Structured Concord artifacts
+### 8.1 Structured Concord Artifacts
 
-These are generated specifically by Concord and contain stable page layouts, QR codes, prompts, tables, rubrics, or graphic organizers.
+These are generated by Concord and contain stable page layouts, PDS2 QR codes, prompts, tables, rubrics, trackers, or graphic organizers.
 
-Examples:
+Examples include:
 
 - teacher observation sheet;
 - peer observation form;
-- group process rubric;
+- standards-based scoring rubric;
+- local process checklist;
 - contribution log;
 - decision map;
 - concept map;
-- project retrospective; and
-- scoring rubric.
+- project retrospective;
+- and Artifact cover sheet.
 
-Concord identifies and files these artifacts but does not interpret handwritten content automatically.
+Concord identifies and files these Artifacts but does not interpret handwritten content automatically.
 
 ### 8.2 Attached collaborative work
 
-These are irregular or teacher-created artifacts associated with a Concord activity.
+These are irregular or externally created Artifacts associated with a Concord Activity.
 
-Examples:
+Examples include:
 
 - poster;
 - handwritten design sketch;
 - annotated text;
-- group notes;
+- Group notes;
 - chart paper;
 - laboratory diagram;
 - storyboard;
-- project planning page; and
-- printed collaborative document.
+- printed source code;
+- and collaborative digital document export.
 
-These may be filed using:
+They may be associated through:
 
-- a Concord cover sheet;
-- a QR label;
-- a companion artifact slip; or
-- another page-level identifier.
+- an Artifact cover sheet;
+- QR label;
+- Attachment record;
+- External Reference;
+- or companion identification page.
 
 ### 8.3 Instructional scaffolds
 
-These are printable materials that support the activity but may not need to be scanned.
+These are printable materials that support the Activity but may not need to return.
 
-Examples:
+Examples include:
 
-- role cards;
+- Role cards;
 - discussion stems;
 - collaboration norms;
 - protocol instructions;
-- group procedure cards; and
-- peer-feedback guidance.
+- Group procedure cards;
+- and peer-feedback guidance.
 
-Some scaffolds may become evidence-bearing if students write on them. The template definition should declare whether a scaffold is expected to return to the system.
+A Template Version declares whether each page is expected to return and whether it requires a PDS2 route.
 
 ## 9. Artifact Taxonomy
 
-The initial taxonomy should be broad enough to support different subjects without becoming a universal rubric.
+The initial taxonomy should support different subject areas without becoming a universal rubric or fixed curricular ontology.
 
 ### 9.1 `discussion_tracker`
 
@@ -544,7 +949,7 @@ Examples:
 - question-response map;
 - evidence-use tracker;
 - idea-connection chart;
-- seminar observation map.
+- and seminar observation map.
 
 ### 9.2 `teacher_observation`
 
@@ -553,32 +958,41 @@ Provides a paper interface for teacher observation.
 Examples:
 
 - roster grid;
-- group rotation sheet;
+- Group rotation sheet;
 - anecdotal note form;
-- targeted criterion tracker;
-- conference record.
+- Focus Standard tracker;
+- targeted Criterion tracker;
+- and conference record.
 
 ### 9.3 `peer_observation`
 
-Allows a student to record evidence about another student or group.
+Allows a student to record evidence about another student or Group.
 
 Examples:
 
 - seminar observer sheet;
 - teamwork observation form;
-- criterion-specific peer record;
-- peer conference notes.
+- Criterion-specific peer record;
+- and peer conference notes.
+
+Peer evidence may require Moderation before consequential use.
 
 ### 9.4 `group_process_rubric`
 
-Supports evaluation of how the group worked.
+Supports evaluation of how the Group worked.
+
+A Group-process rubric may contain:
+
+- standard-backed Criteria when a selected Focus Standard governs the judgment;
+- local Criteria for Activity-specific procedures;
+- or both in a mixed Activity.
 
 Examples:
 
 - collaboration rubric;
-- group functioning rubric;
+- Group functioning rubric;
 - project-team process rubric;
-- laboratory teamwork rubric.
+- and laboratory teamwork rubric.
 
 ### 9.5 `contribution_record`
 
@@ -589,8 +1003,10 @@ Examples:
 - contribution chart;
 - responsibility record;
 - task-completion record;
-- artifact authorship sheet;
-- role fulfillment record.
+- Artifact authorship sheet;
+- and Role-fulfillment record.
+
+A contribution record is evidence, not automatically a Score.
 
 ### 9.6 `group_graphic_organizer`
 
@@ -605,7 +1021,7 @@ Examples:
 - compare-and-contrast matrix;
 - decision matrix;
 - problem-solution organizer;
-- sequence chart.
+- and sequence chart.
 
 ### 9.7 `collaborative_work_log`
 
@@ -613,16 +1029,17 @@ Provides a lightweight chronological record.
 
 Examples:
 
-- session log;
+- Session log;
 - decision log;
 - troubleshooting record;
-- design iteration log;
+- design-iteration log;
 - milestone record;
-- project checkpoint sheet.
+- project checkpoint sheet;
+- and component-handoff log.
 
 ### 9.8 `group_retrospective`
 
-Helps the group examine its process after or during the activity.
+Helps the Group examine its process after or during the Activity.
 
 Examples:
 
@@ -630,9 +1047,9 @@ Examples:
 - start/stop/continue;
 - team retrospective;
 - process reflection grid;
-- next-session improvement plan.
+- and next-Session improvement plan.
 
-This category should remain concise and structured. Extended individual writing belongs to Quillan.
+This category remains concise and structured. Extended individual writing belongs to Quillan.
 
 ### 9.9 `artifact_cover_sheet`
 
@@ -641,20 +1058,21 @@ Associates irregular or externally created work with Concord metadata.
 Examples:
 
 - poster cover sheet;
-- attached work routing page;
-- project artifact identification page;
-- multi-page submission cover.
+- attached-work routing page;
+- project Artifact identification page;
+- and multi-page submission cover.
 
 ### 9.10 `moderation_record`
 
-Documents teacher review of evidence.
+Documents teacher review of evidence use.
 
 Examples:
 
 - peer-evidence review form;
 - conflicting-evidence resolution;
 - attribution correction;
-- accepted/rejected evidence record.
+- accepted-with-qualification decision;
+- and rejected-evidence record.
 
 ### 9.11 `scoring_rubric`
 
@@ -662,37 +1080,44 @@ Supports criterion-level teacher scoring.
 
 Examples:
 
-- individual collaboration rubric;
-- group outcome rubric;
-- seminar performance rubric;
-- project contribution rubric.
+- Focus Standards seminar rubric;
+- standards-based laboratory-practice rubric;
+- engineering-design Criterion rubric;
+- mixed standards-and-local project rubric;
+- local procedural checklist;
+- and Group outcome rubric.
+
+A rubric must make standard-backed and local Criteria distinguishable.
 
 ### 9.12 `correction_or_exception`
 
-Handles unusual or damaged records.
+Handles unusual, damaged, corrected, or unresolved records.
 
 Examples:
 
 - missing-page form;
-- incorrect group assignment;
+- incorrect Group assignment;
 - absence note;
 - disputed attribution;
 - rescan request;
-- unmatched scan routing sheet.
+- unmatched Scan Reference;
+- and Score revision record.
 
 ## 10. Packet Model
 
-Concord should treat packets as composable collections of artifacts rather than as lessons.
+Concord treats packets as composable collections of versioned components rather than as lessons.
 
 A packet may contain:
 
-- student-facing artifacts;
-- group-facing artifacts;
-- peer-observer artifacts;
-- teacher-facing artifacts;
-- scoring artifacts;
-- cover sheets; and
-- optional links to ScoreForm or Quillan work.
+- student-facing Artifacts;
+- Group-facing Artifacts;
+- peer-observer Artifacts;
+- teacher-facing Artifacts;
+- standards-based scoring Artifacts;
+- local process Artifacts;
+- cover sheets;
+- instructional scaffolds;
+- and optional links to ScoreForm or Quillan work.
 
 ### 10.1 Example: Socratic seminar packet
 
@@ -700,23 +1125,37 @@ A packet may contain:
 Socratic Seminar Packet
 ├── Group discussion map
 ├── Peer observation sheet
-├── Teacher observation tracker
-├── Seminar scoring rubric
+├── Teacher Focus Standards observation tracker
+├── Standards-based seminar scoring rubric
+├── Optional local observer-rotation checklist
 └── Optional Quillan reflection reference
 ```
+
+Possible direct standards judgments might include:
+
+- builds on peers’ ideas;
+- uses relevant textual evidence;
+- and integrates information from the discussion.
+
+The observer-rotation checklist may remain a local Criterion if it is not a direct standards judgment.
 
 ### 10.2 Example: Science laboratory packet
 
 ```text
 Science Laboratory Packet
-├── Shared K-W-L or prediction chart
+├── Shared prediction organizer
 ├── Group procedure organizer
 ├── Contribution record
 ├── Decision and troubleshooting log
-├── Teacher observation sheet
-├── Group process rubric
+├── Teacher standards observation sheet
+├── Mixed standards-and-local rubric
 └── Optional ScoreForm accountability check reference
 ```
+
+The mixed rubric might include:
+
+- a standard-backed Criterion for evaluating evidence or engineering constraints;
+- and a local Criterion for completing a required equipment check.
 
 ### 10.3 Example: Programming or engineering project packet
 
@@ -724,115 +1163,155 @@ Science Laboratory Packet
 Collaborative Project Packet
 ├── Task and responsibility record
 ├── Design decision matrix
-├── Work-session log
+├── Work-Session log
 ├── Contribution record
 ├── Group retrospective
-├── Teacher scoring rubric
+├── Focus Standards scoring rubric
+├── Optional local handoff-protocol checklist
 └── Artifact cover sheet
 ```
+
+Source code, CAD files, and repository history remain externally owned evidence.
 
 ## 11. Artifact Lifecycle
 
 The conceptual lifecycle is:
 
 ```text
-Select packet or templates
+Select Packet Version or Template Versions
         ↓
-Configure activity context
+Configure Activity and scoring orientation
         ↓
-Generate packet and artifact instances
+Select standards profile and Focus Standards when required
+        ↓
+Select standard-backed and/or local Criteria
+        ↓
+Generate Packet and Artifact Instances
+        ↓
+Create Artifact Pages and PDS2 Route Registrations
         ↓
 Print and distribute
         ↓
-Complete artifacts on paper
+Complete Artifacts on paper
         ↓
 Collect and scan
         ↓
-Identify and file pages
+Core retains source scans
+        ↓
+Resolve and file Artifact Pages
         ↓
 Review scans and metadata
         ↓
-Moderate evidence where needed
+Moderate evidence where required
         ↓
-Record scores
+Record teacher-approved Scores when configured
         ↓
-Export or link scores elsewhere
+Project standards results or expose local Scores appropriately
         ↓
-Retain, archive, or delete according to policy
+Retain or archive according to policy
 ```
+
+Not every Activity or Artifact passes through every step.
+
+Examples:
+
+- an evidence-only Activity stops before scoring;
+- a non-returned scaffold stops after distribution;
+- a missing Artifact never reaches Scan Review;
+- a peer observation may require Moderation;
+- a teacher tracker may move directly from Review to scoring use;
+- and a local-criteria-only Activity produces no direct standards-result projection.
 
 ### 11.1 Select
 
-The teacher chooses a reusable packet definition or individual templates.
+The teacher chooses one immutable Packet Version or one or more Template Versions.
 
 ### 11.2 Configure
 
-The teacher supplies only the context necessary to generate artifacts, such as:
+The teacher supplies only the context necessary to generate and interpret Artifacts, such as:
 
 - class;
-- activity;
-- session;
-- groups;
-- students;
-- criteria;
-- scorer;
-- privacy setting; and
-- linked ScoreForm or Quillan work.
+- Activity;
+- Sessions;
+- Groups;
+- participants;
+- scoring orientation;
+- standards profile and ordered Focus Standards when required;
+- Criterion Sets;
+- Scoring Scales;
+- privacy policy;
+- and linked ScoreForm or Quillan work.
 
-This is configuration, not lesson planning.
+This is Activity configuration, not lesson planning.
 
 ### 11.3 Generate
 
 Concord creates:
 
+- Packet Instance records;
+- Artifact Instance records;
+- Artifact Page records;
 - printable PDFs;
+- PDS2 Route Registrations for route-required pages;
 - page-level QR codes;
 - human-readable fallback identifiers;
 - packet manifests;
-- artifact instance records; and
-- page numbering.
+- and page numbering.
 
 ### 11.4 Complete
 
-Students and teachers write, draw, annotate, or mark the printed artifacts.
+Students and teachers write, draw, annotate, or mark the printed Artifacts.
 
 ### 11.5 Scan
 
 Completed pages are scanned individually or in batches.
 
-### 11.6 Identify and file
+Core retains the selected source before Concord-specific filing.
 
-Concord reads page-level identifiers and associates each scan with its artifact instance.
+### 11.6 Resolve and file
+
+Core resolves the PDS2 locator to an Artifact Page registration and dispatches the route to Concord.
+
+Concord creates a Scan Reference linking the routed source page to that Artifact Page.
 
 This stage identifies the page. It does not interpret handwritten content.
 
 ### 11.7 Review
 
-The teacher confirms:
+The teacher confirms or records:
 
 - correct filing;
 - scan quality;
-- completeness;
-- author and subject;
+- page completeness;
+- Author and Subject attribution;
 - relevance;
-- privacy classification; and
-- readiness for scoring.
+- privacy classification;
+- Moderation requirement;
+- and readiness for possible scoring.
 
 ### 11.8 Moderate
 
-The teacher reviews student-generated evidence when it may affect a consequential score.
+The teacher determines whether and how evidence may be used when reliability, fairness, attribution, or consequential use requires a separate judgment.
 
 ### 11.9 Score
 
-The teacher records criterion or component scores while viewing the source artifact.
+The authorized scorer records one criterion-level judgment for one target using one exact Scoring Scale revision.
 
-### 11.10 Export or link
+For a standard-backed Score, the governing standard is unambiguous through the immutable standard-backed Criterion and the Score contract.
 
-Concord makes approved scores or evidence references available to other Paper Data Suite modules.
+For a local Score, the record remains explicitly local and is not projected as a direct standards result.
 
-## 12. QR and Identification Design
+### 11.10 Handoff or link
 
-Every scannable page should normally contain its own QR code.
+Concord makes approved records available to other modules through explicit contracts:
+
+- standard-backed Scores through a future Standards Result Handoff Projection;
+- local Scores as local Criterion judgments;
+- and evidence through module-qualified references.
+
+## 12. PDS2 QR and Identification Design
+
+Every returnable scannable page should normally contain its own PDS2 QR code.
 
 Packet-level identification alone is insufficient because pages may be:
 
@@ -840,252 +1319,528 @@ Packet-level identification alone is insufficient because pages may be:
 - reordered;
 - rescanned;
 - submitted independently;
-- attached to other work; or
-- mixed with pages from other groups.
+- attached to other work;
+- or mixed with pages from other Groups.
 
-### 12.1 QR purpose
+### 12.1 PDS2 locator grammar
 
-The QR code identifies and routes the artifact instance.
+The PDS2 grammar is:
 
-It does not encode student responses or scoring results.
+```text
+PDS2|m=<module_id>|c=<class_id>|w=<work_id>|r=<route_id>
+```
 
-### 12.2 Shared `PDS1` alignment
+A Concord page uses:
 
-Concord QR codes should use the shared PDS Core `PDS1` contract rather than a Concord-specific payload grammar.
+```text
+PDS2|m=concord|c=<class_id>|w=<activity_id>|r=<route_id>
+```
 
-The shared payload should identify enough context to route the page, while Concord's local artifact record provides the complete module-specific meaning. Likely shared or Concord-specific references include:
+### 12.2 QR purpose
 
-- `module=concord`;
-- class ID;
-- assignment or activity-routing ID;
-- page number and total pages;
-- document or artifact type;
-- template ID and version;
-- artifact instance ID;
-- packet instance ID;
-- session ID;
-- group ID, when applicable;
-- student ID, when applicable;
-- author or subject type; and
-- privacy classification.
+The QR code identifies one expected physical page route.
 
-The exact field set cannot be finalized until PDS Core extends `PDS1` for Concord. The current contract requires `student_id`, but many Concord pages concern a group, teacher observation, session, or activity rather than one student. The shared contract must represent those cases directly without fake student records or overloaded fields.
+It does not encode:
 
-QR payloads should contain only routing identifiers and minimal metadata. Names and other unnecessary personally identifiable information should remain outside the payload.
+- student responses;
+- Artifact Authors;
+- Artifact Subjects;
+- Group Membership;
+- Score target;
+- Criterion;
+- standard;
+- Scoring Scale;
+- Score value;
+- privacy graph;
+- or the complete semantic context of the page.
 
-### 12.3 Human-readable fallback
+Those meanings resolve through the registered Artifact Page and linked Concord records.
 
-Each page should also contain a visible short code or label for manual filing when:
+### 12.3 Route Registration
+
+A route-required Artifact Page has one immutable `route_id`.
+
+Core stores a Route Registration targeting:
+
+```text
+module_id: concord
+record_kind: artifact_page
+record_id: <artifact_page_id>
+```
+
+The Artifact Page must exist before registration and rendering.
+
+### 12.4 Human-readable fallback
+
+Each route-required page should contain a visible fallback label for manual resolution when:
 
 - the QR code is damaged;
 - the scan is incomplete;
-- the code cannot be read; or
-- the page must be handled without software.
+- the code cannot be read;
+- or the page must be handled without automated routing.
 
-### 12.4 Page design
+The fallback identifier must not expose unnecessary PII.
+
+### 12.5 Page design
 
 Templates should reserve stable areas for:
 
 - QR code;
-- short identifier;
+- fallback identifier;
 - title;
-- activity and session context;
-- student or group identification, when needed;
+- human-readable Activity or Session context where useful;
+- student or Group display labels where pedagogically necessary;
 - page number;
-- teacher review status; and
-- template version.
+- and Template Version.
+
+Printed display labels are not durable identities.
 
 ## 13. Scan and Filing Model
 
-PDS Core owns the shared active source-scan retention and provenance contract. Concord should retain each readable selected source through Core before Concord-specific QR extraction, page splitting, identification, filing, review, or scoring.
+PDS Core owns shared source-scan retention, source-page provenance, route resolution, failure metadata, and generic dispatch.
 
-Concord's module-specific scanning responsibility is identification and filing, not content extraction.
+Concord’s scan responsibility is the module-specific association between a routed source page and an expected Artifact Page.
 
 ### 13.1 Canonical source
 
-The original scan should be preserved as the canonical artifact image or PDF.
+The Core-retained source scan is canonical.
 
-### 13.2 Derived records
+Concord-created derivatives may support Review, but they never replace the retained source.
 
-The following may be linked to the scan:
+### 13.2 Scan Reference
 
-- corrected metadata;
-- teacher notes;
-- review status;
-- moderation decisions;
-- criterion scores;
-- component scores;
-- external references; and
-- audit history.
+After successful dispatch, Concord creates a Scan Reference that may record:
 
-### 13.3 Filing states
+- Artifact Page identity;
+- Core source-scan identity;
+- source-page position;
+- optional routed derivative;
+- routing status;
+- readability status;
+- filing status;
+- Review status;
+- preferred-for-use state;
+- provenance;
+- and supersession.
 
-A scan may move through states such as:
+### 13.3 Independent states
 
-- received;
-- identified;
-- unmatched;
-- partially matched;
-- filed;
-- needs review;
-- reviewed;
-- approved for scoring;
-- scored;
-- superseded by rescan; and
-- archived.
+Concord should not collapse all scan facts into one status.
 
-Final state names should be decided during contract design.
+A Scan Reference may separately represent:
 
-### 13.4 Rescans
+- routing state;
+- readability;
+- filing correctness;
+- Review state;
+- preferred-for-use state;
+- duplicate state;
+- and supersession state.
 
-A rescan should not silently erase the earlier image.
+### 13.4 Rescans and duplicates
 
-The later scan may supersede the earlier one while preserving:
+A rescan creates a new retained source and a new Scan Reference.
 
-- the original file;
-- the reason for replacement;
-- the date;
-- the user who performed the action; and
-- the relationship between versions.
+A duplicate is preserved and may later be reclassified.
+
+Neither silently erases an earlier source or association.
 
 ## 14. Review and Moderation Model
 
 ### 14.1 Review is not transcription
 
-A teacher may write a note or select a review status, but Concord should not require the teacher to recreate all handwritten content digitally.
+A teacher may enter a note or select a Review judgment, but Concord should not require the teacher to recreate all handwritten content digitally.
 
-### 14.2 Moderation status
+### 14.2 Review is not scoring
 
-Student-generated evidence may be marked conceptually as:
+A Review may establish that evidence is readable, correctly filed, relevant, and ready for possible use.
 
-- unreviewed;
+It does not determine performance and does not create a Score.
+
+### 14.3 Moderation status
+
+Student-generated evidence may be moderated as:
+
 - accepted;
 - accepted with qualification;
-- rejected;
-- disputed;
 - insufficient;
-- or not applicable.
+- disputed;
+- rejected;
+- or not used for scoring.
 
-The final set of states should remain small and understandable.
+An accepted Moderation decision means that evidence may be used under the recorded conditions. It is not a high Score.
 
-### 14.3 Missing evidence
+A rejected decision is not negative evidence against the Subject.
+
+### 14.4 Missing and exceptional evidence
 
 The system must distinguish:
 
 - not observed;
 - not applicable;
 - absent;
-- incomplete artifact;
-- unreadable artifact;
-- insufficient evidence;
-- and not demonstrated.
+- excused;
+- deferred;
+- incomplete Artifact;
+- unreadable Artifact;
+- misrouted evidence;
+- unavailable external evidence;
+- and insufficient evidence.
 
-These conditions should not automatically receive the same score.
+These conditions must not be converted automatically into zero, the lowest Scoring Scale value, or a mastery failure.
 
 ## 15. Scoring Model
 
-### 15.1 Score ownership
+### 15.1 Primary model
 
-A score is recorded by an authorized scorer, normally the teacher.
+Concord’s primary academic scoring model is standards-based.
 
-Student-generated peer ratings may be stored as evidence, but they should not become final Concord scores without teacher review.
+The normal academic relationship is:
 
-### 15.2 Score targets
+```text
+reviewed and permitted evidence
+    -> standard-backed Criterion
+    -> teacher-approved standard-backed Score
+```
 
-A score may target:
+Concord remains standards-aware without being standards-exclusive.
 
-- one student;
-- one group;
-- one artifact;
-- one criterion;
-- one session;
-- one activity component;
-- or one shared outcome.
+Some Activities are evidence-only. Some use local Criteria only. Mixed Activities use both standard-backed and local Criteria.
 
-### 15.3 Score components
+### 15.2 Activity scoring orientations
 
-A conceptual score record may need:
+Each Activity declares one scoring orientation.
 
-- scorer;
-- subject;
-- criterion;
-- scale;
-- value;
-- maximum or level set;
-- artifact source;
-- activity and session;
-- individual or group scope;
-- date;
-- moderation status;
-- note or rationale;
-- superseded status; and
-- export status.
+#### `evidence_only`
 
-### 15.4 Scoring scales
+The Activity produces no Concord Score Records.
 
-Concord should not impose one universal scale.
+It may still produce reviewed, moderated, and exportable evidence.
+
+#### `standards_based`
+
+The Activity produces direct standards judgments through standard-backed Criteria.
+
+It requires:
+
+- one valid `standards_profile_id`;
+- one or more ordered `focus_standard_ids`;
+- standard-backed Criteria;
+- and exact Scoring Scale revisions.
+
+#### `mixed`
+
+The Activity produces both:
+
+- direct standard-backed Scores;
+- and local Criterion Scores.
+
+It also requires one standards profile and one or more ordered Focus Standards.
+
+#### `local_criteria_only`
+
+The Activity produces local Scores but no direct standards judgments.
+
+Local Scores may later affect a Grade only through an explicit downstream policy.
+
+### 15.3 Focus Standards
+
+Focus Standards define the Activity’s intended standards-scoring scope.
+
+Rules include:
+
+- standards identity remains Core-owned;
+- `standards_profile_id` is one durable Core profile reference;
+- `focus_standard_ids` is ordered and nonempty for standards-based and mixed Activities;
+- duplicate Focus Standards are invalid;
+- each Focus Standard should belong to the selected profile;
+- and selection alone does not create a Score or mastery claim.
+
+### 15.4 Criterion kinds
+
+Every scored Criterion is classified as standard-backed or local.
+
+#### Standard-backed Criterion
+
+A standard-backed Criterion:
+
+- has exactly one governing `standard_id`;
+- uses a standard selected as an Activity Focus Standard;
+- defines what that standard looks like in the Activity context;
+- and may support one or more valid target kinds.
+
+Example:
+
+```text
+Standard:
+njsls-ela:SL.PE.9-10.1
+
+Criterion:
+Builds on peers’ ideas and responds substantively during collaborative discussion
+```
+
+#### Local Criterion
+
+A local Criterion:
+
+- has no governing `standard_id`;
+- evaluates an Activity-specific or procedural expectation;
+- may carry optional non-governing alignment metadata;
+- and does not produce a direct standards result.
+
+Example:
+
+```text
+Local Criterion:
+Completes the assigned observer rotation and submits the observation form
+```
+
+#### Multi-standard holistic Criteria
+
+One Score against a holistic Criterion must not be treated as several direct standards ratings.
+
+When a behavior provides direct evidence for two standards, Concord should ordinarily use two standard-backed Criteria and two Score Records.
+
+A holistic multi-standard Criterion may remain local with alignment metadata, or a later explicit composite contract may define another interpretation.
+
+### 15.5 Score ownership and meaning
+
+A Score is recorded by an authorized scorer, normally the teacher.
+
+Student-generated peer ratings may be stored as evidence, but they do not become final Concord Scores without teacher approval.
+
+One Score Record evaluates:
+
+- exactly one Criterion;
+- for exactly one target;
+- in one Activity context;
+- using one exact Scoring Scale revision.
+
+A standard-backed Score is one contextual judgment about one governing standard.
+
+A local Score is one contextual judgment about one local Criterion.
+
+### 15.6 Score dispositions
+
+A Score Record distinguishes:
+
+- `scored`;
+- `insufficient_evidence`;
+- `absent`;
+- `excused`;
+- `not_observed`;
+- `not_applicable`;
+- and `deferred`.
+
+When the disposition is `scored`, a valid value from the selected Scoring Scale is required.
+
+When the disposition is not `scored`, a value is absent. Zero or the lowest level must not be inferred.
+
+### 15.7 Score targets
+
+A Score target may be:
+
+- one Core student;
+- one Concord Group;
+- one Session;
+- one Activity;
+- one Artifact Instance;
+- one Work Item;
+- or another approved Activity component.
+
+A target must be valid for the Criterion.
+
+A Group Score does not become an individual Score for each member.
+
+### 15.8 Evidence and Scores
+
+One Score may use:
+
+- several Concord Artifacts;
+- one teacher tracker;
+- peer evidence permitted through Moderation;
+- an Attachment;
+- an Activity Event;
+- a Contribution Claim;
+- a ScoreForm result;
+- a Quillan response or result;
+- another external record;
+- professional judgment with rationale;
+- or a mixed basis.
+
+One evidence source may support several Scores through separate Score Evidence Links.
+
+Group or multi-subject evidence may support an individual Score only when:
+
+- the evidence is relevant to the individual target;
+- required Moderation permits that use;
+- the teacher makes an explicit individual judgment;
+- and the evidence link or rationale explains the relevance.
+
+Group evidence must never generate individual Scores automatically.
+
+### 15.9 Scoring Scales
+
+Concord does not impose one universal Scoring Scale.
 
 Possible scales include:
 
-- binary;
-- ordinal levels;
-- numeric points;
-- rubric bands;
-- completion status;
-- proficiency categories; and
-- teacher-defined labels.
+- Developing / Approaching / Meeting / Exceeding;
+- Beginning / Progressing / Proficient / Advanced;
+- numeric ordinal levels;
+- binary demonstrated/not-demonstrated where appropriate;
+- categorical judgments;
+- and teacher-defined labels.
 
-### 15.5 Score is not grade
+A Scoring Scale revision preserves:
 
-Concord may record:
+- permitted machine values;
+- display labels;
+- descriptions;
+- ordering where applicable;
+- semantic meaning;
+- and historical revision identity.
+
+Concord does not assume that one scale’s `3` means the same as another scale’s `3`.
+
+### 15.10 Examples
+
+#### Standards-based seminar
 
 ```text
-Uses evidence in discussion: 3 of 4
-Responds to peers' ideas: 2 of 4
-Group process: 15 of 20
-Shared product: 18 of 20
+Focus Standard: SL.PE.9-10.1
+Criterion: Builds on peers’ ideas during discussion
+Score: Meeting
+Target: Student
+Evidence: Teacher tracker + moderated peer observation
 ```
 
-These are scores.
+```text
+Focus Standard: RL.CR.9-10.1
+Criterion: Uses relevant textual evidence to support claims
+Score: Approaching
+Target: Student
+Evidence: Discussion map + teacher observation
+```
 
-A future gradebook or reporting module may decide:
+These are direct standards-based Concord judgments.
 
-- how scores are weighted;
-- whether they are combined;
-- whether they are dropped;
-- how they affect a course grade; and
-- how they are reported.
+#### Mixed laboratory Activity
 
-Concord should not make those decisions.
+```text
+Focus Standard: HS-ETS1-3
+Standard-backed Criterion: Evaluates proposed solutions against constraints
+Score: Proficient
+Target: Group
+```
+
+```text
+Local Criterion: Completes required equipment check
+Score: Complete
+Target: Group
+```
+
+The first Score is a direct standards result. The second is a local procedural judgment.
+
+#### Local-only Activity
+
+```text
+Local Criterion: Maintains the Group handoff log
+Score: Complete
+Target: Group
+```
+
+This is a valid Concord Score but not a direct standards rating.
+
+### 15.11 Standards-result handoff
+
+A future grading and reporting module must be able to identify a standard-backed Concord result without guessing from display text or plural alignment metadata.
+
+A standards-result handoff should expose:
+
+```text
+module_id
+class_id
+activity_id
+optional session_id
+score_record_id
+target reference
+standard_id
+criterion_id
+scoring_scale_id
+score disposition
+score value when applicable
+scorer
+scored_at
+evidence-link references
+moderation state
+supersession state
+```
+
+The exact file, event, API, or storage contract remains later work.
+
+### 15.12 Score is not Grade or mastery
+
+A standard-backed Concord Score is one contextual teacher judgment.
+
+It does not automatically establish:
+
+- final mastery;
+- permanent proficiency;
+- marking-period performance;
+- course-level attainment;
+- growth;
+- or a Grade.
+
+The future grading and reporting module will define how contextual judgments are compared, weighted, combined, normalized, superseded, summarized, and reported.
 
 ## 16. Privacy and Access
 
-### 16.1 Sensitive artifact types
+### 16.1 Sensitive record types
 
 The following may require restricted visibility:
 
 - peer observations;
 - contribution disputes;
-- teacher moderation notes;
-- individual scoring rubrics;
-- correction records; and
-- exception records.
+- teacher Review notes;
+- Moderation rationales;
+- individual Score Records;
+- evidence links;
+- correction records;
+- and exception records.
 
-### 16.2 Default visibility
+### 16.2 Record-specific privacy
+
+Privacy is record-specific.
+
+A Score may be less restrictive than some supporting evidence when that difference is deliberate.
+
+For example:
+
+- a teacher-restricted peer observation may support a student-visible standards Score;
+- the student may receive the Score without receiving the observer’s identity;
+- a Group Artifact may remain Group-and-teacher visible while individual Scores remain teacher-and-subject visible;
+- and a Moderation rationale may remain more restricted than the resulting Score.
+
+Access to a Score does not imply access to every supporting source.
+
+### 16.3 Default visibility
 
 Peer- and teacher-generated evidence should be private by default unless the teacher deliberately chooses another policy.
 
-### 16.3 Public repository data
+### 16.4 Public repository data
 
-All examples, fixtures, screenshots, tests, and sample packets in the public repository must use synthetic students, classes, and activities.
+All examples, fixtures, screenshots, tests, and sample packets in the public repository must use synthetic students, classes, Activities, standards selections, and Scores.
 
-### 16.4 Data minimization
+### 16.5 Data minimization
 
-QR payloads and artifact records should contain only the identifiers necessary to route and interpret the page.
+QR payloads and records should contain only the identifiers and context required by their contracts.
+
+Sensitive medical, disability, disciplinary, or counseling details must not be copied into Concord merely to explain a restriction or disposition.
 
 ## 17. Integration Model
 
-Concord should depend on PDS Core for suite-level infrastructure and reference other module records through shared identifiers rather than direct package dependencies.
+Concord depends on PDS Core for suite-level infrastructure and references sibling-module records through public identifiers rather than package dependencies.
 
 ```text
 pds-concord -> pds-core
@@ -1093,194 +1848,262 @@ pds-concord -/-> pds-scoreform
 pds-concord -/-> pds-quillan
 ```
 
-Concord may link to ScoreForm or Quillan work, but it should not import those modules merely to obtain shared workspace, roster, QR, routing, scan-retention, or standards behavior.
+### 17.1 Shared Core concepts
 
 Shared PDS Core concepts include:
 
-- student;
-- class;
-- teacher;
+- class identity;
+- student identity;
 - roster;
-- standard;
-- assignment or activity;
-- workspace;
-- file location;
-- export destination; and
-- audit metadata.
+- identifier validation;
+- module-qualified work identity;
+- workspace paths;
+- PDS2 locator;
+- Route Registration;
+- source-scan identity and provenance;
+- generic route-resolution and failure metadata;
+- standards library;
+- standards profile;
+- durable standard identity;
+- and shared contract versions.
 
-### 17.1 ScoreForm integration
+### 17.2 ScoreForm integration
 
-Concord may reference a ScoreForm assignment as:
+Concord may reference a ScoreForm assignment or result as:
 
 - an individual accountability check;
-- a pre- or post-activity content check;
-- a structured peer or self-rating instrument; or
-- another OMR artifact.
+- a pre- or post-Activity content check;
+- supporting evidence for one or several explicitly judged Concord Scores;
+- or another OMR component.
 
-The actual form generation, scanning, OMR extraction, and scoring remain ScoreForm responsibilities.
+The actual form generation, scanning, OMR extraction, correctness determination, and ScoreForm result remain ScoreForm responsibilities.
 
-### 17.2 Quillan integration
+### 17.3 Quillan integration
 
-Concord may reference a Quillan assignment as:
+Concord may reference a Quillan assignment, response, or standards result as:
 
 - an individual reflection;
 - written explanation;
 - extended peer feedback;
-- defense of a group decision; or
-- analytical follow-up.
+- defense of a Group decision;
+- analytical follow-up;
+- or supporting evidence for an explicit Concord judgment.
 
-The actual written-response workflow remains Quillan's responsibility.
+The written-response workflow and Quillan result remain Quillan responsibilities.
 
-### 17.3 Future lesson-planning integration
+### 17.4 Future planning integration
 
-A future planning module may supply Concord with:
+A future planning module may supply Activity configuration recommendations, including standards and packet selections.
 
-- activity title;
-- class;
-- date;
-- groups;
-- selected criteria;
-- packet recommendation; and
-- related standards.
+Concord remains authoritative for the Concord Activity record and should still function independently.
 
-Concord should still function independently.
+### 17.5 Future grading and reporting integration
 
-### 17.4 Future reporting integration
+A future grading and reporting module may consume:
 
-A future reporting module may consume:
+- standard-backed Concord Score projections;
+- local Concord Scores under an explicit policy;
+- ScoreForm and Quillan results;
+- Activity metadata;
+- Group and individual distinctions;
+- exact scale semantics;
+- evidence references;
+- and supersession state.
 
-- approved scores;
-- criterion summaries;
-- activity metadata;
-- group and individual distinctions; and
-- artifact references.
+The downstream module must not treat standards selection, local alignment, or evidence presence as a direct standards Score.
 
 ## 18. Representative Use Cases
 
-### 18.1 Socratic seminar
+### 18.1 Standards-based Socratic seminar
 
-The teacher selects a seminar packet and assigns peer observers.
+The teacher configures a `standards_based` seminar Activity.
+
+The Activity selects:
+
+- one Core ELA standards profile;
+- ordered Focus Standards for collaborative discussion and textual evidence;
+- standard-backed Criteria for those Focus Standards;
+- and one teacher-approved Scoring Scale revision.
 
 Students complete:
 
 - a discussion map;
-- a peer observation form; and
-- a group process rubric.
+- and peer observation forms.
 
 The teacher completes:
 
-- a roaming observation sheet; and
-- a scoring rubric.
+- a roaming Focus Standards observation tracker;
+- and a standards-based scoring rubric.
 
-The pages are scanned, identified, and filed by artifact instance. The teacher reviews the peer evidence, scores selected criteria, and optionally links a Quillan reflection.
+The pages are scanned, retained by Core, resolved through PDS2, and filed by Artifact Page.
 
-### 18.2 Science laboratory
+The teacher Reviews the Artifacts, moderates peer evidence, and creates separate standard-backed Scores for each directly evaluated Focus Standard.
 
-The teacher generates one group packet per laboratory team.
+An optional Quillan reflection may support one or more Scores through explicit evidence links, but it does not determine them automatically.
+
+### 18.2 Mixed science laboratory
+
+The teacher configures a `mixed` laboratory Activity.
 
 The packet contains:
 
-- a K-W-L or prediction organizer;
-- a decision and troubleshooting log;
-- a contribution record;
-- a group process rubric; and
-- a teacher observation sheet.
+- prediction organizer;
+- procedure organizer;
+- decision and troubleshooting log;
+- contribution record;
+- teacher observation sheet;
+- and mixed scoring rubric.
 
-The final laboratory explanation may be handled by Quillan, while an individual concept check may be handled by ScoreForm.
+The Activity selects a science or engineering Focus Standard and defines a standard-backed Criterion for evaluating evidence or constraints.
 
-### 18.3 Collaborative programming task
+It also defines a local equipment-check Criterion.
+
+The teacher may create:
+
+- a Group standard-backed Score for the selected practice standard;
+- and a local Group Score for the equipment check.
+
+An individual ScoreForm concept check may be linked as supporting evidence, but Concord does not convert it automatically into the Group or individual Concord Score.
+
+### 18.3 Standards-based collaborative programming task
+
+The teacher configures a `standards_based` or `mixed` project Activity.
 
 The teacher generates:
 
-- a responsibility record;
-- a design decision matrix;
-- a debugging log;
-- a contribution record;
-- a group retrospective; and
-- a teacher scoring rubric.
+- responsibility record;
+- design decision matrix;
+- debugging log;
+- contribution record;
+- Group retrospective;
+- Focus Standards scoring rubric;
+- and Artifact cover sheet.
 
-The completed paper artifacts are scanned and filed. Concord stores the collaborative evidence and scores, while source code remains an external project artifact.
+Source code and repository history remain external evidence.
 
-### 18.4 Attached poster or chart paper
+A standard-backed Criterion may evaluate documentation, testing, iterative improvement, or collaborative program development under one governing standard.
 
-The group creates work on a large sheet that is not itself a Concord template.
+A local Criterion may evaluate a school-specific handoff protocol.
 
-A Concord artifact cover sheet is completed and scanned with a photograph or scan of the poster. Concord files both under the same artifact relationship.
+The teacher may use Group evidence to support an individual Score only through an explicit individual judgment and relevance explanation.
+
+### 18.4 Evidence-only peer-review workshop
+
+The teacher configures an `evidence_only` Activity.
+
+Concord generates peer-feedback forms and a teacher Review tracker.
+
+The completed forms are scanned, filed, and available as evidence for a later Quillan revision workflow.
+
+Concord creates no Scores for the Activity.
+
+### 18.5 Attached poster or chart paper
+
+A Group creates work on a large sheet that is not a normal Concord Template.
+
+A Concord Artifact cover sheet is generated and routed through PDS2. The poster is represented through an Attachment or External Reference.
+
+The teacher may use the attached work as evidence for several separate standard-backed Scores and one local process Score.
+
+The shared source does not force those Scores to have the same target, standard, Criterion, or value.
 
 ## 19. Initial Product Decisions
 
 The following decisions are accepted for the conceptual design phase:
 
-1. Concord is a paper-based collaborative-evidence system.
-2. Concord begins after activity planning.
-3. Concord generates templates and packets, not lesson plans.
-4. Concord depends on PDS Core for shared workspace, roster, identifier, QR-contract, active scan-retention, routing-metadata, standards, and navigation infrastructure.
+1. Concord is a paper-based collaborative-evidence and standards-scoring system.
+2. Concord begins after Activity planning.
+3. Concord generates Templates and Packets, not lesson plans.
+4. Concord depends on PDS Core for shared workspace, identity, identifier, PDS2, route-registration, source-retention, dispatch, standards, and contract infrastructure.
 5. Concord must not create a separate QR grammar or duplicate PDS Core contracts.
-6. PDS Core's shared QR contract must be extended before Concord implementation to register Concord and support artifacts without a single student subject.
-7. Activity-specific groups, sessions, roles, packet definitions, artifacts, criteria, moderation, and scores remain Concord-owned.
-8. Concord does not perform handwriting recognition.
-9. Concord does not perform audio or video transcription.
-10. Concord does not generate AI records of classroom discussion.
-11. ScoreForm owns OMR workflows.
-12. Quillan owns focused written-response workflows.
-13. Concord preserves scans as canonical evidence while using PDS Core's retained source-scan and provenance contract.
-14. QR codes identify and route artifact instances rather than encode responses.
-15. Every scannable page should normally carry its own QR code.
-16. Concord supports both individual- and group-level evidence.
-17. Concord separates evidence, review, moderation, score, grade, and report.
-18. Concord records scores but does not calculate course grades.
-19. Concord uses activity-specific templates rather than one universal collaboration rubric.
-20. Student-generated evidence requires provenance and may require teacher moderation.
-21. Peer evidence is private by default.
-22. Public repository examples use synthetic data.
-23. Concord should integrate through shared references rather than duplicate sibling-module capabilities.
-24. The minimum viable workflow must remain useful without cloud services or student devices.
+6. The effective PDS2 work identity is `module_id + class_id + activity_id`.
+7. For Concord, `work_id = activity_id`.
+8. A normal PDS2 Route Registration targets an existing Concord Artifact Page.
+9. PDS2 identifies a physical route, not complete Artifact semantics.
+10. Activity-specific Groups, Sessions, Memberships, Roles, Responsibilities, Artifacts, Criteria, Reviews, Moderation Records, and Scores remain Concord-owned.
+11. Core owns standards libraries, profiles, and durable standards identity.
+12. Concord’s primary academic scoring model is standards-based.
+13. Concord is not standards-exclusive.
+14. Every Activity declares one scoring orientation.
+15. Standards-based and mixed Activities select one standards profile and ordered Focus Standards.
+16. Standards selection or alignment does not create a standards Score.
+17. A standard-backed Criterion has exactly one governing standard.
+18. A local Criterion has no governing standard and may carry only non-governing alignment metadata.
+19. One direct standards Score evaluates one standard-backed Criterion for one target.
+20. A holistic multi-standard Score must not be duplicated across several standards automatically.
+21. Local Scores remain distinguishable from direct standards results.
+22. Group evidence may support an individual Score only through explicit teacher judgment.
+23. A Group Score does not create individual Scores for Group members.
+24. Missing or exceptional evidence states do not become zero or the lowest scale value automatically.
+25. Concord records contextual Scores but does not determine Grades, mastery, growth, or longitudinal proficiency.
+26. A future standards-result handoff must expose governing standards semantics without heuristic interpretation.
+27. Template Definitions and immutable Template Versions are separate.
+28. Packet Definitions and immutable Packet Versions are separate.
+29. Artifact Authors and Artifact Subjects are separate association records.
+30. Concord does not perform handwriting recognition, audio transcription, or automated behavior inference.
+31. ScoreForm owns OMR workflows and Quillan owns focused written-response workflows.
+32. External results may support Concord Scores but do not determine them automatically.
+33. Concord preserves Core-retained scans as canonical evidence.
+34. Review, Moderation, Scoring, Grading, and Reporting remain separate.
+35. Student-generated evidence requires provenance and may require teacher Moderation.
+36. Peer evidence is private by default.
+37. Public repository examples use synthetic data.
+38. Concord integrates through public references rather than duplicating sibling-module capabilities.
+39. The minimum viable workflow remains useful without cloud services or student devices.
+40. Corrections, rescans, revised attributions, Moderation decisions, and Scores preserve history.
 
-## 20. Open Questions for Contract Design
+## 20. Open Questions for Contract and Implementation Design
 
-The conceptual model leaves several questions for the next phase:
+The foundational semantics are now substantially settled. The following questions remain for representative examples, implementation contracts, or later grading and reporting work:
 
-1. What is the minimum required metadata for every artifact instance?
-2. Which metadata belongs in the QR payload, the QR-linked local record, and the visible printed page?
-3. How should PDS Core extend `PDS1` to register `module=concord`?
-4. How should `PDS1` represent group-, teacher-, session-, and activity-level artifacts that do not have one `student_id`?
-5. Should Concord's `activity_id` map to PDS Core's existing `assignment_id`, or does the suite need a broader shared work-item concept?
-6. Which Concord routes require new PDS Core helpers, and which module-specific subdirectories may safely live inside the canonical assignment folder?
-7. Which identifiers and validation rules should be shared through PDS Core, and which identifiers remain Concord-specific?
-8. How should packet definitions represent optional and repeated artifacts?
-9. How should one artifact represent multiple authors or subjects?
-10. How should changing group membership across sessions be represented?
-11. Should artifact categories be a fixed enumeration, extensible identifiers, or both?
-12. How should custom teacher-created templates declare their printable fields and filing metadata?
-13. How should Concord represent irregular attachments and multi-page artifacts?
-14. Which review and moderation states are necessary without overcomplicating the workflow?
-15. How should scores reference one or several source artifacts?
-16. How should corrected scores and rescored artifacts preserve history?
-17. How should Concord use PDS Core standards profiles and durable `standard_id` references without moving Concord-specific criteria into Core?
-18. How should Concord export scores without making assumptions about grading systems?
-19. What privacy controls are required for peer observations and disputes?
-20. What is the smallest practical user interface for reviewing scanned pages and entering scores?
-21. Which three representative packets should be modeled first to test the contracts?
+1. What exact serialized schemas and schema-version fields should implement the accepted conceptual records?
+2. Which identifier-generation helpers should Concord consume directly from Core?
+3. What exact module-qualified filesystem paths should store each Concord record family beneath the Activity work root?
+4. What human-readable fallback format should appear on route-required pages?
+5. What packet-rendering manifest should connect Packet Version, Artifact Instance, Artifact Page, and Route Registration creation atomically?
+6. Which Activity-scoring orientation should the user interface recommend by default without preventing deliberate alternatives?
+7. How should reusable standard-backed Criterion Sets declare compatibility with different standards profiles or standard editions?
+8. Should Score Records store a direct `standard_id` snapshot in addition to resolving it through the immutable Criterion?
+9. What validation behavior should apply when a historical profile or standard becomes inactive, deprecated, or temporarily unavailable?
+10. Which Scoring Scale revisions should ship as starter data?
+11. How should the interface present two standard-backed Criteria based on the same evidence without encouraging duplicate or automatic Scores?
+12. What exact workflow should record professional judgment when no formal evidence link exists?
+13. What evidence-locator conventions are practical for multi-subject teacher trackers?
+14. What exact privacy vocabulary should remain Concord-owned and what should later move to Core?
+15. What exact exported file, event, or API contract will carry the Standards Result Handoff Projection?
+16. How will the future grading and reporting module compare or combine results that use different Scoring Scale revisions?
+17. Which local Scores, if any, may contribute to Grades under later explicit policy?
+18. What is the smallest practical interface for reviewing scans, selecting evidence, and entering separate standards judgments efficiently?
+19. Which starter Criterion Sets, Template Versions, and Packet Versions should ship without turning examples into universal domain requirements?
+20. Which specialized Activity Event contracts, if any, are justified by representative records?
 
 ## 21. Recommended Next Step
 
-Before creating schemas, model three representative packet types in detail:
+Use this revised conceptual design, ADR 0014, the revised initial domain model, and the revised conceptual data contracts to create the representative contract examples required by issue `#12`.
 
-1. a Socratic seminar;
-2. a science laboratory group; and
-3. a collaborative programming or engineering project.
+The examples should include at least:
 
-For each packet, identify:
+1. a standards-based Socratic seminar;
+2. a mixed science laboratory Activity;
+3. a standards-based or mixed collaborative programming or engineering project;
+4. an evidence-only Activity or component;
+5. a local-criteria-only judgment;
+6. an individual standards Score;
+7. a Group standards Score;
+8. Group or multi-subject evidence supporting an individual Score through explicit teacher judgment;
+9. one source supporting several separate standard-backed Scores;
+10. a non-score disposition for a Focus Standard;
+11. a ScoreForm result used as supporting evidence;
+12. a Quillan result used as supporting evidence;
+13. a local Criterion with optional alignment metadata that remains non-governing;
+14. and PDS2 routing from Artifact Page registration through Scan Reference creation.
 
-- templates;
-- authors;
-- subjects;
-- pages;
-- QR context;
-- scan workflow;
-- review states;
-- scoring targets;
-- cross-module references; and
-- privacy requirements.
+Those examples should test whether the architecture permits a future grading and reporting module to distinguish:
 
-The common requirements that survive all three cases should become the basis of the first Concord data contracts.
+- standards selection from standards judgment;
+- standard-backed Scores from local Scores;
+- individual targets from Group targets;
+- evidence from Scores;
+- current Scores from superseded Scores;
+- non-score dispositions from low performance;
+- and Concord-owned judgments from external evidence.

--- a/docs/decisions/0014-make-standards-based-scoring-the-primary-concord-scoring-model.md
+++ b/docs/decisions/0014-make-standards-based-scoring-the-primary-concord-scoring-model.md
@@ -1,0 +1,1215 @@
+# ADR 0014: Make Standards-Based Scoring the Primary Concord Scoring Model
+
+**Status:** Accepted
+**Date:** July 22, 2026
+**Decision owners:** Paper Data Suite maintainers
+**Applies to:** `pds-concord`
+
+## Context
+
+Paper Data Suite is predominantly a standards-based assessment and grading system.
+
+Its assignment modules collect different kinds of evidence:
+
+* `pds-scoreform` processes machine-readable selected-response evidence;
+* `pds-quillan` supports teacher review of written-response evidence;
+* `pds-concord` supports collaborative evidence from discussions, laboratories, group projects, design activities, and other collaborative work;
+* and a future Paper Data Suite grading and reporting module will combine approved results across assignments, modules, courses, terms, and time.
+
+The future grading and reporting module has not yet begun development. Its architecture depends partly on the result contracts produced by Concord.
+
+Concord must therefore preserve enough standards-specific meaning for that future module to determine:
+
+* which standard a teacher evaluated;
+* which student, Group, or other target received the judgment;
+* which Activity and optional Session supplied the context;
+* which scale revision governed the judgment;
+* which evidence supported it;
+* whether required Moderation was completed;
+* whether the teacher made a scored judgment or recorded a non-score disposition;
+* and whether a later judgment superseded an earlier one.
+
+Concord’s existing foundational documents already establish several necessary pieces:
+
+* PDS Core owns shared standards definitions, standards profiles, durable `standard_id` references, and module-neutral standards validation;
+* Concord may select Criteria and Criterion Sets;
+* a Score Record represents one teacher-approved judgment about one Criterion for one target;
+* Score Records may cite several evidence sources;
+* Review, Moderation, Scoring, Grading, and Reporting are separate concepts;
+* missing or exceptional evidence states must not become low Scores automatically;
+* and grading and cross-module reporting remain outside Concord.
+
+Those decisions are necessary but not sufficient to establish standards-based scoring.
+
+The current generic model can be summarized as:
+
+```text
+evidence
+    -> Criterion
+    -> teacher-approved Score
+```
+
+A Criterion may carry one or more optional standards references, but the model does not yet define whether those references mean:
+
+* the Criterion directly evaluates one standard;
+* the Criterion evaluates several standards simultaneously;
+* the standards are contextual alignments only;
+* the Criterion is local to the Activity;
+* or the resulting Score may be treated as a direct standards result.
+
+That ambiguity would force the future grading and reporting module to infer standards meaning from generic Criterion metadata.
+
+For example, consider this Criterion:
+
+```text
+Uses evidence while responding to peers
+```
+
+Suppose it references:
+
+```text
+njsls-ela:SL.PE.9-10.1
+njsls-ela:RL.CR.9-10.1
+```
+
+A Score of `3` against that Criterion would not reveal whether:
+
+* both standards received a rating of `3`;
+* only the speaking-and-listening standard was directly evaluated;
+* the reading standard was supporting context;
+* the Score was holistic and cannot be separated;
+* or the standards were merely attached for instructional alignment.
+
+The future reporting module must not guess.
+
+Paper Data Suite’s existing modules demonstrate two compatible standards-integration patterns.
+
+### Quillan pattern
+
+Quillan makes Focus Standards the organizing structure for teacher review:
+
+```text
+student evidence
+    -> review unit
+    -> Focus Standard
+    -> teacher judgment
+    -> feedback and assignment-local reporting
+```
+
+Quillan assignments explicitly select:
+
+* one standards profile;
+* one ordered set of Focus Standards;
+* and one standards-rating scale.
+
+Its teacher-confirmed overall Focus Standard ratings are direct standards-based judgments.
+
+### ScoreForm pattern
+
+ScoreForm attaches durable standards references to individual questions.
+
+The selected-response score remains governed by the answer key. Standards metadata does not change whether an answer is correct.
+
+Question-level standards alignment and question-level response results can later provide standards-relevant evidence, but ScoreForm does not automatically determine longitudinal mastery, course Grades, or cross-module standards results.
+
+### Concord’s distinct need
+
+Concord should not copy either module’s complete workflow.
+
+Concord’s distinctive domain includes:
+
+* individual and Group targets;
+* changing Group Membership;
+* shared and individual evidence;
+* Artifact Authors and Subjects;
+* teacher and peer observation;
+* Moderation;
+* contribution evidence;
+* collaborative process Criteria;
+* Activity-specific local Criteria;
+* and evidence that may concern several students, Groups, Sessions, or components.
+
+Concord therefore needs a standards architecture that:
+
+1. makes direct standards judgments unambiguous;
+2. preserves Criterion-level scoring;
+3. supports Group and individual targets;
+4. retains legitimate local collaborative Criteria;
+5. avoids forcing every Activity into standards scoring;
+6. does not make standards alignment equivalent to mastery;
+7. and provides a clean future handoff to grading and reporting.
+
+## Decision
+
+Concord will use **standards-based scoring as its primary academic scoring model**.
+
+Concord will be **predominantly standards-based but not standards-exclusive**.
+
+Activities intended to produce academic performance judgments should normally select Focus Standards and use standard-backed Criteria.
+
+Concord will continue to support:
+
+* evidence-only Activities;
+* local collaborative Criteria;
+* Group-process Criteria;
+* Activity-component Criteria;
+* operational or procedural Criteria;
+* and formative Activities that produce no standards Scores.
+
+The central standards-based scoring relationship will be:
+
+```text
+collaborative evidence
+    -> standard-backed Criterion
+    -> teacher-approved Score
+    -> future standards-based grading and reporting
+```
+
+For a direct standards judgment:
+
+```text
+one Score Record
+    -> one immutable standard-backed Criterion
+    -> exactly one governing standard_id
+    -> exactly one Score target
+    -> exactly one Scoring Scale revision
+```
+
+## Standards ownership
+
+PDS Core remains authoritative for:
+
+* shared standard definitions;
+* durable `standard_id` values;
+* standards profiles;
+* durable `profile_id` values;
+* standards-library storage;
+* standards browsing and selection;
+* profile-membership validation;
+* standard display metadata;
+* active, inactive, and deprecated status;
+* and module-neutral standards reference validation.
+
+Concord owns:
+
+* selecting Focus Standards for an Activity;
+* defining or selecting Concord Criteria;
+* declaring whether a Criterion is standard-backed or local;
+* selecting Concord Scoring Scales;
+* recording teacher-approved Score Records;
+* linking evidence to those Scores;
+* applying Concord Review and Moderation requirements;
+* producing Concord-specific standards-result handoff data;
+* and presenting standards-based scoring workflows to the teacher.
+
+Concord must not:
+
+* create a competing standards library;
+* copy full standard definitions into Activity or Score records;
+* use display codes as durable identities;
+* silently substitute one standard for another;
+* or mutate Core standards while creating or reviewing Concord records.
+
+## Activity scoring orientation
+
+Each Activity will declare its intended scoring orientation.
+
+The initial semantic orientations are:
+
+```text
+evidence_only
+standards_based
+mixed
+local_criteria_only
+```
+
+The exact serialized values belong to the conceptual and later persisted contracts, but these distinctions are required.
+
+### `evidence_only`
+
+The Activity collects, organizes, reviews, or moderates evidence without producing Concord Score Records.
+
+Examples include:
+
+* an unscored discussion map;
+* a formative Group retrospective;
+* a teacher observation collection used only for planning;
+* or a collaborative record retained for later reference.
+
+An evidence-only Activity does not require Focus Standards, Criteria, or a Scoring Scale.
+
+### `standards_based`
+
+The Activity’s scored judgments are direct judgments against selected Focus Standards.
+
+A standards-based Activity must select:
+
+* one `standards_profile_id`;
+* one or more ordered `focus_standard_ids`;
+* one or more standard-backed Criteria;
+* and applicable Scoring Scale revisions.
+
+Local unscored context records may still exist, but scored Criteria should ordinarily be standard-backed.
+
+### `mixed`
+
+The Activity uses both:
+
+* direct standard-backed Criteria;
+* and local Concord Criteria.
+
+Examples include:
+
+* a laboratory Activity that scores a science-practice standard and also records a local equipment-management Criterion;
+* a seminar that scores speaking-and-listening standards and separately records an ungraded facilitation responsibility;
+* or a programming project that scores computational-thinking standards while also evaluating a local handoff protocol.
+
+A mixed Activity must select a standards profile and one or more Focus Standards.
+
+### `local_criteria_only`
+
+The Activity produces Score Records, but those Scores are not direct standards judgments.
+
+Examples may include:
+
+* a local procedural check;
+* a school-specific team protocol;
+* an extracurricular collaborative Activity;
+* or a temporary Activity component whose Criteria are not intended for standards reporting.
+
+Local-criteria scoring remains teacher-controlled and may later contribute to a Grade only through an explicit downstream policy.
+
+It must not be presented as direct standards performance.
+
+## Activity Focus Standards
+
+An Activity using `standards_based` or `mixed` scoring must identify:
+
+```text
+standards_profile_id
+focus_standard_ids
+```
+
+### `standards_profile_id`
+
+The Activity’s `standards_profile_id` identifies the Core-owned standards profile from which its Focus Standards were selected.
+
+Rules:
+
+* it must be a durable Core `profile_id`;
+* it must resolve through the active workspace standards library at creation and validation boundaries;
+* Concord stores the reference but does not own the profile;
+* and missing or inactive profile metadata must not cause silent mutation of the Activity.
+
+### `focus_standard_ids`
+
+The Activity’s `focus_standard_ids` identify the standards that the Activity is deliberately configured to evaluate.
+
+Rules:
+
+* the list must be nonempty for `standards_based` and `mixed` Activities;
+* every entry must be a durable Core `standard_id`;
+* duplicate IDs are invalid;
+* every selected standard should belong to the selected profile;
+* ordering is meaningful for teacher-facing scoring and future handoff workflows;
+* and a selected Focus Standard does not by itself prove that the standard was taught, practiced, assessed, demonstrated, or mastered.
+
+The Focus Standards define the Activity’s intended standards-scoring scope.
+
+A standard becomes direct Concord performance evidence only through an explicit teacher-approved standard-backed Score Record or another later contract that deliberately defines a standards-result event.
+
+## Criterion classifications
+
+Every Criterion used for scoring will declare whether it is:
+
+```text
+standard_backed
+local
+```
+
+The exact serialized field name and values belong to the conceptual data contract, but this distinction is mandatory.
+
+## Standard-backed Criterion
+
+A **standard-backed Criterion** defines how one selected standard will be judged in the Concord Activity context.
+
+It has exactly one governing `standard_id`.
+
+Conceptually:
+
+```text
+criterion_kind: standard_backed
+standard_id: <one Core standard_id>
+```
+
+Examples include:
+
+```text
+Standard:
+njsls-ela:SL.PE.9-10.1
+
+Activity-specific Criterion:
+Builds on peers’ ideas and responds substantively during collaborative discussion
+```
+
+```text
+Standard:
+ngss:HS-ETS1-3
+
+Activity-specific Criterion:
+Evaluates proposed solutions against relevant constraints and evidence
+```
+
+```text
+Standard:
+csta:2-AP-17
+
+Activity-specific Criterion:
+Provides useful documentation that supports collaborative program development
+```
+
+The Activity-specific Criterion may clarify what the selected standard looks like in:
+
+* a seminar;
+* a laboratory;
+* a programming project;
+* an engineering challenge;
+* or another collaborative context.
+
+It does not redefine the shared standard.
+
+### Exactly one governing standard
+
+A standard-backed Criterion must identify exactly one governing standard.
+
+This preserves an unambiguous relationship:
+
+```text
+Score
+    -> Criterion
+    -> one standard_id
+```
+
+If the teacher intends to make direct judgments about two standards, Concord should ordinarily use:
+
+* two Criteria;
+* and two Score Records.
+
+A user interface may display or enter those judgments together, but the persisted judgments remain separate.
+
+### Multi-standard or holistic Criteria
+
+A Criterion may describe a complex behavior aligned to several standards, but one Score against such a Criterion must not be treated as several direct standards ratings.
+
+A multi-standard holistic Criterion must therefore be modeled as:
+
+* a local Criterion with non-governing alignment references;
+* several separate standard-backed Criteria;
+* or another explicitly defined future composite contract.
+
+The future grading and reporting module must not split one holistic Score across several standards automatically.
+
+### Focus Standard membership
+
+When a standard-backed Criterion is used by an Activity:
+
+* its `standard_id` must appear in the Activity’s `focus_standard_ids`;
+* the standard should belong to the Activity’s selected standards profile;
+* and any unresolved, inactive, or deprecated reference must be reported explicitly.
+
+Historical Criteria and Scores remain preserved even if a standard later becomes inactive or deprecated.
+
+## Local Criterion
+
+A **local Criterion** evaluates an Activity-specific, procedural, organizational, or collaborative expectation that is not a direct standards rating.
+
+Conceptually:
+
+```text
+criterion_kind: local
+standard_id: absent
+```
+
+Examples include:
+
+* returns shared materials to the agreed location;
+* completes a designated equipment check;
+* records a component handoff;
+* follows a locally defined discussion protocol;
+* maintains the Group’s version log;
+* or completes an Activity-specific procedural responsibility.
+
+A local Criterion may include optional alignment metadata such as:
+
+```text
+alignment_standard_ids
+```
+
+when the teacher wants to document instructional relevance.
+
+Such alignment is non-governing.
+
+A Score against a local Criterion must not be reported as a direct rating for any aligned standard unless the teacher separately creates a standard-backed Score.
+
+## Criterion Sets
+
+A Criterion Set may contain:
+
+* only standard-backed Criteria;
+* only local Criteria;
+* or both.
+
+A Criterion Set should identify its intended orientation and scope.
+
+For example:
+
+```text
+Seminar Focus Standards
+├── SL.PE.9-10.1 — Builds on peers’ ideas
+├── SL.II.9-10.2 — Integrates information from discussion
+└── RL.CR.9-10.1 — Uses relevant textual evidence
+```
+
+A mixed Criterion Set may also contain:
+
+```text
+Local seminar-process Criterion:
+Performs the assigned observer rotation
+```
+
+The local Criterion remains distinguishable from the direct standards judgments.
+
+Criterion Sets and Criteria used by Scores remain immutable under the existing historical-preservation decisions.
+
+Changing:
+
+* a governing standard;
+* a Criterion definition;
+* target applicability;
+* scoring interpretation;
+* or standard/local classification
+
+requires a new Criterion revision or identity under the later finalized contract.
+
+## Score Record semantics
+
+The existing Score Record model remains:
+
+> One teacher-approved judgment about one Criterion for one target in one defined Activity context using one exact Scoring Scale revision.
+
+This ADR adds standards semantics to that model.
+
+### Standard-backed Score
+
+A Score against a standard-backed Criterion is a direct Concord judgment about the Criterion’s one governing standard.
+
+It must preserve or expose unambiguously:
+
+* `activity_id`;
+* optional `session_id`;
+* one Score target;
+* one Criterion;
+* one governing `standard_id`;
+* one Scoring Scale revision;
+* one Score disposition;
+* one value when scored;
+* scorer identity;
+* scoring timestamp;
+* applicable evidence links;
+* required Moderation state;
+* optional rationale;
+* and correction or supersession history.
+
+The later serialized contract may:
+
+1. store `standard_id` directly on the Score Record as a historical snapshot;
+2. resolve it through the immutable referenced Criterion;
+3. or do both.
+
+Whichever representation is chosen, the public contract must make the governing standard:
+
+* unambiguous;
+* reproducible;
+* historically stable;
+* and available without heuristic interpretation.
+
+### Local Score
+
+A Score against a local Criterion remains a valid Concord Score.
+
+It must be identifiable as a local-criterion judgment and must not be exported or interpreted as a direct standard rating.
+
+### Score dispositions
+
+The existing universal Score dispositions remain applicable:
+
+```text
+scored
+insufficient_evidence
+absent
+excused
+not_observed
+not_applicable
+deferred
+```
+
+Standards-based scoring does not alter the rule that exceptional states are not low Scores.
+
+For a standard-backed Score:
+
+* `scored` requires a valid value from the selected Scoring Scale;
+* all non-score dispositions require no score value;
+* zero or the lowest level must not be inferred from missing or exceptional evidence;
+* and a later valid judgment may supersede an earlier non-score disposition while preserving history.
+
+### Standards selection is not a Score
+
+The following do not create a standards Score:
+
+* selecting a Focus Standard;
+* placing a Standard Reference on an Activity;
+* printing a rubric that names a standard;
+* generating an Artifact linked to a standard-backed Criterion;
+* receiving a completed Artifact;
+* reviewing evidence;
+* approving evidence as readable;
+* accepting evidence through Moderation;
+* attaching a standard to an external ScoreForm question;
+* or linking a Quillan assignment to the Activity.
+
+A standards Score exists only when an authorized scorer records the teacher-approved criterion-level judgment.
+
+## Scoring Scales
+
+Concord will not impose one universal standards-rating scale.
+
+A standards-based Activity may use an exact immutable Scoring Scale revision such as:
+
+* Developing / Approaching / Meeting / Exceeding;
+* Beginning / Progressing / Proficient / Advanced;
+* a numeric ordinal scale;
+* a binary demonstrated/not-demonstrated scale where appropriate;
+* or another teacher- or organization-approved scale.
+
+The Scoring Scale must preserve:
+
+* permitted values;
+* display labels;
+* descriptions;
+* ordering where applicable;
+* revision identity;
+* and historical reproducibility.
+
+A future grading and reporting module must not assume that similarly numbered scales are semantically equivalent.
+
+For example:
+
+```text
+Concord Scale A:
+1 = Developing
+2 = Approaching
+3 = Meeting
+4 = Exceeding
+```
+
+is not automatically equivalent to:
+
+```text
+External Scale B:
+1 = Beginning
+2 = Developing
+3 = Proficient
+4 = Advanced
+```
+
+Cross-scale conversion, normalization, weighting, and mastery policies belong to explicit future grading and reporting contracts.
+
+## Evidence and standards Scores
+
+The existing many-to-many evidence model remains unchanged.
+
+One standard-backed Score may use:
+
+* zero formal evidence links with a required professional-judgment rationale;
+* one evidence source;
+* or several evidence sources.
+
+One evidence source may support:
+
+* several standards Scores;
+* several targets;
+* Group and individual judgments;
+* or both standard-backed and local Criteria.
+
+Each use requires a separate deliberate Score Evidence Link.
+
+### Group evidence and individual standards Scores
+
+Group or multi-subject evidence may support an individual standards Score when:
+
+* the evidence is relevant to that individual target;
+* the applicable evidence location or Subject context is identified where useful;
+* any required Moderation permits that use;
+* the teacher makes an explicit individual judgment;
+* and the evidence-link description or Score rationale explains the relevance.
+
+Group evidence must not generate individual standards Scores automatically.
+
+### Group standards Scores
+
+A standard-backed Score may target a Group when:
+
+* the governing standard validly supports Group-level judgment;
+* the Criterion identifies Group applicability;
+* and the teacher deliberately selects the Group target.
+
+A Group standards Score does not become an individual standards Score for every Group member.
+
+The future grading and reporting module must preserve that distinction unless a later explicit policy defines a conversion.
+
+### Authors and Subjects
+
+Standards-based scoring does not collapse:
+
+* Artifact Author;
+* Artifact Subject;
+* Score target;
+* standard;
+* and scorer
+
+into one relationship.
+
+For example:
+
+```text
+Artifact Author:
+Student observer
+
+Artifact Subject:
+Observed student
+
+Score target:
+Observed student
+
+Standard:
+Speaking-and-listening participation standard
+
+Scorer:
+Teacher
+```
+
+or:
+
+```text
+Artifact Authors:
+Group recorder and represented Group
+
+Artifact Subjects:
+Group and Session
+
+Score target:
+Group
+
+Standard:
+Engineering design-practice standard
+
+Scorer:
+Teacher
+```
+
+These relationships remain explicit and independent.
+
+## Review and Moderation
+
+Standards-based scoring does not bypass Review or Moderation.
+
+Review continues to determine whether evidence is:
+
+* correctly identified;
+* readable;
+* complete;
+* properly filed;
+* correctly attributed;
+* relevant;
+* and ready for possible use.
+
+Moderation continues to determine whether evidence is:
+
+* reliable;
+* fair;
+* credible;
+* sufficiently specific;
+* appropriately qualified;
+* and permissible for the proposed consequential use.
+
+Neither Review nor Moderation creates a standards Score.
+
+An accepted Moderation decision means only that the evidence may be used under the recorded conditions.
+
+The teacher still chooses:
+
+* the standard-backed Criterion;
+* the Score target;
+* the Scoring Scale value;
+* the evidence links;
+* and the final rationale where applicable.
+
+## Integration with Quillan
+
+Quillan’s standards-based review records remain Quillan-owned.
+
+A Quillan overall Focus Standard rating may be referenced by Concord as:
+
+* supporting evidence;
+* contextual evidence;
+* complementary individual evidence;
+* a follow-up reflection result;
+* or another explicit External Reference purpose.
+
+Concord must not:
+
+* copy Quillan’s review record into a Concord-owned review;
+* recreate Quillan’s review-unit workflow;
+* assume that a Quillan rating automatically determines a Concord Score;
+* or convert a Quillan result without explicit teacher judgment.
+
+When a Quillan result contributes to a Concord Score:
+
+```text
+Quillan standard result
+    -> Concord External Reference
+    -> Concord Evidence Reference
+    -> Concord Score Evidence Link
+    -> explicit Concord Score Record
+```
+
+The Quillan record remains authoritative for the Quillan judgment.
+
+The Concord Score remains authoritative for the Concord Activity judgment.
+
+## Integration with ScoreForm
+
+ScoreForm’s question-level standards alignment and selected-response results remain ScoreForm-owned.
+
+A ScoreForm result may contribute to a Concord standards Score when it is relevant to the governing standard and Activity context.
+
+For example:
+
+```text
+ScoreForm evidence:
+Individual procedure-check result
+
+Concord Focus Standard:
+Uses appropriate scientific procedures and evidence
+
+Concord judgment:
+Teacher-approved standard-backed Score using the ScoreForm result
+with laboratory observations and Group records
+```
+
+Concord must not:
+
+* perform ScoreForm OMR processing;
+* copy ScoreForm answer keys;
+* treat a question-level standard alignment as a Concord Score;
+* convert percentage correct automatically into a Concord rating;
+* or infer a standard judgment from a ScoreForm result without teacher approval.
+
+The integration path remains:
+
+```text
+ScoreForm result
+    -> Concord External Reference
+    -> Concord Evidence Reference
+    -> Concord Score Evidence Link
+    -> explicit Concord Score Record
+```
+
+## Future grading and reporting handoff
+
+Concord will preserve enough structured standards-result information for a future Paper Data Suite grading and reporting module to consume without reverse-engineering generic Criteria.
+
+A standards-result handoff must eventually make available:
+
+```text
+module_id
+class_id
+activity_id
+optional session_id
+score_record_id
+target reference
+standard_id
+criterion_id
+scoring_scale_id
+score disposition
+score value when applicable
+scorer
+scored_at
+evidence-link references
+moderation state
+supersession state
+```
+
+The exact export schema, event structure, storage path, and inter-module interface belong to later work.
+
+This ADR does not authorize Concord to perform:
+
+* cross-Activity aggregation;
+* cross-module aggregation;
+* marking-period calculations;
+* course-grade calculations;
+* mastery determination;
+* standards-growth reporting;
+* score weighting;
+* scale normalization;
+* report-card generation;
+* parent reporting;
+* or longitudinal reporting.
+
+Those responsibilities remain with the future Paper Data Suite grading and reporting module.
+
+## No automatic mastery determination
+
+A standard-backed Concord Score is one contextual teacher judgment.
+
+It does not automatically establish:
+
+* final mastery;
+* permanent proficiency;
+* course-level attainment;
+* marking-period performance;
+* or a Grade.
+
+A student may receive several judgments for the same standard:
+
+* in different Activities;
+* in different Sessions;
+* through different modules;
+* using different evidence;
+* or using different Scoring Scale revisions.
+
+The future grading and reporting module must determine how those judgments are:
+
+* compared;
+* weighted;
+* combined;
+* superseded;
+* summarized;
+* or reported.
+
+Concord supplies the contextual standards result. It does not define the broader academic policy.
+
+## Missing, inactive, or deprecated standards
+
+Concord will preserve teacher-owned records when a standards reference no longer resolves cleanly.
+
+### Missing standards library
+
+Validation should report that shared standards infrastructure is unavailable.
+
+Concord must not create a competing library merely to satisfy validation.
+
+Existing Activity, Criterion, and Score records remain unchanged.
+
+### Missing profile
+
+Validation should identify the unresolved `standards_profile_id`.
+
+Concord must not silently choose another profile.
+
+### Missing standard
+
+Validation should identify the unresolved `standard_id`.
+
+Concord must not delete, replace, or reinterpret the Criterion or Score.
+
+### Inactive or deprecated standard
+
+Historical references remain valid provenance.
+
+Teacher-facing displays should identify the standard as inactive or deprecated where Core supplies that metadata.
+
+New Activity configuration should ordinarily prefer active standards unless the teacher deliberately chooses otherwise under an authorized workflow.
+
+## Privacy
+
+Standards-based Scores may be sensitive student records.
+
+Privacy must remain record-specific.
+
+A standards Score may be less restrictive than some of its supporting evidence, but that difference must be deliberate.
+
+For example:
+
+* a teacher-restricted peer observation may support a student-visible standards rating;
+* the student may receive the Score and feedback without receiving the observer’s identity;
+* a Group Artifact may remain Group-and-teacher visible while individual Score Records remain teacher-and-subject visible;
+* and a Moderation rationale may remain more restricted than the resulting Score.
+
+The future reporting module must not infer that access to a Score grants access to every supporting source.
+
+## Consequences
+
+### Positive consequences
+
+* Concord’s standards-based purpose becomes explicit.
+* The future grading and reporting module can consume Concord results without guessing how generic Criteria relate to standards.
+* Direct standards judgments identify exactly one governing `standard_id`.
+* Activity Focus Standards provide a clear scoring scope.
+* Standard-backed and local Criteria remain distinguishable.
+* Concord can support standards-based academic evaluation without forcing every Activity to produce Scores.
+* Group and individual standards Scores remain explicit and separate.
+* Existing Review, Moderation, evidence, and provenance decisions remain intact.
+* Core remains the single owner of standards identity and profiles.
+* Quillan, ScoreForm, and Concord can contribute different evidence forms without duplicating one another’s workflows.
+* Missing evidence and non-score dispositions remain distinct from low performance.
+* Historical standards results remain reproducible through immutable Criteria and Scoring Scale revisions.
+* Future cross-module reporting can distinguish direct standards results from contextual alignment.
+
+### Negative consequences
+
+* Activity configuration becomes more explicit.
+* Criteria require a standard-backed/local classification.
+* Standard-backed Criteria cannot use several governing standards for one Score.
+* Teachers may need to enter separate judgments when one classroom behavior reflects several standards.
+* Criterion and Score validation becomes more complex.
+* Reusable Criterion Sets must be checked against Activity Focus Standards.
+* The user interface must distinguish direct standards judgments from local criteria clearly.
+* Future exports must preserve standard identity, scale identity, target type, and contextual provenance.
+* Cross-scale comparison remains unavailable until the grading and reporting module defines an explicit policy.
+* Existing generic points-based examples may require revision or relabeling.
+
+## Compatibility with prior decisions
+
+This ADR supplements rather than replaces the existing Concord architecture.
+
+### ADR 0001: Concord Module Boundaries
+
+Core still owns shared standards infrastructure.
+
+Concord still owns its Activity configuration, Criteria, Scoring Scales, Score Records, and scoring workflows.
+
+### ADR 0005: Separate Artifact Authors and Subjects
+
+Author, Subject, Score target, scorer, and standard remain separate concepts.
+
+### ADR 0007: Preserve Source Evidence and History
+
+Standard-backed Scores, Criteria, evidence links, and revisions retain non-destructive history.
+
+### ADR 0008: Separate Review, Moderation, Scoring, Grading, and Reporting
+
+Standards-based Scoring remains separate from Grading and Reporting.
+
+This ADR clarifies the semantic content of Concord Scores. It does not move Grade calculation or cross-module Reporting into Concord.
+
+### ADR 0009: Many-to-Many Evidence-to-Score Relationships
+
+The many-to-many evidence model remains unchanged.
+
+One source may support several standards Scores, and one standards Score may use several sources.
+
+### ADR 0010: Exceptional Evidence States Are Not Low Scores
+
+Non-score dispositions remain explicit and never become inferred zeros or lowest proficiency levels.
+
+### ADR 0012: Link ScoreForm and Quillan Without Duplication
+
+External standards-related records remain owned by their source modules.
+
+Concord references and uses them through explicit evidence relationships.
+
+### ADR 0013: Keep Activity-Specific Structures Optional
+
+Not every Activity requires Focus Standards, Criteria, or Scores.
+
+Standards-based scoring is the primary academic scoring model, not a universal record-presence requirement.
+
+## Alternatives considered
+
+### Alternative 1: Retain generic Criteria with optional standards references
+
+Rejected because a future consumer could not determine whether a Score was:
+
+* a direct judgment of one standard;
+* a holistic judgment across several standards;
+* a local Criterion;
+* or merely standards-aligned.
+
+Optional references are sufficient for instructional alignment but insufficient for unambiguous standards results.
+
+### Alternative 2: Require every Concord Criterion to be a standard
+
+Rejected because Concord also needs legitimate local Criteria for:
+
+* Activity-specific procedures;
+* collaboration protocols;
+* equipment or material responsibilities;
+* project handoffs;
+* operational checks;
+* and nonacademic collaborative contexts.
+
+Making all Criteria standards-backed would either eliminate useful local judgments or encourage false standards mappings.
+
+### Alternative 3: Permit one direct Score to govern several standards
+
+Rejected because one value could not be apportioned defensibly among the standards.
+
+A later reporting module would be forced to:
+
+* duplicate the value across all standards;
+* select one standard arbitrarily;
+* average or divide the value;
+* or discard the Score.
+
+None of those interpretations should occur without a teacher decision.
+
+### Alternative 4: Defer standards semantics until the grading and reporting module
+
+Rejected because the reporting module cannot recover meaning that Concord failed to preserve.
+
+The distinction between a direct standard judgment and a local Criterion must be recorded when the Activity and Score are created.
+
+### Alternative 5: Copy Quillan’s standards-based review-unit model
+
+Rejected because Concord evidence is not organized primarily around written review units.
+
+Concord must support:
+
+* Groups;
+* Sessions;
+* shared Artifacts;
+* multi-subject evidence;
+* teacher trackers;
+* Activity Events;
+* Attachments;
+* contribution evidence;
+* and changing Memberships.
+
+Concord should share the principle of Focus Standard–centered teacher judgment without copying Quillan’s writing-specific workflow.
+
+### Alternative 6: Treat ScoreForm or Quillan results as automatic Concord Scores
+
+Rejected because external module results have their own:
+
+* evidence context;
+* target;
+* scale;
+* scoring method;
+* and semantic scope.
+
+External results may support a Concord judgment, but they do not determine it automatically.
+
+### Alternative 7: Make standards-based scoring mandatory for every Activity
+
+Rejected because some Concord Activities are:
+
+* evidence-only;
+* formative;
+* procedural;
+* extracurricular;
+* or intentionally local.
+
+The foundational domain must support standards-based scoring without requiring meaningless standards records.
+
+## Required follow-up
+
+Before approving the Concord v0.1.0 foundation, the following documentation must be updated.
+
+### Conceptual data contracts
+
+Revise `docs/design/conceptual-data-contracts.md` to add or clarify:
+
+* Activity scoring orientation;
+* `standards_profile_id`;
+* ordered `focus_standard_ids`;
+* standard-backed and local Criterion classifications;
+* exactly one governing `standard_id` for a standard-backed Criterion;
+* optional non-governing alignment references for local Criteria;
+* standards semantics for Score Records;
+* standards-result handoff requirements;
+* standards-specific validation invariants;
+* and issue #12 representative examples.
+
+### Initial domain model
+
+Revise `docs/design/initial-concord-domain-model.md` so that:
+
+* Focus Standards are explicit Activity configuration;
+* standard-backed Criteria are distinguished from local Criteria;
+* direct standards Scores are unambiguous;
+* and generic points-based Criteria are not presented as the sole or primary scoring architecture.
+
+### Cross-case requirements
+
+Revise `docs/design/cross-case-requirements.md` to require representative support for:
+
+* standards profile selection;
+* ordered Focus Standards;
+* standard-backed Criteria;
+* local Criteria;
+* Group standards Scores;
+* individual standards Scores supported by Group or multi-subject evidence;
+* non-score dispositions by standard;
+* and future standards-result handoff.
+
+### Conceptual design
+
+Revise `docs/concord-conceptual-design-revised.md` to state explicitly that:
+
+* Concord’s primary academic scoring model is standards-based;
+* local collaborative Criteria remain valid;
+* Score is distinct from Grade and mastery;
+* and the future grading and reporting module will combine contextual standards results under later policies.
+
+### Representative contract examples
+
+Issue `#12` must include examples that demonstrate:
+
+1. a standards-based Activity;
+2. a mixed Activity containing standard-backed and local Criteria;
+3. an evidence-only Activity or evidence-bearing component;
+4. an individual standards Score;
+5. a Group standards Score;
+6. Group evidence supporting an individual standards Score through explicit teacher judgment;
+7. one evidence source supporting several standard-backed Scores;
+8. separate Criteria when one Artifact contains evidence relevant to several standards;
+9. a non-score disposition for a Focus Standard;
+10. an external ScoreForm result used as supporting evidence;
+11. an external Quillan standards result used as supporting evidence;
+12. and a local Criterion that carries optional alignment metadata but is not exported as a direct standards rating.
+
+### Foundation review
+
+Issue `#13` must verify that the proposed contracts allow a future grading and reporting module to distinguish:
+
+* direct standard-backed Scores;
+* local Criterion Scores;
+* evidence-only records;
+* standard alignment without judgment;
+* non-score dispositions;
+* Group versus individual targets;
+* current versus superseded Scores;
+* and external evidence versus Concord-owned judgments.
+
+## References
+
+* [`docs/concord-conceptual-design-revised.md`](../concord-conceptual-design-revised.md)
+* [`docs/design/cross-case-requirements.md`](../design/cross-case-requirements.md)
+* [`docs/design/initial-concord-domain-model.md`](../design/initial-concord-domain-model.md)
+* [`docs/design/conceptual-data-contracts.md`](../design/conceptual-data-contracts.md)
+* [`docs/decisions/0001-concord-module-boundaries.md`](0001-concord-module-boundaries.md)
+* [`docs/decisions/0005-separate-artifact-authors-and-subjects.md`](0005-separate-artifact-authors-and-subjects.md)
+* [`docs/decisions/0007-preserve-source-evidence-and-history.md`](0007-preserve-source-evidence-and-history.md)
+* [`docs/decisions/0008-separate-review-moderation-scoring-grading-and-reporting.md`](0008-separate-review-moderation-scoring-grading-and-reporting.md)
+* [`docs/decisions/0009-many-to-many-evidence-to-score-relationships.md`](0009-many-to-many-evidence-to-score-relationships.md)
+* [`docs/decisions/0010-exceptional-evidence-states-are-not-low-scores.md`](0010-exceptional-evidence-states-are-not-low-scores.md)
+* [`docs/decisions/0012-link-scoreform-and-quillan-without-duplication.md`](0012-link-scoreform-and-quillan-without-duplication.md)
+* [`docs/decisions/0013-keep-activity-specific-structures-optional.md`](0013-keep-activity-specific-structures-optional.md)
+* `pds-core/docs/module_standards_integration.md`
+* `pds-core/docs/standards_contract.md`
+* `pds-quillan/docs/adr/0001-standards-based-review-model.md`
+* `pds-quillan/docs/assignment_contract.md`
+* `pds-quillan/docs/review_record_contract.md`
+* `pds-quillan/docs/assignment_reporting_contract.md`
+* `pds-scoreform/docs/schema_contracts.md`

--- a/docs/design/conceptual-data-contracts.md
+++ b/docs/design/conceptual-data-contracts.md
@@ -1,0 +1,3169 @@
+# Initial Concord Conceptual Data Contracts
+
+**Status:** Draft for foundation review
+**Project:** Paper Data Suite
+**Module:** `pds-concord`
+**Issue:** `#11 — 10. Draft initial conceptual data contracts`
+**Date:** July 22, 2026
+**Revision:** 2 — incorporates ADR 0014 standards-based scoring architecture
+**Suggested branch:** `11-draft-conceptual-data-contracts`
+
+## 1. Purpose
+
+This document defines the initial conceptual data contracts for `pds-concord`.
+
+The contracts translate the accepted Concord architecture decisions, cross-case requirements, domain model, finalized `pds-core` PDS2 integration architecture, and ADR 0014 standards-based scoring decision into explicit record-level structures.
+
+The document defines:
+
+* record responsibilities;
+* ownership boundaries;
+* durable identities;
+* required and optional fields;
+* typed references;
+* relationships and cardinalities;
+* lifecycle semantics;
+* standards profile and Focus Standard selection;
+* standard-backed and local Criterion semantics;
+* standards-based and local Score semantics;
+* future standards-result handoff requirements;
+* provenance;
+* privacy;
+* correction and supersession;
+* and domain invariants.
+
+The contracts are implementation-neutral. They establish the semantics that future serialized schemas, Python models, filesystem records, persistence services, command-line interfaces, graphical interfaces, and downstream grading and reporting integrations must preserve.
+
+Concord is predominantly standards-based but not standards-exclusive. Activities may collect evidence without scoring, produce direct standards-based judgments, combine standards-based and local Criteria, or use local Criteria only. Standards selection, evidence alignment, teacher-approved scoring, grading, mastery determination, and reporting remain distinct concepts.
+
+## 2. Scope
+
+This document covers the foundational records required to represent:
+
+1. collaborative Activities and Sessions;
+2. Activity scoring orientation;
+3. Core standards-profile selection and ordered Focus Standards;
+4. Groups, Memberships, Roles, and Responsibilities;
+5. reusable Templates and Packet definitions;
+6. generated Packet, Artifact, and Artifact Page instances;
+7. Artifact Authors and Artifact Subjects;
+8. routed Scan References;
+9. Artifact Review and evidence Moderation;
+10. standard-backed and local Criteria;
+11. Scoring Scales, standard-backed Scores, local Scores, and evidence links;
+12. future standards-result handoff semantics;
+13. Attachments and External References;
+14. correction and supersession history;
+15. optional Activity Markers, Work Items, Events, and Contribution Claims;
+16. privacy and provenance across evidence-bearing and judgment-bearing records.
+
+The contracts must support at least the following representative activity families without changing the foundation:
+
+* Socratic seminars and structured discussions;
+* laboratory investigations;
+* collaborative programming projects;
+* engineering and design projects;
+* debates;
+* group research;
+* peer-review workshops;
+* and other teacher-defined collaborative activities.
+
+The contracts must also support the following scoring configurations:
+
+* evidence-only Activities that produce no Score Records;
+* standards-based Activities using only standard-backed Criteria;
+* mixed Activities using both standard-backed and local Criteria;
+* local-criteria-only Activities;
+* individual standards Scores;
+* Group standards Scores;
+* individual standards Scores supported by Group or multi-subject evidence through explicit teacher judgment;
+* local Scores that are not direct standards results;
+* and explicit non-score dispositions for either standard-backed or local Criteria.
+
+## 3. Non-goals
+
+This document does not define:
+
+* production Python classes;
+* Pydantic models;
+* JSON Schema documents;
+* database tables;
+* final filesystem layouts beneath the Concord work root;
+* packet-rendering code;
+* QR-generation code;
+* route-registration persistence code;
+* scan-dispatch handlers;
+* user-interface workflows;
+* automated handwriting interpretation;
+* optical character recognition;
+* optical mark recognition;
+* automated standards scoring;
+* automated mastery determination;
+* cross-Activity standards aggregation;
+* cross-module standards aggregation;
+* cross-scale normalization;
+* score weighting;
+* marking-period or course-grade calculation;
+* longitudinal reporting;
+* report cards;
+* parent communication;
+* or final public API stability.
+
+Concord defines contextual teacher-approved Scores. A future Paper Data Suite grading and reporting module will decide how results from Concord, Quillan, ScoreForm, and other sources are combined, normalized, weighted, summarized, or reported.
+
+Representative complete seminar, laboratory, and project records belong to issue `#12`.
+
+The skeptical foundation review and approval decision belong to issue `#13`.
+
+## 4. Governing sources
+
+These contracts are governed by the accepted Concord architecture decisions and current design documents, including:
+
+* `docs/concord-conceptual-design-revised.md`;
+* `docs/design/cross-case-requirements.md`;
+* `docs/design/initial-concord-domain-model.md`;
+* `docs/design/pds-core-integration-requirements.md`;
+* `docs/decisions/0001-concord-module-boundaries.md`;
+* `docs/decisions/0002-paper-first-human-reviewed-evidence.md`;
+* `docs/decisions/0005-separate-artifact-authors-and-subjects.md`;
+* `docs/decisions/0007-preserve-source-evidence-and-history.md`;
+* `docs/decisions/0008-separate-review-moderation-scoring-grading-and-reporting.md`;
+* `docs/decisions/0009-many-to-many-evidence-to-score-relationships.md`;
+* `docs/decisions/0010-exceptional-evidence-states-are-not-low-scores.md`;
+* `docs/decisions/0012-link-scoreform-and-quillan-without-duplication.md`;
+* `docs/decisions/0013-keep-activity-specific-structures-optional.md`;
+* `docs/decisions/0014-make-standards-based-scoring-the-primary-concord-scoring-model.md`;
+* the released `pds-core` 0.5/PDS2 contracts;
+* the Core standards contracts and module-integration guidance;
+* and the standards-based integration patterns established by Quillan and ScoreForm.
+
+When an earlier design document conflicts with the finalized PDS2 architecture, the finalized Core contract governs.
+
+When an earlier Concord design document treats standards as merely optional scoring metadata, ADR 0014 and this revised contract govern.
+
+When this document conflicts with an accepted Concord ADR, the ADR governs unless a later ADR explicitly supersedes it.
+
+## 5. Governing PDS2 constraints
+
+The following constraints are settled and are not open design questions in this contract phase.
+
+### 5.1 Module work identity
+
+For Core routing and workspace identity:
+
+```text
+module_id = concord
+class_id  = <Core class identifier>
+work_id   = <Concord activity_id>
+```
+
+The effective module work identity is:
+
+```text
+module_id + class_id + work_id
+```
+
+For Concord:
+
+```text
+work_id = activity_id
+```
+
+This does not mean that every Concord Activity is a graded assignment. `work_id` is the neutral Core routing and storage identifier for the top-level module-owned work unit.
+
+### 5.2 Module-qualified work root
+
+The canonical Concord work root is constructed through Core helpers and is conceptually:
+
+```text
+classes/<class_id>/modules/concord/work/<activity_id>/
+```
+
+Concord must not construct this path by concatenating unvalidated identifiers.
+
+### 5.3 QR payload
+
+The PDS2 QR grammar is:
+
+```text
+PDS2|m=<module_id>|c=<class_id>|w=<work_id>|r=<route_id>
+```
+
+A QR code identifies one expected physical page route.
+
+It does not identify:
+
+* a student;
+* an Artifact Author;
+* an Artifact Subject;
+* a Group;
+* a scorer;
+* a score target;
+* a Criterion;
+* a logical assignment;
+* or the complete semantic context of the page.
+
+### 5.4 Route registration target
+
+A normal Concord route registration targets an existing Artifact Page:
+
+```text
+module_id: concord
+record_kind: artifact_page
+record_id: <artifact_page_id>
+```
+
+The Artifact Page must exist before the corresponding route registration and QR code are generated.
+
+### 5.5 Semantic resolution
+
+The normal semantic resolution chain is:
+
+```text
+PDS2 locator
+    -> Core Route Registration
+    -> Concord Artifact Page
+    -> Concord Artifact Instance
+    -> optional Packet Instance
+    -> Activity
+    -> optional Session and Group context
+    -> Artifact Authors
+    -> Artifact Subjects
+```
+
+The Artifact Page and linked Concord records are authoritative for Concord semantics.
+
+The QR and route registration must not duplicate the complete Author, Subject, Membership, or Score graph.
+
+### 5.6 Source-scan ownership
+
+Core owns:
+
+* source-scan retention;
+* source-scan identity;
+* source-page provenance;
+* generic route resolution;
+* generic failure metadata;
+* and generic dispatch.
+
+Concord owns:
+
+* the link from a routed source page to an Artifact Page;
+* Concord filing status;
+* Artifact semantics;
+* Author and Subject relationships;
+* Review;
+* Moderation;
+* and Scoring.
+
+## 6. Contract conventions
+
+### 6.1 Conceptual record
+
+A conceptual record has:
+
+* a defined purpose;
+* a durable identity;
+* an owning system;
+* an independent lifecycle;
+* explicit references;
+* and stated invariants.
+
+A conceptual record does not imply a separate database table or Python class.
+
+### 6.2 Association record
+
+A relationship is modeled as a durable association record when it:
+
+* carries metadata;
+* has an independent lifecycle;
+* may be corrected;
+* may be superseded;
+* may be disputed;
+* or may be cited as evidence.
+
+Association records include:
+
+* Group Membership;
+* Role Assignment;
+* Responsibility Assignment;
+* Artifact Author;
+* Artifact Subject;
+* Score Evidence Link;
+* Work-Item Dependency;
+* and External Reference.
+
+### 6.3 Value object
+
+A value object has defined semantics but does not require independent durable identity.
+
+Value objects include:
+
+* typed references;
+* Core standards references;
+* provenance;
+* effective context;
+* privacy policy;
+* evidence locator;
+* status reason;
+* external locator;
+* authorship mode;
+* Activity scoring orientation;
+* Criterion kind;
+* Score kind;
+* score disposition;
+* and page position.
+
+### 6.4 Required field notation
+
+In the field tables:
+
+* **Required** means every valid record must contain the field.
+* **Conditional** means the field is required when a stated condition is true.
+* **Optional** means omission is valid and has defined semantics.
+* **Forbidden** means the field must not appear in that state.
+
+### 6.5 Naming
+
+Concept names use Title Case in prose.
+
+Conceptual serialized field names use `snake_case`.
+
+Identifiers use the pattern:
+
+```text
+<concept>_id
+```
+
+Examples:
+
+```text
+activity_id
+session_id
+artifact_instance_id
+score_record_id
+```
+
+The exact identifier generation algorithm belongs to Core conventions and later implementation work.
+
+### 6.6 Identifier requirements
+
+Every durable Concord identifier must:
+
+* be non-empty;
+* be stable;
+* be opaque;
+* be collision-resistant within its documented scope;
+* be safe under Core identifier rules;
+* avoid student names and other direct PII;
+* remain valid when display labels change;
+* and never be reused for a different record.
+
+Human-readable labels are not identifiers.
+
+### 6.7 Timestamps
+
+Timestamps represent provenance or chronology.
+
+They must not be used as the sole durable identity of a record.
+
+Timestamps should use an unambiguous offset-aware representation.
+
+Conceptual fields include:
+
+* `created_at`;
+* `updated_at`;
+* `reviewed_at`;
+* `moderated_at`;
+* `scored_at`;
+* `occurred_at`;
+* and `superseded_at`.
+
+### 6.8 Historical preservation
+
+A record that has been:
+
+* printed;
+* distributed;
+* scanned;
+* reviewed;
+* moderated;
+* scored;
+* exported;
+* reported;
+* or used as evidence
+
+must not be silently rewritten in a way that changes its historical meaning.
+
+Corrections and replacements create explicit history.
+
+### 6.9 Surface neutrality
+
+The same conceptual record must be capable of being created through:
+
+* a paper form;
+* a terminal interface;
+* a graphical interface;
+* an import;
+* or another authorized local workflow.
+
+A paper rubric and a digital rubric entry may produce equivalent Score Records when they represent the same teacher judgment.
+
+## 7. Shared reference and value-object contracts
+
+## 7.1 Concord Record Reference
+
+A **Concord Record Reference** identifies another Concord-owned record.
+
+### Conceptual fields
+
+| Field              | Requirement | Meaning                                   |
+| ------------------ | ----------- | ----------------------------------------- |
+| `record_kind`      | Required    | Stable Concord record-kind identifier     |
+| `record_id`        | Required    | Durable identifier of the target record   |
+| `contract_version` | Optional    | Version of the referenced public contract |
+
+### Invariants
+
+* The pair `record_kind + record_id` identifies one record.
+* The reference does not copy the referenced record.
+* A missing target must produce an explicit unavailable or invalid-reference condition.
+* Record-kind vocabulary is controlled by Concord.
+
+## 7.2 Module Record Reference
+
+A **Module Record Reference** identifies a record owned by a PDS module.
+
+### Conceptual fields
+
+| Field              | Requirement | Meaning                            |
+| ------------------ | ----------- | ---------------------------------- |
+| `module_id`        | Required    | Owning PDS module                  |
+| `record_kind`      | Required    | Public record kind                 |
+| `record_id`        | Required    | Durable module-owned identifier    |
+| `contract_version` | Optional    | Referenced public contract version |
+
+### Invariants
+
+* A bare `record_id` is not sufficient across modules.
+* Concord must not import sibling-module private implementations to resolve the reference.
+* The owning module remains authoritative.
+
+## 7.3 Participant Reference
+
+A **Participant Reference** identifies a human participant in an Activity.
+
+### Conceptual fields
+
+| Field              | Requirement | Meaning                                                     |
+| ------------------ | ----------- | ----------------------------------------------------------- |
+| `participant_kind` | Required    | `core_student`, `authorized_actor`, or future approved kind |
+| `participant_id`   | Required    | Durable identifier in the owning identity system            |
+| `owning_system`    | Required    | `core`, `concord`, or another approved authority            |
+
+### Decision
+
+Core student identity is used for rostered students.
+
+Teachers and other authorized adults use an Actor Reference. Concord does not create synthetic students for adult participants.
+
+## 7.4 Actor Reference
+
+An **Actor Reference** identifies a person or system responsible for creating, reviewing, moderating, correcting, generating, or scoring a record.
+
+### Conceptual fields
+
+| Field                    | Requirement | Meaning                                                           |
+| ------------------------ | ----------- | ----------------------------------------------------------------- |
+| `actor_kind`             | Required    | `core_student`, `authorized_adult`, `system`, or `external_actor` |
+| `actor_id`               | Required    | Durable identifier under the named authority                      |
+| `owning_system`          | Required    | Authority that owns the actor identity                            |
+| `display_label_snapshot` | Optional    | Historical display aid, not identity                              |
+| `role_snapshot`          | Optional    | Actor role at the time of action                                  |
+
+### Decision
+
+The foundation uses a typed Actor Reference rather than defining a mandatory Concord-local actor registry.
+
+A later identity capability may resolve authorized-adult identities more fully without changing these record contracts.
+
+### Invariants
+
+* Actor identity is never represented only by a name string.
+* `display_label_snapshot` cannot be used for joins or authorization.
+* A system actor must be distinguishable from a human actor.
+* An Actor Reference is provenance, not necessarily Artifact authorship.
+
+## 7.5 Subject Reference
+
+A **Subject Reference** identifies whom or what a record concerns.
+
+### Conceptual fields
+
+| Field              | Requirement | Meaning                     |
+| ------------------ | ----------- | --------------------------- |
+| `subject_kind`     | Required    | Type of subject             |
+| `subject_id`       | Required    | Durable subject identifier  |
+| `owning_system`    | Required    | Owner of the subject record |
+| `contract_version` | Optional    | Public contract version     |
+
+Initial supported kinds include:
+
+* `core_student`;
+* `concord_group`;
+* `concord_session`;
+* `concord_activity`;
+* `concord_activity_marker`;
+* `concord_work_item`;
+* `concord_activity_event`;
+* `concord_attachment`;
+* and `external_record`.
+
+### Invariants
+
+* A Subject Reference does not establish authorship.
+* A Subject Reference does not establish a Score target.
+* A student Subject is not required for every Artifact.
+* Group and contextual Subjects must not be represented through synthetic students.
+
+## 7.6 Score-Target Reference
+
+A **Score-Target Reference** identifies the entity receiving one criterion-level judgment.
+
+Initial target kinds include:
+
+* `core_student`;
+* `concord_group`;
+* `concord_session`;
+* `concord_activity`;
+* `concord_artifact_instance`;
+* `concord_work_item`;
+* and another approved activity component.
+
+### Invariants
+
+* Every Score Record has exactly one Score target.
+* A Score target is distinct from Artifact Author and Artifact Subject.
+* A target must be valid for the selected Criterion.
+* A Group target does not imply individual Scores for Group members.
+
+## 7.7 Evidence Reference
+
+An **Evidence Reference** identifies one evidence source without transforming every source into one universal Evidence entity.
+
+### Conceptual fields
+
+| Field                    | Requirement | Meaning                          |
+| ------------------------ | ----------- | -------------------------------- |
+| `evidence_kind`          | Required    | Type of evidence source          |
+| `owning_system`          | Required    | Owner of the source              |
+| `record_id`              | Required    | Durable source identifier        |
+| `contract_version`       | Optional    | Public source-contract version   |
+| `locator`                | Optional    | Location within a broader source |
+| `subject_context`        | Optional    | Subject relevant to this use     |
+| `moderation_requirement` | Optional    | Whether moderation is required   |
+
+Initial evidence kinds include:
+
+* `artifact_instance`;
+* `artifact_page`;
+* `attachment`;
+* `contribution_claim`;
+* `activity_event`;
+* `teacher_rationale`;
+* `scoreform_result`;
+* `quillan_response`;
+* and `external_record`.
+
+### Invariants
+
+* Evidence ownership remains with the source record’s owner.
+* The reference does not copy or reinterpret the source.
+* The evidence kind must be compatible with the owning system.
+* A reference to evidence does not create a Score.
+
+## 7.8 Evidence Locator
+
+An **Evidence Locator** helps an authorized reviewer find the relevant portion of a broader source.
+
+### Conceptual fields
+
+| Field                | Requirement | Meaning                                                   |
+| -------------------- | ----------- | --------------------------------------------------------- |
+| `page_number`        | Optional    | Human-readable page number                                |
+| `source_page_index`  | Optional    | Zero- or one-based source position as defined by contract |
+| `section_label`      | Optional    | Section or heading                                        |
+| `row_label`          | Optional    | Row identifier                                            |
+| `column_label`       | Optional    | Column identifier                                         |
+| `participant_label`  | Optional    | Display aid within the source                             |
+| `session_id`         | Optional    | Relevant Session                                          |
+| `activity_marker_id` | Optional    | Relevant marker                                           |
+| `work_item_id`       | Optional    | Relevant Work Item                                        |
+| `note`               | Optional    | Human-entered locator description                         |
+
+### Invariants
+
+* A locator identifies where evidence can be found.
+* A locator does not create a new evidence source.
+* A locator does not imply automated interpretation.
+* Pixel coordinates, OCR, and handwriting-region extraction are not required by the foundation.
+
+## 7.9 Provenance
+
+A **Provenance** value object records how and when a record was created or changed.
+
+### Conceptual fields
+
+| Field                 | Requirement | Meaning                                                                 |
+| --------------------- | ----------- | ----------------------------------------------------------------------- |
+| `actor`               | Required    | Actor responsible for the action                                        |
+| `timestamp`           | Required    | Time of the action                                                      |
+| `source_kind`         | Required    | `manual`, `generated`, `imported`, `routed`, `system`, or approved kind |
+| `source_reference`    | Optional    | Record or process that caused the action                                |
+| `application_version` | Optional    | Producing software version                                              |
+| `note`                | Optional    | Human explanation                                                       |
+
+### Invariants
+
+* Provenance identifies the action source, not necessarily the Artifact Author.
+* Imported records retain import provenance.
+* Generated records identify the generator or authorized actor where available.
+
+## 7.10 Effective Context
+
+An **Effective Context** defines when a relationship applies within an Activity.
+
+### Conceptual fields
+
+| Field                           | Requirement | Meaning                                                   |
+| ------------------------------- | ----------- | --------------------------------------------------------- |
+| `activity_id`                   | Required    | Parent Activity                                           |
+| `session_ids`                   | Conditional | Explicit Sessions in which the relationship applies       |
+| `activity_marker_ids`           | Optional    | Additional marker context                                 |
+| `sequence_start`                | Optional    | Start position within a Session or marker                 |
+| `sequence_end`                  | Optional    | End position within a Session or marker                   |
+| `applies_to_remaining_activity` | Optional    | Whether the relationship continues through later Sessions |
+
+### Decision
+
+Session identity is the primary temporal unit for Memberships, Roles, and Responsibilities.
+
+Explicit Session references are preferred over timestamps for instructional applicability.
+
+Sequence positions or Activity Markers may refine the context when rotation or stage precision is required.
+
+Timestamps remain provenance, not the primary effective-period model.
+
+### Invariants
+
+* The effective context belongs to exactly one Activity.
+* Referenced Sessions and Markers must belong to the same Activity.
+* A relationship may apply to one or several Sessions.
+* Historical relationships are not rewritten when later assignments differ.
+
+## 7.11 Privacy Policy
+
+A **Privacy Policy** describes the permitted audience for an evidence-bearing or judgment-bearing record.
+
+### Initial classifications
+
+* `teacher_restricted`
+* `teacher_and_subjects`
+* `group_and_teacher`
+* `classroom_shared`
+* `inherited`
+* `external_policy`
+
+### Conceptual fields
+
+| Field                 | Requirement | Meaning                                               |
+| --------------------- | ----------- | ----------------------------------------------------- |
+| `classification`      | Required    | Initial shared classification                         |
+| `audience_references` | Optional    | Explicit audience when the classification requires it |
+| `policy_reference`    | Optional    | External policy controlling access                    |
+| `reason`              | Optional    | Minimal explanation for restriction                   |
+| `inherited_from`      | Optional    | Parent record supplying the default                   |
+
+### Decision
+
+The foundation defines minimum privacy semantics but does not claim final suite-wide ownership of the vocabulary.
+
+The values may later move into a shared Core contract.
+
+### Invariants
+
+* A child record may be more restrictive than its parent.
+* A child record must not become less restrictive automatically.
+* Privacy is record-specific.
+* Author or Subject visibility does not determine full Artifact visibility.
+* Sensitive medical, disability, disciplinary, or counseling details must not be copied into Concord merely to explain a restriction.
+
+## 7.12 Status Reason
+
+A **Status Reason** explains why a record has a particular state.
+
+### Conceptual fields
+
+| Field            | Requirement | Meaning                                      |
+| ---------------- | ----------- | -------------------------------------------- |
+| `reason_code`    | Required    | Stable reason category                       |
+| `note`           | Optional    | Human explanation                            |
+| `related_record` | Optional    | Related exception, event, or external record |
+| `recorded_by`    | Required    | Actor recording the reason                   |
+| `recorded_at`    | Required    | Time recorded                                |
+
+Reasons explain states. They do not replace lifecycle or Score-disposition fields.
+
+## 7.13 External Locator
+
+An **External Locator** identifies an authorized physical or digital location without assuming a specific provider.
+
+### Conceptual fields
+
+| Field            | Requirement | Meaning                                 |
+| ---------------- | ----------- | --------------------------------------- |
+| `scheme`         | Required    | Locator scheme or provider-neutral type |
+| `locator`        | Required    | Provider-specific opaque locator        |
+| `version_label`  | Optional    | Human-readable version or revision      |
+| `content_digest` | Optional    | Integrity digest where available        |
+| `display_label`  | Optional    | Human-facing label                      |
+| `access_hint`    | Optional    | Non-secret access guidance              |
+
+Possible schemes include:
+
+* `https`;
+* `file`;
+* `git`;
+* `cloud_document`;
+* `institutional_record`;
+* `physical_location`;
+* and another registered scheme.
+
+### Invariants
+
+* Credentials and access tokens must not be stored.
+* The locator does not transfer ownership to Concord.
+* File or account ownership does not establish Artifact authorship.
+* Availability must be tracked independently.
+
+## 7.14 Core Standards References
+
+Concord uses Core-owned durable standards references.
+
+### Conceptual fields
+
+| Field | Requirement | Meaning |
+| --- | --- | --- |
+| `standards_profile_id` | Conditional | Durable Core profile identifier governing an Activity’s Focus Standard selection |
+| `standard_id` | Conditional | Durable Core standard identifier governing one standard-backed Criterion or Score |
+| `focus_standard_ids` | Conditional | Ordered, nonempty collection of durable Core standard identifiers selected for an Activity |
+| `alignment_standard_ids` | Optional | Non-governing standards alignment attached to a local Criterion |
+
+### Ownership
+
+Core owns:
+
+* standards definitions;
+* standards profiles;
+* durable identifiers;
+* display metadata;
+* profile membership;
+* active, inactive, and deprecated status;
+* browsing and selection helpers;
+* and module-neutral validation behavior.
+
+Concord stores durable references and owns their Activity-, Criterion-, Score-, and workflow-specific meaning.
+
+### Invariants
+
+* Concord must not create a competing standards library.
+* A standard display code, title, or description is not a durable identity.
+* `focus_standard_ids` order is meaningful for teacher-facing scoring and future handoff.
+* Duplicate Focus Standard IDs are invalid.
+* When a profile and Focus Standards are present, every Focus Standard should belong to that profile.
+* A selected Focus Standard does not by itself establish that the standard was taught, practiced, assessed, demonstrated, or mastered.
+* A standard becomes a direct Concord result only through an explicit teacher-approved standard-backed Score Record.
+* `alignment_standard_ids` on a local Criterion are non-governing and must not be converted into direct standards Scores.
+* Missing, inactive, or deprecated standards references are reported explicitly without silently deleting or rewriting Concord-owned data.
+
+## 8. Ownership boundaries
+
+## 8.1 Concord-owned records
+
+Concord owns:
+
+* Activity;
+* Session;
+* Group;
+* Group Membership;
+* Role Assignment;
+* Responsibility Assignment;
+* Template Definition;
+* Template Version;
+* Packet Definition;
+* Packet Version;
+* Packet Component;
+* Packet Instance;
+* Artifact Instance;
+* Artifact Page;
+* Artifact Author;
+* Artifact Subject;
+* Scan Reference;
+* Artifact Review;
+* Moderation Record;
+* Correction Record;
+* Criterion Set;
+* Criterion;
+* Scoring Scale;
+* Score Record;
+* Score Evidence Link;
+* Attachment;
+* External Reference;
+* Activity Marker;
+* Work Item;
+* Work-Item Dependency;
+* Activity Event;
+* and Contribution Claim.
+
+## 8.2 Core-owned records and capabilities
+
+Core owns:
+
+* workspace resolution;
+* canonical class identity;
+* roster and student identity;
+* identifier validation;
+* module-qualified work paths;
+* PDS2 parsing and serialization;
+* Route Locator;
+* Route Registration;
+* Module Record Reference structure;
+* source-scan retention;
+* source-scan provenance;
+* generic routing failures;
+* generic route resolutions;
+* module-profile dispatch;
+* shared standards definitions;
+* shared standards profiles;
+* standards-library storage;
+* standards selection and display helpers;
+* profile-membership and standards-reference validation;
+* durable `standard_id` and `profile_id` semantics;
+* and shared contract-version information.
+
+Concord references these records and capabilities.
+
+Concord owns its Activity scoring orientation, Focus Standard selection, Criterion classification, teacher-approved Scores, standards-result handoff semantics, and module-specific interpretation of shared standards.
+
+## 8.3 Sibling-module ownership
+
+ScoreForm owns:
+
+* OMR instruments;
+* machine-readable checks;
+* selected-response processing;
+* ScoreForm attempts;
+* and ScoreForm results.
+
+Quillan owns:
+
+* focused and extended written responses;
+* Quillan submission assembly;
+* Quillan review;
+* Quillan feedback;
+* and Quillan result records.
+
+Concord may reference public ScoreForm and Quillan records. It must not reproduce or mutate them.
+
+## 8.4 External ownership
+
+External systems remain authoritative for:
+
+* course grades;
+* formal reports;
+* parent communication;
+* safety and disciplinary incidents;
+* medical and accommodation records;
+* source-control history;
+* cloud-document history;
+* CAD and engineering files;
+* and institutional records.
+
+## 9. Activity and collaboration contracts
+
+## 9.1 Activity
+
+An **Activity** represents one already-planned collaborative classroom undertaking.
+
+Examples include:
+
+* a seminar;
+* a laboratory investigation;
+* a programming project;
+* a design challenge;
+* a debate;
+* or a group research task.
+
+Every Activity declares how Concord is expected to use its evidence and Criteria.
+
+### Fields
+
+| Field | Requirement | Meaning |
+| --- | --- | --- |
+| `activity_id` | Required | Durable Concord Activity identity and Core `work_id` |
+| `class_reference` | Required | Core class reference |
+| `title` | Required | Teacher-facing title |
+| `activity_type` | Required | Teacher-defined or starter activity category |
+| `scoring_orientation` | Required | `evidence_only`, `standards_based`, `mixed`, or `local_criteria_only` |
+| `standards_profile_id` | Conditional | Core standards profile required for standards-based and mixed Activities |
+| `focus_standard_ids` | Conditional | Ordered Focus Standards required for standards-based and mixed Activities |
+| `status` | Required | Activity lifecycle state |
+| `description` | Optional | Concise Activity description |
+| `criterion_set_ids` | Optional | Selected Criterion Sets |
+| `privacy_policy` | Optional | Activity-level default |
+| `created_provenance` | Required | Creation provenance |
+| `updated_provenance` | Optional | Most recent non-historical metadata update |
+| `external_reference_ids` | Optional | Related external records |
+
+### Initial scoring orientations
+
+```text
+evidence_only
+standards_based
+mixed
+local_criteria_only
+```
+
+#### `evidence_only`
+
+The Activity collects, organizes, reviews, or moderates evidence without producing Concord Score Records.
+
+It does not require:
+
+* a standards profile;
+* Focus Standards;
+* Criteria;
+* or a Scoring Scale.
+
+#### `standards_based`
+
+The Activity’s scored judgments are direct judgments against selected Focus Standards.
+
+It requires:
+
+* one `standards_profile_id`;
+* one or more ordered `focus_standard_ids`;
+* one or more standard-backed Criteria before scoring;
+* and applicable Scoring Scale revisions.
+
+Scored Criteria should ordinarily be standard-backed.
+
+#### `mixed`
+
+The Activity uses both standard-backed and local Criteria.
+
+It requires:
+
+* one `standards_profile_id`;
+* one or more ordered `focus_standard_ids`;
+* at least one standard-backed Criterion before standards scoring;
+* and may also use local Criteria.
+
+#### `local_criteria_only`
+
+The Activity may produce Score Records, but none are direct standards judgments.
+
+It does not require a standards profile or Focus Standards.
+
+A local Score may later affect a Grade only through an explicit downstream policy. It must not be represented as a direct standards result.
+
+### Lifecycle
+
+Initial Activity states are:
+
+```text
+draft
+configured
+active
+completed
+cancelled
+archived
+```
+
+Typical progression:
+
+```text
+draft -> configured -> active -> completed -> archived
+```
+
+Cancellation may occur from a non-archived state.
+
+### Relationships
+
+* One Core class has zero or many Activities.
+* One Activity belongs to exactly one Core class.
+* One Activity contains one or more Sessions.
+* One Activity may contain zero or many Groups.
+* One Activity may select zero or many Criterion Sets.
+* One standards-based or mixed Activity selects exactly one Core standards profile.
+* One standards-based or mixed Activity selects one or more Focus Standards.
+* One Activity may generate zero or many Packet Instances.
+* One Activity may contain zero or many Artifacts.
+* One Activity may contain zero or many Scores.
+
+### Invariants
+
+* `activity_id` is Concord’s PDS2 `work_id`.
+* Cross-class Activities are outside the initial contract.
+* Every Activity contains at least one Session.
+* Every Activity declares exactly one scoring orientation.
+* `standards_based` and `mixed` Activities require one valid `standards_profile_id` and a nonempty ordered `focus_standard_ids` collection.
+* `evidence_only` and `local_criteria_only` Activities do not require standards configuration.
+* Duplicate Focus Standard IDs are invalid.
+* Focus Standards should belong to the selected profile.
+* Selecting a Focus Standard does not create a Score or establish mastery.
+* A standard-backed Criterion used by the Activity must govern one of the Activity’s Focus Standards.
+* An Activity is not automatically a graded assignment.
+* Cancellation does not delete existing evidence or Scores.
+* Activity-specific structures are optional unless selected records require them.
+
+## 9.2 Session
+
+A **Session** represents one occurrence, instructional period, rotation window, or work period within an Activity.
+
+### Fields
+
+| Field                | Requirement | Meaning                             |
+| -------------------- | ----------- | ----------------------------------- |
+| `session_id`         | Required    | Durable Session identity            |
+| `activity_id`        | Required    | Parent Activity                     |
+| `sequence`           | Required    | Stable ordering within the Activity |
+| `label`              | Optional    | Teacher-facing label                |
+| `scheduled_start`    | Optional    | Planned start                       |
+| `scheduled_end`      | Optional    | Planned end                         |
+| `actual_start`       | Optional    | Actual start                        |
+| `actual_end`         | Optional    | Actual end                          |
+| `status`             | Required    | Session lifecycle                   |
+| `status_reason`      | Optional    | Explanation of exceptional state    |
+| `notes`              | Optional    | Contextual notes                    |
+| `created_provenance` | Required    | Creation provenance                 |
+
+### Initial lifecycle states
+
+```text
+planned
+active
+completed
+cancelled
+interrupted
+archived
+```
+
+### Relationships
+
+* One Activity contains one or more Sessions.
+* One Session belongs to exactly one Activity.
+* One Session may contextualize Memberships, Roles, Responsibilities, Groups, Artifacts, Events, and Scores.
+
+### Invariants
+
+* Even a single-period Activity has one explicit Session.
+* Session sequence is unique within an Activity.
+* Cancellation or interruption is not a performance judgment.
+* Session status does not automatically set Score dispositions.
+
+## 9.3 Group
+
+A **Group** is an Activity-specific collaborative unit.
+
+### Fields
+
+| Field                 | Requirement | Meaning                                   |
+| --------------------- | ----------- | ----------------------------------------- |
+| `group_id`            | Required    | Durable Group identity                    |
+| `activity_id`         | Required    | Parent Activity                           |
+| `label`               | Required    | Teacher-facing label                      |
+| `description`         | Optional    | Group purpose or description              |
+| `parent_group_id`     | Optional    | Parent Group for a child Group or subteam |
+| `effective_context`   | Optional    | Bounded Session or marker context         |
+| `status`              | Required    | Group lifecycle                           |
+| `created_provenance`  | Required    | Creation provenance                       |
+| `supersedes_group_id` | Optional    | Replaced Group record where applicable    |
+
+### Lifecycle states
+
+```text
+planned
+active
+inactive
+completed
+cancelled
+archived
+superseded
+```
+
+### Relationships
+
+* One Activity may contain zero or many Groups.
+* One Group belongs to exactly one Activity.
+* One Group may have zero or one parent Group.
+* One Group may have zero or many child Groups.
+* One Group may have zero or many Memberships.
+* One Group may be an Artifact Author, Artifact Subject, or Score target.
+
+### Invariants
+
+* Groups are not added to the Core roster.
+* A Group identifier must not be stored in `student_id`.
+* Child Groups represent subteams when bounded collaborative identity matters.
+* Different responsibilities alone do not require child Groups.
+* Group labels may change without changing `group_id`.
+
+## 9.4 Group Membership
+
+A **Group Membership** associates one participant with one Group for a defined Activity context.
+
+### Fields
+
+| Field                      | Requirement | Meaning                                         |
+| -------------------------- | ----------- | ----------------------------------------------- |
+| `membership_id`            | Required    | Durable association identity                    |
+| `group_id`                 | Required    | Group                                           |
+| `participant_reference`    | Required    | Participant                                     |
+| `effective_context`        | Required    | Sessions or markers in which membership applies |
+| `status`                   | Required    | Membership status                               |
+| `status_reason`            | Optional    | Reason for change                               |
+| `created_provenance`       | Required    | Creation provenance                             |
+| `supersedes_membership_id` | Optional    | Earlier Membership replaced by this record      |
+
+### Initial statuses
+
+```text
+planned
+active
+completed
+withdrawn
+reassigned
+cancelled
+superseded
+```
+
+### Relationships
+
+* One Group has zero or many Memberships.
+* One participant may have zero or many Memberships in an Activity.
+* One Membership belongs to exactly one Group.
+* One Membership refers to exactly one participant.
+* One Membership applies to one or more Sessions.
+
+### Invariants
+
+* Membership is contextual, not a permanent participant property.
+* A participant may belong to different Groups in different Sessions.
+* A later reassignment does not rewrite prior Membership.
+* Membership does not establish Artifact authorship.
+* Membership does not prove contribution.
+* Membership does not create a Score.
+
+## 9.5 Role Assignment
+
+A **Role Assignment** records a contextual function held by a participant.
+
+Examples include:
+
+* facilitator;
+* observer;
+* discussion mapper;
+* recorder;
+* materials manager;
+* tester;
+* debugger;
+* or integration coordinator.
+
+### Fields
+
+| Field                           | Requirement | Meaning                        |
+| ------------------------------- | ----------- | ------------------------------ |
+| `role_assignment_id`            | Required    | Durable association identity   |
+| `activity_id`                   | Required    | Parent Activity                |
+| `participant_reference`         | Required    | Assigned participant           |
+| `membership_id`                 | Optional    | Relevant Membership            |
+| `group_id`                      | Optional    | Group context                  |
+| `role_key`                      | Required    | Role vocabulary key            |
+| `role_label_snapshot`           | Optional    | Historical display label       |
+| `effective_context`             | Required    | Sessions, markers, or sequence |
+| `status`                        | Required    | Assignment status              |
+| `assigned_by`                   | Required    | Actor assigning the role       |
+| `created_provenance`            | Required    | Creation provenance            |
+| `supersedes_role_assignment_id` | Optional    | Earlier assignment replaced    |
+
+### Invariants
+
+* Roles are contextual functions, not personality labels.
+* One participant may hold several Roles.
+* A Role may be shared by several participants.
+* A Role Assignment does not prove that the participant fulfilled the Role.
+* A recorder Role does not establish sole Artifact authorship.
+* Role vocabularies may be teacher-defined under controlled keys.
+
+## 9.6 Responsibility Assignment
+
+A **Responsibility Assignment** records a specific obligation assigned to a participant, Group, or child Group.
+
+### Fields
+
+| Field                                     | Requirement | Meaning                             |
+| ----------------------------------------- | ----------- | ----------------------------------- |
+| `responsibility_assignment_id`            | Required    | Durable association identity        |
+| `activity_id`                             | Required    | Parent Activity                     |
+| `assignee_reference`                      | Required    | Participant or Group                |
+| `description`                             | Required    | Concise assigned obligation         |
+| `effective_context`                       | Required    | Applicable Sessions or markers      |
+| `group_id`                                | Optional    | Group context                       |
+| `work_item_id`                            | Optional    | Related Work Item                   |
+| `expected_output`                         | Optional    | Expected deliverable                |
+| `status`                                  | Required    | Assignment status                   |
+| `assigned_by`                             | Required    | Assigning Actor                     |
+| `status_reason`                           | Optional    | Reassignment or cancellation reason |
+| `created_provenance`                      | Required    | Creation provenance                 |
+| `supersedes_responsibility_assignment_id` | Optional    | Earlier assignment replaced         |
+
+### Invariants
+
+* Responsibility Assignment is optional at the Activity level.
+* Responsibility identifies what was assigned.
+* It does not prove completion, quality, contribution, or Role fulfillment.
+* Reassignment preserves the original assignment.
+* A Responsibility may contextualize evidence without becoming evidence of successful performance by itself.
+
+## 10. Reusable definition and generated-instance contracts
+
+## 10.1 Template Definition
+
+A **Template Definition** represents the stable lineage of one reusable printable design.
+
+### Fields
+
+| Field                | Requirement | Meaning                          |
+| -------------------- | ----------- | -------------------------------- |
+| `template_id`        | Required    | Stable Template lineage identity |
+| `name`               | Required    | Template name                    |
+| `artifact_category`  | Required    | General Artifact category        |
+| `purpose`            | Required    | Intended use                     |
+| `owner_reference`    | Optional    | Creator or source                |
+| `status`             | Required    | Definition lifecycle             |
+| `created_provenance` | Required    | Creation provenance              |
+
+### Relationships
+
+* One Template Definition has one or more Template Versions.
+* One Template Version belongs to exactly one Template Definition.
+
+### Invariants
+
+* A Template Definition contains no specific class, student, Group, or Activity assignment.
+* Changes to printable content occur through Template Versions.
+
+## 10.2 Template Version
+
+A **Template Version** is one immutable revision of a Template Definition.
+
+### Fields
+
+| Field                               | Requirement | Meaning                            |
+| ----------------------------------- | ----------- | ---------------------------------- |
+| `template_version_id`               | Required    | Durable immutable version identity |
+| `template_id`                       | Required    | Parent Template Definition         |
+| `version_label`                     | Required    | Human-facing version               |
+| `revision_sequence`                 | Required    | Ordered revision                   |
+| `rendering_specification_reference` | Required    | Layout or rendering source         |
+| `artifact_category`                 | Required    | Artifact category                  |
+| `page_manifest`                     | Required    | Expected page structure            |
+| `expected_return_behavior`          | Required    | Which pages are expected back      |
+| `default_privacy_policy`            | Required    | Default privacy                    |
+| `default_authorship_expectation`    | Optional    | Proposed authorship rule           |
+| `default_subject_expectation`       | Optional    | Proposed subject rule              |
+| `supported_criterion_ids`           | Optional    | Compatible Criteria                |
+| `qr_requirements`                   | Required    | Which pages require PDS2 routes    |
+| `created_provenance`                | Required    | Creation provenance                |
+| `status`                            | Required    | Version status                     |
+| `supersedes_template_version_id`    | Optional    | Earlier version                    |
+
+### Initial statuses
+
+```text
+draft
+active
+retired
+superseded
+```
+
+### Invariants
+
+* A Template Version becomes immutable once it generates an Artifact Instance.
+* Changes to wording, layout, page structure, QR placement, authorship expectations, subject expectations, or supported Criteria require a new Template Version.
+* Retirement does not invalidate historical Artifact Instances.
+
+## 10.3 Packet Definition
+
+A **Packet Definition** represents the stable lineage of a reusable packet design.
+
+### Fields
+
+| Field                  | Requirement | Meaning                        |
+| ---------------------- | ----------- | ------------------------------ |
+| `packet_definition_id` | Required    | Stable Packet lineage identity |
+| `name`                 | Required    | Packet name                    |
+| `purpose`              | Required    | Intended Activity use          |
+| `status`               | Required    | Definition lifecycle           |
+| `created_provenance`   | Required    | Creation provenance            |
+
+### Decision
+
+Packet definition identity is separated from Packet Version identity.
+
+This parallels Template Definition and Template Version and avoids treating a mutable composition field as the identity of a reusable packet lineage.
+
+## 10.4 Packet Version
+
+A **Packet Version** is one immutable ordered composition of Template Versions and optional external components.
+
+### Fields
+
+| Field                          | Requirement | Meaning                                    |
+| ------------------------------ | ----------- | ------------------------------------------ |
+| `packet_version_id`            | Required    | Durable immutable version identity         |
+| `packet_definition_id`         | Required    | Parent Packet Definition                   |
+| `version_label`                | Required    | Human-facing version                       |
+| `revision_sequence`            | Required    | Ordered revision                           |
+| `component_ids`                | Required    | Ordered Packet Components                  |
+| `generation_rules`             | Optional    | Repetition or conditional-generation rules |
+| `created_provenance`           | Required    | Creation provenance                        |
+| `status`                       | Required    | Version status                             |
+| `supersedes_packet_version_id` | Optional    | Earlier version                            |
+
+### Invariants
+
+* A Packet Version must contain at least one Packet Component.
+* A Packet Version becomes immutable after generating a Packet Instance.
+* Changes to composition or order require a new Packet Version.
+
+## 10.5 Packet Component
+
+A **Packet Component** is one ordered element of a Packet Version.
+
+### Fields
+
+| Field                   | Requirement | Meaning                                     |
+| ----------------------- | ----------- | ------------------------------------------- |
+| `packet_component_id`   | Required    | Durable component identity                  |
+| `packet_version_id`     | Required    | Parent Packet Version                       |
+| `sequence`              | Required    | Component order                             |
+| `component_kind`        | Required    | `concord_template` or `external_component`  |
+| `template_version_id`   | Conditional | Exact Concord Template Version              |
+| `external_reference_id` | Conditional | Expected external component                 |
+| `quantity_rule`         | Required    | Number or repetition rule                   |
+| `audience_rule`         | Optional    | Intended participant or Group               |
+| `requirement_level`     | Required    | `required`, `recommended`, or `conditional` |
+| `condition`             | Optional    | Generation condition                        |
+| `label`                 | Optional    | Human-facing component label                |
+
+### Invariants
+
+* Exactly one of `template_version_id` or `external_reference_id` is present according to `component_kind`.
+* An external component remains owned by its originating module.
+* Physical assembly into one packet does not transfer record ownership.
+
+## 10.6 Packet Instance
+
+A **Packet Instance** is one generated packet tied to a specific Activity context.
+
+### Fields
+
+| Field                         | Requirement | Meaning                           |
+| ----------------------------- | ----------- | --------------------------------- |
+| `packet_instance_id`          | Required    | Durable generated-packet identity |
+| `packet_version_id`           | Required    | Exact Packet Version              |
+| `activity_id`                 | Required    | Parent Activity                   |
+| `session_id`                  | Optional    | Session context                   |
+| `group_id`                    | Optional    | Group context                     |
+| `participant_reference`       | Optional    | Participant context               |
+| `series_id`                   | Optional    | Long-running packet series        |
+| `previous_packet_instance_id` | Optional    | Previous checkpoint packet        |
+| `generation_status`           | Required    | Generation lifecycle              |
+| `generated_at`                | Required    | Generation time                   |
+| `generated_by`                | Required    | Generator Actor                   |
+| `artifact_instance_ids`       | Required    | Generated Concord Artifacts       |
+| `created_provenance`          | Required    | Creation provenance               |
+
+### Decision
+
+Both long-running models are permitted:
+
+1. one continuing Packet Instance whose Artifacts span several Sessions; or
+2. several linked Packet Instances within one `series_id`.
+
+The Activity or packet-generation configuration must choose deliberately.
+
+### Invariants
+
+* One Packet Instance uses exactly one Packet Version.
+* One Packet Instance belongs to exactly one Activity.
+* One Packet Instance contains one or more Concord Artifact Instances.
+* External components may be recorded as expected components but are not Concord Artifact Instances.
+* Regeneration does not silently replace an already distributed Packet Instance.
+
+## 10.7 Artifact Instance
+
+An **Artifact Instance** is one generated copy of one Template Version.
+
+### Fields
+
+| Field                             | Requirement | Meaning                             |
+| --------------------------------- | ----------- | ----------------------------------- |
+| `artifact_instance_id`            | Required    | Durable generated-Artifact identity |
+| `template_version_id`             | Required    | Exact Template Version              |
+| `activity_id`                     | Required    | Parent Activity                     |
+| `packet_instance_id`              | Optional    | Parent Packet Instance              |
+| `session_id`                      | Optional    | Session context                     |
+| `group_id`                        | Optional    | Group context                       |
+| `activity_marker_id`              | Optional    | Marker context                      |
+| `work_item_id`                    | Optional    | Work Item context                   |
+| `artifact_category`               | Required    | Category snapshot                   |
+| `generation_status`               | Required    | Generation state                    |
+| `expected_return_status`          | Required    | Return expectation                  |
+| `artifact_status`                 | Required    | Artifact lifecycle                  |
+| `privacy_policy`                  | Required    | Effective privacy                   |
+| `page_ids`                        | Required    | Ordered Artifact Pages              |
+| `created_provenance`              | Required    | Generation provenance               |
+| `supersedes_artifact_instance_id` | Optional    | Replacement Artifact                |
+
+### Invariants
+
+* One Artifact Instance uses exactly one Template Version.
+* One Artifact Instance belongs to exactly one Activity.
+* One Artifact Instance may exist outside a Packet Instance.
+* One Artifact Instance contains one or more Artifact Pages.
+* Artifact Authors and Subjects are separate association records.
+* Artifact identity is not scan identity.
+* A replacement Artifact does not erase the earlier generated Artifact.
+
+## 10.8 Artifact Page
+
+An **Artifact Page** represents one expected physical page within an Artifact Instance.
+
+### Fields
+
+| Field                     | Requirement | Meaning                          |
+| ------------------------- | ----------- | -------------------------------- |
+| `artifact_page_id`        | Required    | Durable page identity            |
+| `artifact_instance_id`    | Required    | Parent Artifact Instance         |
+| `page_number`             | Required    | Logical page number              |
+| `expected_page_count`     | Optional    | Expected total                   |
+| `page_kind`               | Required    | Page role                        |
+| `return_expected`         | Required    | Whether the page should return   |
+| `route_required`          | Required    | Whether PDS2 routing is required |
+| `route_id`                | Conditional | PDS2 route identity              |
+| `human_fallback`          | Conditional | Printed recovery identifier      |
+| `continuation_of_page_id` | Optional    | Prior logical page               |
+| `page_status`             | Required    | Page lifecycle                   |
+| `created_provenance`      | Required    | Creation provenance              |
+
+### Initial page kinds
+
+Examples include:
+
+* `primary`;
+* `continuation`;
+* `rubric`;
+* `cover`;
+* `instructional`;
+* `observation`;
+* and `attachment_label`.
+
+The vocabulary may be extended under controlled keys.
+
+### Invariants
+
+* Every returned scannable page has stable identity before rendering.
+* A route-required page has one immutable `route_id`.
+* A `route_id` is never reused.
+* The route registration targets this Artifact Page.
+* `route_id` does not encode Authors, Subjects, page meaning, or score targets.
+* A non-returned instructional page may omit a route when declared by the Template Version.
+* One Artifact Page may have zero or many Scan References over time.
+
+## 11. Authorship and subject contracts
+
+## 11.1 Artifact Author
+
+An **Artifact Author** associates an Artifact Instance with a person or collective that completed, produced, recorded, or formally represented it.
+
+### Fields
+
+| Field                           | Requirement | Meaning                                               |
+| ------------------------------- | ----------- | ----------------------------------------------------- |
+| `artifact_author_id`            | Required    | Durable association identity                          |
+| `artifact_instance_id`          | Required    | Artifact                                              |
+| `author_reference`              | Required    | Participant, Actor, or Group reference                |
+| `authorship_mode`               | Required    | Nature of authorship                                  |
+| `represented_group_id`          | Optional    | Group represented by an individual recorder           |
+| `role_assignment_id`            | Optional    | Relevant Role context                                 |
+| `representation_status`         | Optional    | Consensus or representation form                      |
+| `attribution_status`            | Required    | Proposed, confirmed, disputed, unknown, or superseded |
+| `attribution_source`            | Required    | Source of attribution                                 |
+| `privacy_policy`                | Optional    | Association-specific privacy                          |
+| `created_provenance`            | Required    | Creation provenance                                   |
+| `supersedes_artifact_author_id` | Optional    | Earlier attribution replaced                          |
+
+### Initial authorship modes
+
+* `individual_author`
+* `co_author`
+* `observer`
+* `recorder`
+* `recorder_for_group`
+* `collective_group_author`
+* `teacher_author`
+* `authorized_adult_author`
+* `unknown`
+
+### Initial representation statuses
+
+* `individual_view`
+* `recorder_summary`
+* `majority_position`
+* `unanimous_position`
+* `multiple_named_positions`
+* `no_consensus`
+* `not_applicable`
+
+### Invariants
+
+* One Artifact may have zero or many Authors.
+* Author and Subject are independent.
+* Group Membership does not establish authorship.
+* Role Assignment does not establish authorship automatically.
+* Handwriting, possession, scanning, device ownership, account ownership, file ownership, and upload identity do not establish sole authorship.
+* A reviewed evidence-bearing Artifact normally has a confirmed, collective, or explicit unknown-author status.
+* Correction preserves prior attribution.
+
+## 11.2 Artifact Subject
+
+An **Artifact Subject** associates an Artifact Instance with the person, Group, context, event, or object that it concerns.
+
+### Fields
+
+| Field                            | Requirement | Meaning                                                  |
+| -------------------------------- | ----------- | -------------------------------------------------------- |
+| `artifact_subject_id`            | Required    | Durable association identity                             |
+| `artifact_instance_id`           | Required    | Artifact                                                 |
+| `subject_reference`              | Required    | Typed Subject Reference                                  |
+| `subject_role`                   | Required    | Relationship of the Subject to the Artifact              |
+| `criterion_id`                   | Optional    | Criterion-specific subject context                       |
+| `confirmation_status`            | Required    | Proposed, confirmed, disputed, unresolved, or superseded |
+| `assignment_source`              | Required    | Source of Subject assignment                             |
+| `privacy_policy`                 | Optional    | Association-specific privacy                             |
+| `created_provenance`             | Required    | Creation provenance                                      |
+| `supersedes_artifact_subject_id` | Optional    | Earlier Subject assignment replaced                      |
+
+### Initial subject roles
+
+Examples include:
+
+* `observed_participant`;
+* `represented_group`;
+* `activity_context`;
+* `session_context`;
+* `evaluated_work_item`;
+* `documented_event`;
+* `related_attachment`;
+* and `general_subject`.
+
+### Invariants
+
+* One Artifact may have zero or many Subjects.
+* A Group-level Artifact need not have an individual student Subject.
+* A teacher tracker may remain one Artifact with several Subjects.
+* Several Subjects do not require duplicate source scans.
+* Subject does not establish authorship.
+* Subject does not automatically create a Score for that Subject.
+* An unresolved Artifact may temporarily have no confirmed Subject.
+
+## 12. Scan, Review, Moderation, and Correction contracts
+
+## 12.1 Scan Reference
+
+A **Scan Reference** is Concord’s durable association between one Artifact Page and one page or region of a Core-retained source scan.
+
+### Fields
+
+| Field                          | Requirement | Meaning                                           |
+| ------------------------------ | ----------- | ------------------------------------------------- |
+| `scan_reference_id`            | Required    | Durable association identity                      |
+| `artifact_page_id`             | Required    | Expected Concord page                             |
+| `core_source_scan_reference`   | Required    | Core source-scan identity                         |
+| `source_page_index`            | Required    | Page position in retained source                  |
+| `routed_derivative_reference`  | Optional    | Concord-created review derivative                 |
+| `routing_status`               | Required    | Route state                                       |
+| `readability_status`           | Required    | Readability state                                 |
+| `filing_status`                | Required    | Concord filing state                              |
+| `review_status`                | Required    | Review state                                      |
+| `preferred_for_use`            | Required    | Whether currently preferred                       |
+| `created_provenance`           | Required    | Route/filing provenance                           |
+| `supersedes_scan_reference_id` | Optional    | Earlier Scan Reference replaced                   |
+| `status_reason`                | Optional    | Duplicate, rescan, conflict, or correction reason |
+
+### Initial routing statuses
+
+```text
+routed
+manually_resolved
+conflicting
+misrouted
+unidentified
+inactive
+superseded
+```
+
+### Initial readability statuses
+
+```text
+readable
+partially_readable
+unreadable
+not_reviewed
+```
+
+### Initial filing statuses
+
+```text
+proposed
+confirmed
+incorrect
+awaiting_correction
+superseded
+```
+
+### Invariants
+
+* The Core-retained source scan remains canonical.
+* One Scan Reference links one source page or defined region to one Artifact Page.
+* One Artifact Page may have several Scan References because of duplicates, rescans, or corrections.
+* A rescan creates a new source scan and Scan Reference.
+* A duplicate is preserved and may later be reclassified.
+* A routed derivative never replaces the retained source.
+* Misroute correction preserves the earlier route history.
+
+## 12.2 Artifact Review
+
+An **Artifact Review** records one human examination of an Artifact Instance and its available routed evidence.
+
+### Fields
+
+| Field                           | Requirement | Meaning                        |
+| ------------------------------- | ----------- | ------------------------------ |
+| `artifact_review_id`            | Required    | Durable Review identity        |
+| `artifact_instance_id`          | Required    | Reviewed Artifact              |
+| `reviewer`                      | Required    | Reviewing Actor                |
+| `reviewed_at`                   | Required    | Review time                    |
+| `readability_judgment`          | Required    | Overall readability            |
+| `page_completeness_judgment`    | Required    | Completeness                   |
+| `filing_judgment`               | Required    | Filing correctness             |
+| `author_judgment`               | Required    | Attribution state              |
+| `subject_judgment`              | Required    | Subject state                  |
+| `privacy_judgment`              | Required    | Privacy state                  |
+| `relevance_judgment`            | Required    | Evidentiary relevance          |
+| `moderation_requirement`        | Required    | Whether moderation is required |
+| `scoring_readiness`             | Required    | Readiness for possible use     |
+| `review_outcome`                | Required    | Overall Review outcome         |
+| `notes`                         | Optional    | Review explanation             |
+| `privacy_policy`                | Required    | Review privacy                 |
+| `supersedes_artifact_review_id` | Optional    | Earlier Review replaced        |
+
+### Initial Review outcomes
+
+* `ready`
+* `ready_with_qualification`
+* `incomplete`
+* `unreadable`
+* `misrouted`
+* `duplicate`
+* `awaiting_correction`
+* `awaiting_additional_evidence`
+* `moderation_required`
+* `not_suitable_for_scoring`
+
+### Invariants
+
+* Review confirms administrative and evidentiary readiness.
+* Review does not determine performance.
+* Review does not create a Score.
+* Review does not imply that student-generated claims are fair or reliable.
+* Review does not modify the source scan.
+* Later Reviews preserve earlier Review history.
+* A Review may produce correction records or replacement associations.
+
+## 12.3 Moderation Record
+
+A **Moderation Record** documents an authorized judgment about whether and how evidence may be used consequentially.
+
+### Fields
+
+| Field                             | Requirement | Meaning                               |
+| --------------------------------- | ----------- | ------------------------------------- |
+| `moderation_record_id`            | Required    | Durable Moderation identity           |
+| `target_evidence_reference`       | Required    | Evidence being moderated              |
+| `target_subject_references`       | Optional    | Subjects to whom the decision applies |
+| `moderator`                       | Required    | Authorized Actor                      |
+| `moderated_at`                    | Required    | Decision time                         |
+| `status`                          | Required    | Moderation outcome                    |
+| `qualification`                   | Conditional | Required for qualified acceptance     |
+| `permitted_use`                   | Required    | Consequential use allowed             |
+| `rationale`                       | Required    | Decision rationale                    |
+| `privacy_policy`                  | Required    | Moderation privacy                    |
+| `supersedes_moderation_record_id` | Optional    | Earlier decision replaced             |
+
+### Initial statuses
+
+* `accepted`
+* `accepted_with_qualification`
+* `insufficient`
+* `disputed`
+* `rejected`
+* `not_used_for_scoring`
+
+### Permitted-use examples
+
+* may support Group scoring;
+* may corroborate teacher evidence;
+* may support one named Subject only;
+* may be used formatively only;
+* may not independently determine a Score;
+* may not be used for scoring.
+
+### Invariants
+
+* Moderation evaluates evidence use, not performance.
+* `accepted` is not a high Score.
+* `rejected` is not negative evidence against the Subject.
+* Evidence requiring moderation cannot support a consequential Score until permitted.
+* A Moderation decision does not select the Criterion, target, or score value.
+* Superseded decisions remain available.
+
+## 12.4 Correction Record
+
+A **Correction Record** documents why an earlier record or association was corrected or replaced.
+
+### Decision
+
+Concord uses a hybrid correction model:
+
+1. same-type replacement records use an explicit `supersedes_<record>_id` relationship; and
+2. a generic Correction Record explains the correction, actor, reason, and old-to-new relationship.
+
+This preserves efficient current-record traversal while maintaining one consistent audit contract.
+
+### Fields
+
+| Field                      | Requirement | Meaning                                 |
+| -------------------------- | ----------- | --------------------------------------- |
+| `correction_id`            | Required    | Durable Correction identity             |
+| `target_reference`         | Required    | Record determined to require correction |
+| `correction_type`          | Required    | Nature of correction                    |
+| `reason`                   | Required    | Explanation                             |
+| `correcting_actor`         | Required    | Actor                                   |
+| `corrected_at`             | Required    | Correction time                         |
+| `replacement_reference`    | Optional    | New governing record                    |
+| `related_source_reference` | Optional    | Source supporting the correction        |
+| `note`                     | Optional    | Additional explanation                  |
+| `privacy_policy`           | Required    | Correction privacy                      |
+
+### Initial correction types
+
+Examples include:
+
+* `filing_correction`;
+* `author_correction`;
+* `subject_correction`;
+* `membership_correction`;
+* `role_correction`;
+* `responsibility_correction`;
+* `scan_replacement`;
+* `review_correction`;
+* `moderation_revision`;
+* `score_revision`;
+* and `metadata_correction`.
+
+### Invariants
+
+* The target record remains available.
+* A Correction Record never rewrites a retained source scan.
+* The replacement must identify the record it supersedes.
+* A current-record designation is a retrieval aid, not deletion of history.
+* Corrections must not create ambiguous competing current records.
+
+## 13. Criteria and scoring contracts
+
+Concord’s primary academic scoring model is standards-based.
+
+Concord remains capable of representing:
+
+* evidence-only Activities;
+* direct standards-based Criteria and Scores;
+* mixed standards-based and local scoring;
+* and local-criteria-only scoring.
+
+The central direct standards relationship is:
+
+```text
+collaborative evidence
+    -> standard-backed Criterion
+    -> teacher-approved Score
+    -> future standards-based grading and reporting
+```
+
+Standards selection, evidence alignment, Review, Moderation, Scoring, Grading, mastery determination, and Reporting remain separate.
+
+## 13.1 Criterion Set
+
+A **Criterion Set** is one immutable revision of an ordered collection of related Criteria.
+
+### Decision
+
+Criterion Sets use immutable revision records rather than a separate mandatory `CriterionSetVersion` entity.
+
+Each revision receives a new `criterion_set_id` and retains a stable `lineage_id`.
+
+A Criterion Set declares whether it contains:
+
+```text
+standard_backed
+local
+mixed
+```
+
+### Fields
+
+| Field | Requirement | Meaning |
+| --- | --- | --- |
+| `criterion_set_id` | Required | Durable immutable revision identity |
+| `lineage_id` | Required | Stable Criterion Set lineage |
+| `name` | Required | Set name |
+| `purpose` | Required | Intended use |
+| `revision` | Required | Revision label or sequence |
+| `scope` | Required | Reusable or Activity-specific |
+| `criterion_set_kind` | Required | `standard_backed`, `local`, or `mixed` |
+| `standards_profile_id` | Optional | Core profile context when the Set is intentionally profile-bound |
+| `criterion_ids` | Required | Ordered Criteria |
+| `status` | Required | Lifecycle |
+| `created_provenance` | Required | Creation provenance |
+| `supersedes_criterion_set_id` | Optional | Earlier revision |
+
+### Invariants
+
+* A Criterion Set contains one or more Criteria.
+* A `standard_backed` Set contains only standard-backed Criteria.
+* A `local` Set contains only local Criteria.
+* A `mixed` Set may contain both kinds.
+* When `standards_profile_id` is present, each standard-backed Criterion should govern a standard in that profile.
+* A Criterion Set becomes immutable once selected by an Activity that produces Scores.
+* Changes to Criterion membership, order, definitions, governing standards, target applicability, classification, or scoring meaning require a new revision.
+* Historical Scores retain the exact referenced Criterion and Set revision.
+* Selecting a Criterion Set does not create Scores.
+
+## 13.2 Criterion
+
+A **Criterion** defines one aspect of performance, process, contribution, or product quality.
+
+Every Criterion used for scoring is classified as either:
+
+```text
+standard_backed
+local
+```
+
+### Fields
+
+| Field | Requirement | Meaning |
+| --- | --- | --- |
+| `criterion_id` | Required | Durable immutable Criterion identity |
+| `criterion_set_id` | Required | Parent Criterion Set revision |
+| `key` | Required | Stable key within the Set |
+| `label` | Required | Teacher-facing label |
+| `definition` | Required | Performance definition |
+| `criterion_kind` | Required | `standard_backed` or `local` |
+| `standard_id` | Conditional | Exactly one governing Core standard for a standard-backed Criterion |
+| `alignment_standard_ids` | Optional | Non-governing standards alignment for a local Criterion |
+| `supported_target_kinds` | Required | Valid Score-target types |
+| `default_scoring_scale_id` | Optional | Default Scoring Scale revision |
+| `status` | Required | Criterion lifecycle |
+| `created_provenance` | Required | Creation provenance |
+
+### Standard-backed Criterion
+
+A standard-backed Criterion defines how one selected Focus Standard will be judged in the Activity context.
+
+Conceptually:
+
+```text
+criterion_kind: standard_backed
+standard_id: <one durable Core standard_id>
+```
+
+It may translate a shared standard into an Activity-specific performance statement without redefining the shared standard.
+
+Example:
+
+```text
+Standard:
+njsls-ela:SL.PE.9-10.1
+
+Activity-specific Criterion:
+Builds on peers' ideas and responds substantively during collaborative discussion
+```
+
+### Local Criterion
+
+A local Criterion evaluates an Activity-specific, procedural, organizational, or collaborative expectation that is not a direct standards rating.
+
+Conceptually:
+
+```text
+criterion_kind: local
+standard_id: absent
+```
+
+A local Criterion may include optional `alignment_standard_ids` to record instructional relevance.
+
+Those references are non-governing.
+
+A Score against the local Criterion must not be exported or interpreted as a direct rating for an aligned standard.
+
+### Multi-standard and holistic Criteria
+
+One direct Score must not govern several standards.
+
+When one classroom behavior reflects several standards, Concord should ordinarily create:
+
+* separate standard-backed Criteria;
+* and separate Score Records.
+
+A holistic multi-standard Criterion may instead be local with optional non-governing alignment, or use another explicitly defined future composite contract.
+
+A downstream module must not duplicate, split, average, or apportion one holistic Score across several standards automatically.
+
+### Invariants
+
+* A Criterion describes performance, process, contribution, or product quality—not personality.
+* A standard-backed Criterion has exactly one `standard_id`.
+* A local Criterion has no governing `standard_id`.
+* `alignment_standard_ids` on a local Criterion do not create direct standards semantics.
+* A standard-backed Criterion used by an Activity must govern one of that Activity’s Focus Standards.
+* A Criterion used by a Score is immutable.
+* A change to `criterion_kind`, governing standard, definition, target applicability, or scoring interpretation creates a new Criterion identity in a new or revised Criterion Set.
+* Target-kind constraints must be validated.
+* One Score Record evaluates exactly one Criterion.
+* Selecting or printing a Criterion does not create a Score.
+
+## 13.3 Scoring Scale
+
+A **Scoring Scale** defines one immutable revision of the values permitted for Score Records.
+
+### Decision
+
+Scoring Scales use immutable revision records with a stable `lineage_id`.
+
+Concord does not impose one universal standards-rating scale.
+
+### Fields
+
+| Field | Requirement | Meaning |
+| --- | --- | --- |
+| `scoring_scale_id` | Required | Durable immutable revision identity |
+| `lineage_id` | Required | Stable scale lineage |
+| `name` | Required | Scale name |
+| `revision` | Required | Revision label or sequence |
+| `scale_type` | Required | Numeric, ordinal, categorical, binary, or teacher-defined |
+| `levels` | Required | Ordered or otherwise defined permitted values |
+| `intended_use` | Optional | Standards-based, local, or general scoring guidance |
+| `aggregation_guidance` | Optional | Non-binding downstream guidance |
+| `status` | Required | Scale lifecycle |
+| `created_provenance` | Required | Creation provenance |
+| `supersedes_scoring_scale_id` | Optional | Earlier revision |
+
+Each level should define:
+
+* machine value;
+* display label;
+* meaning;
+* ordering where applicable;
+* and optional description.
+
+### Invariants
+
+* A Score value must be one permitted value from the exact referenced scale revision.
+* Scale revisions used by Scores remain reproducible.
+* Changes require a new Scoring Scale revision.
+* Two scales are not semantically equivalent merely because they use the same numeric values or number of levels.
+* Aggregation guidance does not perform cross-scale normalization, mastery determination, or course-grade calculation.
+* A future grading and reporting module must use an explicit policy before comparing or combining different scale revisions.
+
+## 13.4 Score Record
+
+A **Score Record** is one teacher-approved judgment about one Criterion for one target.
+
+Every Score is classified as:
+
+```text
+standard_backed
+local
+```
+
+The classification must match the referenced Criterion.
+
+### Fields
+
+| Field | Requirement | Meaning |
+| --- | --- | --- |
+| `score_record_id` | Required | Durable Score identity |
+| `activity_id` | Required | Activity context |
+| `session_id` | Optional | Session context |
+| `target_reference` | Required | Exactly one Score target |
+| `criterion_id` | Required | Exact immutable Criterion |
+| `score_kind` | Required | `standard_backed` or `local` |
+| `standard_id` | Conditional | Governing Core standard required for a standard-backed Score |
+| `scoring_scale_id` | Required | Exact Scoring Scale revision |
+| `disposition` | Required | Scored or non-score state |
+| `value` | Conditional | Required only when scored |
+| `basis` | Required | Evidence-linked, professional judgment, or mixed basis |
+| `scorer` | Required | Teacher or authorized scorer |
+| `scored_at` | Required | Decision time |
+| `rationale` | Conditional | Required under specified conditions |
+| `status_reason` | Optional | Explanation for non-score state |
+| `moderation_complete` | Required | Whether required moderation is satisfied |
+| `privacy_policy` | Required | Score privacy |
+| `supersedes_score_record_id` | Optional | Earlier Score replaced |
+
+### Standard-backed Score
+
+A standard-backed Score is a direct contextual Concord judgment about one standard.
+
+It must reference:
+
+* one standard-backed Criterion;
+* the same one governing `standard_id`;
+* one target;
+* and one exact Scoring Scale revision.
+
+The direct `standard_id` on the Score Record is a historical and interoperability field. It must match the immutable referenced Criterion.
+
+Conceptually:
+
+```text
+one Score Record
+    -> one standard-backed Criterion
+    -> one standard_id
+    -> one target
+    -> one Scoring Scale revision
+```
+
+A standard-backed Score is not automatically:
+
+* a final mastery determination;
+* a marking-period result;
+* a course Grade;
+* or a permanent proficiency statement.
+
+### Local Score
+
+A local Score references one local Criterion.
+
+It has:
+
+```text
+score_kind: local
+standard_id: absent
+```
+
+A local Score is valid Concord data but is not a direct standards result.
+
+Optional standards alignment on the Criterion does not change that classification.
+
+### Initial dispositions
+
+* `scored`
+* `insufficient_evidence`
+* `absent`
+* `excused`
+* `not_observed`
+* `not_applicable`
+* `deferred`
+
+### Initial basis values
+
+* `linked_evidence`
+* `professional_judgment`
+* `mixed_basis`
+
+### Field rules
+
+When `disposition = scored`:
+
+* `value` is required;
+* the value must belong to the selected scale;
+* `scorer` and `scored_at` are required;
+* and required Moderation must be complete.
+
+When `disposition != scored`:
+
+* `value` is forbidden;
+* zero or the lowest scale value must not be inferred;
+* a Status Reason is recommended and may be required by workflow policy.
+
+When `basis = professional_judgment` and there are no Score Evidence Links:
+
+* `rationale` is required;
+* scorer provenance is required;
+* and the Activity context must be explicit.
+
+When `score_kind = standard_backed`:
+
+* the Activity orientation must be `standards_based` or `mixed`;
+* the referenced Criterion must be standard-backed;
+* `standard_id` is required;
+* `standard_id` must match the Criterion;
+* and `standard_id` must appear in the Activity’s `focus_standard_ids`.
+
+When `score_kind = local`:
+
+* the referenced Criterion must be local;
+* `standard_id` is forbidden;
+* and the Score must not be emitted as a direct standards result.
+
+### Decision: individual Scores and Group evidence
+
+An individual Score is not required to cite an exclusively individual evidence source.
+
+A teacher may use Group or multi-subject evidence when:
+
+* the evidence is relevant to the individual target;
+* any required Moderation permits that use;
+* the Score is an explicit teacher judgment;
+* and the rationale or evidence-link description explains the individual relevance.
+
+This applies to standard-backed and local Scores.
+
+Group evidence must never generate individual Scores automatically.
+
+### Decision: Group standards Scores
+
+A standard-backed Score may target a Group when:
+
+* the governing standard supports Group-level judgment;
+* the Criterion includes `concord_group` among its supported target kinds;
+* and the teacher deliberately selects the Group target.
+
+A Group standards Score does not become an individual standards Score for every Group member.
+
+### Invariants
+
+* One Score evaluates exactly one Criterion for exactly one target.
+* `score_kind` matches `criterion_kind`.
+* A standard-backed Score has exactly one governing `standard_id`.
+* A local Score has no governing `standard_id`.
+* A direct standards Score governs a Focus Standard selected by its Activity.
+* Selecting a Focus Standard, generating an Artifact, completing Review, or accepting evidence through Moderation does not create a Score.
+* A Score is not a course Grade or automatic mastery determination.
+* Review readiness does not create a Score.
+* Moderation acceptance does not create a Score.
+* Group Scores do not populate individual Scores.
+* Group or multi-subject evidence does not create an individual Score without explicit teacher judgment.
+* Missing evidence is not a low Score.
+* Zero is valid only when deliberately selected from a scale.
+* Revised consequential Scores preserve earlier Score Records.
+* A downstream module must not reinterpret a local Score as a direct standards Score.
+
+## 13.5 Score Evidence Link
+
+A **Score Evidence Link** associates one Score Record with one evidence source.
+
+### Fields
+
+| Field | Requirement | Meaning |
+| --- | --- | --- |
+| `score_evidence_link_id` | Required | Durable association identity |
+| `score_record_id` | Required | Parent Score |
+| `evidence_reference` | Required | Evidence source |
+| `evidence_locator` | Optional | Relevant source location |
+| `subject_context` | Optional | Subject relevant to this use |
+| `relevance_description` | Required | Why the source is relevant |
+| `significance` | Optional | Primary, corroborating, contextual, qualifying, counterevidence, or background |
+| `moderation_record_id` | Conditional | Applicable Moderation decision |
+| `status` | Required | Link lifecycle |
+| `created_provenance` | Required | Creation provenance |
+| `supersedes_score_evidence_link_id` | Optional | Earlier link replaced |
+
+### Initial significance values
+
+* `primary`
+* `corroborating`
+* `contextual`
+* `qualifying`
+* `counterevidence`
+* `background`
+
+### Invariants
+
+* One Score may have zero or many Score Evidence Links.
+* One evidence source may support zero or many Scores.
+* One evidence source may support several standard-backed Scores, local Scores, targets, or Criteria.
+* Each use requires a distinct deliberate Score Evidence Link.
+* A link records deliberate use; it does not copy evidence.
+* Link count does not determine Score value.
+* Numeric evidence weighting is not required.
+* Group or multi-subject evidence used for an individual Score should identify the individual relevance through Subject context, locator, or relevance description.
+* Rejected evidence must not remain an active supporting link for a consequential Score.
+* Historical links remain associated with historical Scores.
+
+## 13.6 Standards Result Handoff Projection
+
+A **Standards Result Handoff Projection** is a future derived interoperability view of canonical standard-backed Score Records.
+
+It is not a replacement for:
+
+* the Score Record;
+* the Criterion;
+* the Activity;
+* Score Evidence Links;
+* Moderation Records;
+* or source evidence.
+
+The projection exists conceptually so future grading and reporting work does not need to infer standards meaning from generic Criteria.
+
+### Required information
+
+A future standards-result handoff must expose:
+
+| Field | Requirement | Meaning |
+| --- | --- | --- |
+| `module_id` | Required | `concord` |
+| `class_id` | Required | Core class |
+| `activity_id` | Required | Concord Activity and Core `work_id` |
+| `session_id` | Optional | Session context |
+| `score_record_id` | Required | Canonical Concord Score |
+| `target_reference` | Required | Individual, Group, or other valid target |
+| `standard_id` | Required | Direct governing standard |
+| `criterion_id` | Required | Exact standard-backed Criterion |
+| `scoring_scale_id` | Required | Exact scale revision |
+| `disposition` | Required | Scored or non-score state |
+| `value` | Conditional | Present only when scored |
+| `scorer` | Required | Authorized scorer |
+| `scored_at` | Required | Decision time |
+| `evidence_link_ids` | Optional | Supporting Score Evidence Links |
+| `moderation_complete` | Required | Whether required Moderation is satisfied |
+| `supersedes_score_record_id` | Optional | Earlier Score replaced |
+| `current_status` | Required | Whether the Score is current or superseded |
+
+### Invariants
+
+* Only standard-backed Scores enter the direct standards-result projection.
+* Local Scores are excluded from direct standards-result handoff.
+* Non-score dispositions remain explicit and are not converted to zeros.
+* The projection does not calculate mastery, Grades, weights, averages, or growth.
+* The projection preserves Group versus individual target identity.
+* The projection preserves exact scale identity.
+* The projection is reproducible from canonical Concord records.
+* The exact export schema, path, event structure, and inter-module interface remain deferred.
+
+## 14. Attachment and External Reference contracts
+
+## 14.1 Attachment
+
+An **Attachment** represents related physical or digital work that is not a normal Concord-generated Artifact Page.
+
+Examples include:
+
+* a poster;
+* graph paper;
+* a photograph;
+* a screenshot;
+* printed source code;
+* a project diagram;
+* a model photograph;
+* or an externally generated worksheet.
+
+### Fields
+
+| Field                      | Requirement | Meaning                               |
+| -------------------------- | ----------- | ------------------------------------- |
+| `attachment_id`            | Required    | Durable Attachment identity           |
+| `activity_id`              | Required    | Parent Activity                       |
+| `attachment_type`          | Required    | Attachment category                   |
+| `title`                    | Required    | Human-facing label                    |
+| `session_id`               | Optional    | Session context                       |
+| `group_id`                 | Optional    | Group context                         |
+| `work_item_id`             | Optional    | Work Item context                     |
+| `activity_event_id`        | Optional    | Event context                         |
+| `artifact_instance_id`     | Optional    | Related Artifact                      |
+| `contributor_references`   | Optional    | Known contributors                    |
+| `location`                 | Required    | External Locator or physical location |
+| `version_label`            | Optional    | Human-facing iteration                |
+| `availability_status`      | Required    | Current availability                  |
+| `review_status`            | Required    | Review state                          |
+| `privacy_policy`           | Required    | Attachment privacy                    |
+| `created_provenance`       | Required    | Creation provenance                   |
+| `supersedes_attachment_id` | Optional    | Earlier Attachment replaced           |
+
+### Initial availability statuses
+
+* `available`
+* `temporarily_unavailable`
+* `missing`
+* `inaccessible`
+* `superseded`
+* `unknown`
+
+### Invariants
+
+* An Attachment is distinct from an Artifact Page.
+* An Attachment is distinct from a Scan Reference.
+* An unavailable Attachment is not poor performance.
+* File or account ownership does not establish authorship.
+* A reviewed Attachment may function as evidence through an Evidence Reference.
+
+## 14.2 External Reference
+
+An **External Reference** records a relationship to a record owned by another PDS module or external system.
+
+### Fields
+
+| Field                              | Requirement | Meaning                               |
+| ---------------------------------- | ----------- | ------------------------------------- |
+| `external_reference_id`            | Required    | Durable Concord relationship identity |
+| `owning_system`                    | Required    | Owning module or external authority   |
+| `external_record_kind`             | Required    | Public external record type           |
+| `external_record_id`               | Required    | Durable external identifier           |
+| `contract_version`                 | Optional    | External contract version             |
+| `relationship_purpose`             | Required    | Why the record is connected           |
+| `activity_id`                      | Required    | Parent Activity                       |
+| `session_id`                       | Optional    | Session context                       |
+| `group_id`                         | Optional    | Group context                         |
+| `work_item_id`                     | Optional    | Work Item context                     |
+| `activity_marker_id`               | Optional    | Marker context                        |
+| `artifact_instance_id`             | Optional    | Artifact context                      |
+| `criterion_id`                     | Optional    | Criterion context                     |
+| `score_record_id`                  | Optional    | Score context                         |
+| `subject_reference`                | Optional    | Relevant Subject                      |
+| `external_locator`                 | Optional    | Provider-neutral location             |
+| `display_label`                    | Optional    | Human-facing label                    |
+| `availability_status`              | Required    | Availability                          |
+| `last_confirmed_at`                | Optional    | Last successful resolution            |
+| `created_provenance`               | Required    | Creation provenance                   |
+| `supersedes_external_reference_id` | Optional    | Earlier relationship replaced         |
+
+### Initial relationship purposes
+
+Examples include:
+
+* `related_assignment`;
+* `packet_instruction`;
+* `individual_accountability_check`;
+* `supporting_evidence`;
+* `complementary_written_response`;
+* `prerequisite_check`;
+* `follow_up_reflection`;
+* `score_evidence`;
+* `contextual_result`;
+* and `downstream_export_relationship`.
+
+### Invariants
+
+* External identity is module- or system-qualified.
+* Concord does not copy the full external record when a stable reference is sufficient.
+* The external owner remains authoritative.
+* External unavailability remains explicit.
+* Concord must not require a runtime dependency on ScoreForm or Quillan.
+* An external result does not automatically become a Concord Score.
+* Physical packet assembly does not transfer ownership.
+
+## 15. Optional extension contracts
+
+Optional records are defined contracts when used. They are not arbitrary extension dictionaries.
+
+No Activity is required to instantiate them unless its selected workflow needs them.
+
+## 15.1 Activity Marker
+
+An **Activity Marker** provides an ordered or named context within an Activity.
+
+### Fields
+
+| Field                           | Requirement | Meaning                                                             |
+| ------------------------------- | ----------- | ------------------------------------------------------------------- |
+| `activity_marker_id`            | Required    | Durable Marker identity                                             |
+| `activity_id`                   | Required    | Parent Activity                                                     |
+| `marker_type`                   | Required    | Phase, stage, milestone, checkpoint, rotation, iteration, or custom |
+| `label`                         | Required    | Human-facing label                                                  |
+| `sequence`                      | Required    | Activity ordering                                                   |
+| `session_ids`                   | Optional    | Sessions spanned                                                    |
+| `status`                        | Required    | Marker lifecycle                                                    |
+| `created_provenance`            | Required    | Creation provenance                                                 |
+| `supersedes_activity_marker_id` | Optional    | Earlier Marker replaced                                             |
+
+### Invariants
+
+* Markers represent optional instructional or work structure.
+* Sessions represent occurrences; Markers do not replace Sessions.
+* An Activity need not have Markers.
+
+## 15.2 Work Item
+
+A **Work Item** represents a bounded task, component, deliverable, test, or unit of collaborative work.
+
+### Fields
+
+| Field                     | Requirement | Meaning                            |
+| ------------------------- | ----------- | ---------------------------------- |
+| `work_item_id`            | Required    | Durable Work Item identity         |
+| `activity_id`             | Required    | Parent Activity                    |
+| `parent_work_item_id`     | Optional    | Parent Work Item                   |
+| `work_item_type`          | Required    | Controlled or teacher-defined type |
+| `label`                   | Required    | Concise label                      |
+| `description`             | Optional    | Work description                   |
+| `group_id`                | Optional    | Responsible Group                  |
+| `assignee_reference`      | Optional    | Responsible participant            |
+| `activity_marker_id`      | Optional    | Marker context                     |
+| `status`                  | Required    | Work state                         |
+| `status_reason`           | Optional    | Blocked or exceptional reason      |
+| `created_provenance`      | Required    | Creation provenance                |
+| `supersedes_work_item_id` | Optional    | Earlier Work Item replaced         |
+
+### Invariants
+
+* Work Items contextualize evidence and responsibility.
+* Concord must not become a general project-management system.
+* Incomplete or blocked work is not automatically poor performance.
+* Work Item status does not create a Score.
+
+## 15.3 Work-Item Dependency
+
+A **Work-Item Dependency** records that one Work Item depends on another.
+
+### Fields
+
+| Field                      | Requirement | Meaning                      |
+| -------------------------- | ----------- | ---------------------------- |
+| `work_item_dependency_id`  | Required    | Durable association identity |
+| `predecessor_work_item_id` | Required    | Required predecessor         |
+| `dependent_work_item_id`   | Required    | Blocked or dependent item    |
+| `dependency_type`          | Required    | Nature of dependency         |
+| `status`                   | Required    | Dependency state             |
+| `note`                     | Optional    | Explanation                  |
+| `created_provenance`       | Required    | Creation provenance          |
+| `supersedes_dependency_id` | Optional    | Earlier dependency replaced  |
+
+### Invariants
+
+* Both Work Items belong to the same Activity.
+* A Work Item cannot depend on itself.
+* Cycles must be rejected when dependency semantics require acyclicity.
+* Dependency failure is distinct from neglect or low-quality work.
+
+## 15.4 Activity Event
+
+An **Activity Event** records a meaningful evidence-bearing occurrence.
+
+### Decision
+
+The foundation uses one typed Activity Event envelope.
+
+Specialized event contracts should be introduced only when representative records show that:
+
+* several activity types require the same additional invariant fields;
+* those fields cannot be represented clearly through the generic envelope;
+* and a specialized contract improves validation without making activity-specific terminology universal.
+
+### Fields
+
+| Field                          | Requirement | Meaning                                 |
+| ------------------------------ | ----------- | --------------------------------------- |
+| `activity_event_id`            | Required    | Durable Event identity                  |
+| `activity_id`                  | Required    | Parent Activity                         |
+| `session_id`                   | Optional    | Session context                         |
+| `event_type`                   | Required    | Controlled or namespaced event type     |
+| `occurred_at`                  | Optional    | Event time                              |
+| `sequence`                     | Optional    | Relative chronology                     |
+| `group_id`                     | Optional    | Group context                           |
+| `activity_marker_id`           | Optional    | Marker context                          |
+| `work_item_id`                 | Optional    | Work Item context                       |
+| `contributor_references`       | Optional    | Event contributors                      |
+| `subject_references`           | Optional    | Event Subjects                          |
+| `description`                  | Required    | Concise occurrence description          |
+| `outcome`                      | Optional    | Event result                            |
+| `status`                       | Required    | Event lifecycle                         |
+| `extension_data`               | Optional    | Namespaced, contract-controlled details |
+| `privacy_policy`               | Required    | Event privacy                           |
+| `created_provenance`           | Required    | Creation provenance                     |
+| `supersedes_activity_event_id` | Optional    | Earlier Event replaced                  |
+
+### Initial event types
+
+Examples include:
+
+* `decision`;
+* `troubleshooting`;
+* `test`;
+* `invalid_trial`;
+* `revision`;
+* `handoff`;
+* `teacher_intervention`;
+* `interruption`;
+* and namespaced teacher-defined types.
+
+### Invariants
+
+* Not every routine action becomes an Event.
+* An Event is appropriate when chronology, explanation, or evidence matters.
+* An Event is not automatically a Contribution or Score.
+* Extension data must be namespaced and JSON-compatible in later serialization.
+
+## 15.5 Contribution Claim
+
+A **Contribution Claim** records a statement that a participant or Group made a particular contribution.
+
+### Fields
+
+| Field                              | Requirement | Meaning                                       |
+| ---------------------------------- | ----------- | --------------------------------------------- |
+| `contribution_claim_id`            | Required    | Durable Claim identity                        |
+| `activity_id`                      | Required    | Parent Activity                               |
+| `claimant_reference`               | Required    | Person or Group making or recording the Claim |
+| `claimed_contributor_reference`    | Required    | Alleged contributor                           |
+| `contribution_type`                | Required    | Controlled or teacher-defined type            |
+| `description`                      | Required    | Concise claimed contribution                  |
+| `artifact_instance_id`             | Optional    | Related Artifact                              |
+| `work_item_id`                     | Optional    | Related Work Item                             |
+| `activity_event_id`                | Optional    | Related Event                                 |
+| `responsibility_assignment_id`     | Optional    | Related assigned Responsibility               |
+| `corroboration_status`             | Required    | Claim support state                           |
+| `moderation_requirement`           | Required    | Whether moderation is required                |
+| `privacy_policy`                   | Required    | Claim privacy                                 |
+| `created_provenance`               | Required    | Creation provenance                           |
+| `supersedes_contribution_claim_id` | Optional    | Earlier Claim replaced                        |
+
+### Initial corroboration statuses
+
+* `unreviewed`
+* `corroborated`
+* `partially_corroborated`
+* `disputed`
+* `unsupported`
+* `rejected`
+
+### Invariants
+
+* A Contribution Claim is evidence, not a Score.
+* A Claim about another participant requires human review before consequential use.
+* Assigned Responsibility does not prove the Claim.
+* Artifact authorship does not prove broader contribution.
+* Rejection of a Claim is not negative evidence against the claimed contributor.
+
+## 16. Controlled and extensible vocabularies
+
+### 16.1 Closed foundational vocabularies
+
+The following vocabularies should be small, stable, and contract-controlled:
+
+* Activity scoring orientation;
+* Criterion kind;
+* Score kind;
+* Score disposition;
+* Review outcome;
+* Moderation outcome;
+* basic lifecycle states;
+* availability state;
+* attribution confirmation state;
+* route and filing state;
+* privacy classification;
+* and correction relationship semantics.
+
+Initial required values include:
+
+```text
+Activity scoring orientation:
+evidence_only
+standards_based
+mixed
+local_criteria_only
+
+Criterion kind:
+standard_backed
+local
+
+Score kind:
+standard_backed
+local
+```
+
+Teacher-defined replacements must not alter the meaning of these states.
+
+### 16.2 Extensible vocabularies
+
+The following may use starter values plus namespaced teacher-defined values:
+
+* Activity type;
+* Role key;
+* Responsibility category;
+* Artifact category;
+* page kind;
+* subject role;
+* contribution type;
+* event type;
+* Work Item type;
+* Activity Marker type;
+* local Criterion taxonomy;
+* and external relationship purpose.
+
+Core `standard_id` and `profile_id` values are not Concord-extensible vocabularies. They are Core-owned durable references.
+
+### 16.3 Namespacing rule
+
+Teacher- or organization-defined values should use a distinguishable namespace, conceptually:
+
+```text
+local:<value>
+district:<value>
+plugin:<value>
+```
+
+Exact serialized syntax belongs to later schema work.
+
+Namespaced local values must not impersonate Core standard IDs or profile IDs.
+
+### 16.4 Display labels
+
+Machine keys and display labels must remain separate.
+
+Changing a display label does not change the meaning or identity of a previously used key.
+
+Standard display codes, names, descriptions, profile titles, and scale labels are presentation metadata rather than substitutes for durable IDs.
+
+## 17. Exceptional-state model
+
+Exceptional situations are represented in three separate layers.
+
+### 17.1 Evidence state
+
+Evidence states describe the condition or availability of a source.
+
+Examples:
+
+* expected but not returned;
+* missing page;
+* unreadable;
+* incomplete;
+* duplicate;
+* misrouted;
+* awaiting rescan;
+* external reference unavailable;
+* disputed;
+* or rejected for scoring use.
+
+These states belong to Artifact, Artifact Page, Scan Reference, Review, Attachment, External Reference, or Moderation.
+
+They are not Scores.
+
+### 17.2 Contextual exception
+
+Contextual exceptions explain Activity circumstances.
+
+Examples:
+
+* absence;
+* late arrival;
+* early departure;
+* interrupted Session;
+* equipment failure;
+* invalid trial;
+* blocked dependency;
+* unavailable materials;
+* external tool unavailable;
+* Group reassignment;
+* or Activity cancellation.
+
+They do not determine performance.
+
+### 17.3 Score disposition
+
+Score disposition states whether a valid criterion-level judgment was recorded.
+
+```text
+scored
+insufficient_evidence
+absent
+excused
+not_observed
+not_applicable
+deferred
+```
+
+A disposition may apply to:
+
+* a standard-backed Criterion;
+* or a local Criterion.
+
+For a standard-backed non-score record, the governing `standard_id` remains explicit even though no score value exists.
+
+### Invariants
+
+* A blank value does not mean zero.
+* Missing evidence is not negative evidence.
+* `not_observed` is not equivalent to “did not demonstrate.”
+* `insufficient_evidence` describes the evidence, not the participant.
+* Absence during one Session is not absence from the entire Activity.
+* External failure is not poor performance.
+* A failed experiment may coexist with strong process evidence.
+* A non-score disposition for a Focus Standard is not the lowest standards rating.
+* A later valid Score may supersede an earlier non-score disposition.
+* Supersession preserves the earlier standards or local Criterion context.
+
+## 18. Relationship overview
+
+```mermaid
+erDiagram
+    CORE_CLASS ||--o{ ACTIVITY : contains
+    CORE_STANDARDS_PROFILE ||--o{ ACTIVITY : selected_by
+    CORE_STANDARD ||--o{ CRITERION : governs
+    CORE_STANDARD ||--o{ SCORE_RECORD : identifies
+
+    ACTIVITY ||--|{ SESSION : contains
+    ACTIVITY ||--o{ GROUP : defines
+    GROUP ||--o{ GROUP : contains_child
+    GROUP ||--o{ GROUP_MEMBERSHIP : has
+    SESSION ||--o{ GROUP_MEMBERSHIP : contextualizes
+    GROUP_MEMBERSHIP ||--o{ ROLE_ASSIGNMENT : supports
+    ACTIVITY ||--o{ RESPONSIBILITY_ASSIGNMENT : defines
+
+    TEMPLATE_DEFINITION ||--|{ TEMPLATE_VERSION : versions
+    PACKET_DEFINITION ||--|{ PACKET_VERSION : versions
+    PACKET_VERSION ||--|{ PACKET_COMPONENT : contains
+    TEMPLATE_VERSION ||--o{ PACKET_COMPONENT : selected_by
+
+    ACTIVITY ||--o{ PACKET_INSTANCE : generates
+    PACKET_VERSION ||--o{ PACKET_INSTANCE : instantiates
+    PACKET_INSTANCE ||--|{ ARTIFACT_INSTANCE : contains
+    TEMPLATE_VERSION ||--o{ ARTIFACT_INSTANCE : generates
+    ARTIFACT_INSTANCE ||--|{ ARTIFACT_PAGE : contains
+
+    ARTIFACT_INSTANCE ||--o{ ARTIFACT_AUTHOR : has
+    ARTIFACT_INSTANCE ||--o{ ARTIFACT_SUBJECT : concerns
+    ARTIFACT_PAGE ||--o{ SCAN_REFERENCE : evidenced_by
+    ARTIFACT_INSTANCE ||--o{ ARTIFACT_REVIEW : reviewed_by
+    MODERATION_RECORD }o--|| EVIDENCE_REFERENCE : evaluates
+
+    CRITERION_SET ||--|{ CRITERION : contains
+    ACTIVITY }o--o{ CRITERION_SET : selects
+    CRITERION ||--o{ SCORE_RECORD : evaluated_by
+    SCORING_SCALE ||--o{ SCORE_RECORD : governs
+    SCORE_RECORD ||--o{ SCORE_EVIDENCE_LINK : supported_by
+    SCORE_RECORD ||--o| STANDARDS_RESULT_HANDOFF : projects
+
+    ACTIVITY ||--o{ ATTACHMENT : includes
+    ACTIVITY ||--o{ EXTERNAL_REFERENCE : relates
+    ACTIVITY ||--o{ ACTIVITY_MARKER : structures
+    ACTIVITY ||--o{ WORK_ITEM : contains
+    WORK_ITEM ||--o{ WORK_ITEM_DEPENDENCY : participates_in
+    ACTIVITY ||--o{ ACTIVITY_EVENT : records
+    ACTIVITY ||--o{ CONTRIBUTION_CLAIM : receives
+
+    CORRECTION_RECORD }o--|| CONCORD_RECORD_REFERENCE : corrects
+```
+
+The diagram is conceptual. It does not prescribe foreign keys, aggregate boundaries, storage layout, or a persisted standards-result handoff entity.
+
+`CORE_STANDARDS_PROFILE` and `CORE_STANDARD` represent Core-owned records. Only standards-based and mixed Activities select profiles, and only standard-backed Criteria and Scores have governing standards.
+
+## 19. Cardinality summary
+
+| Relationship | Cardinality |
+| --- | --- |
+| Core Class → Activity | One to zero-or-many |
+| Core Standards Profile → Activity | One to zero-or-many; zero-or-one selected profile per Activity |
+| Core Standard → standard-backed Criterion | One to zero-or-many |
+| Core Standard → standard-backed Score Record | One to zero-or-many |
+| Activity → Focus Standard | Zero-or-many generally; one-or-many for standards-based or mixed Activities |
+| Activity → Session | One to one-or-many |
+| Activity → Group | One to zero-or-many |
+| Group → child Group | One to zero-or-many |
+| Group → Group Membership | One to zero-or-many |
+| Participant → Group Membership | One to zero-or-many |
+| Participant → Role Assignment | One to zero-or-many |
+| Participant/Group → Responsibility Assignment | One to zero-or-many |
+| Template Definition → Template Version | One to one-or-many |
+| Packet Definition → Packet Version | One to one-or-many |
+| Packet Version → Packet Component | One to one-or-many |
+| Template Version → Packet Component | One to zero-or-many |
+| Activity → Packet Instance | One to zero-or-many |
+| Packet Version → Packet Instance | One to zero-or-many |
+| Packet Instance → Artifact Instance | One to one-or-many |
+| Template Version → Artifact Instance | One to zero-or-many |
+| Artifact Instance → Artifact Page | One to one-or-many |
+| Artifact Instance → Artifact Author | One to zero-or-many |
+| Artifact Instance → Artifact Subject | One to zero-or-many |
+| Artifact Page → Scan Reference | One to zero-or-many |
+| Artifact Instance → Artifact Review | One to zero-or-many |
+| Evidence source → Moderation Record | One to zero-or-many |
+| Criterion Set → Criterion | One to one-or-many |
+| Activity → Criterion Set | Many-to-many |
+| Criterion → Score Record | One to zero-or-many |
+| Score target → Score Record | One to zero-or-many |
+| Score Record → Score Evidence Link | One to zero-or-many |
+| Evidence source → Score Evidence Link | One to zero-or-many |
+| standard-backed Score Record → Standards Result Handoff projection | One to zero-or-one current projection row per export context |
+| Activity → Attachment | One to zero-or-many |
+| Activity → External Reference | One to zero-or-many |
+| Activity → Activity Marker | One to zero-or-many |
+| Activity → Work Item | One to zero-or-many |
+| Work Item → Work-Item Dependency | One to zero-or-many |
+| Activity → Activity Event | One to zero-or-many |
+| Activity → Contribution Claim | One to zero-or-many |
+| Record → Correction Record | One to zero-or-many |
+
+## 20. Cross-record invariants
+
+All later implementations must preserve the following rules.
+
+1. **The Core-retained source scan is canonical digital intake evidence.**
+
+2. **A routed derivative does not replace the retained source.**
+
+3. **A QR identifies one expected physical page route, not semantic authorship or scoring context.**
+
+4. **The normal Concord route target is an existing Artifact Page.**
+
+5. **Artifact Author and Artifact Subject are separate relationships.**
+
+6. **Artifact Author, Artifact Subject, Score target, scorer, and governing standard are separate concepts.**
+
+7. **Handwriting, possession, Group Membership, Role Assignment, device ownership, and account ownership do not establish sole authorship.**
+
+8. **Roles, Responsibilities, Work Items, Contribution Claims, and demonstrated performance remain distinct.**
+
+9. **Assignment is not performance.**
+
+10. **Standards selection is not performance.**
+
+11. **Standards alignment is not a direct standards Score.**
+
+12. **Concord’s primary academic scoring model is standards-based, but Activities may be evidence-only, mixed, or local-criteria-only.**
+
+13. **Every Activity declares exactly one scoring orientation.**
+
+14. **Standards-based and mixed Activities select one Core standards profile and one or more ordered Focus Standards.**
+
+15. **A standard-backed Criterion governs exactly one Core standard.**
+
+16. **A local Criterion has no governing standard; optional alignment is non-governing.**
+
+17. **A standard-backed Score governs exactly one standard-backed Criterion, one `standard_id`, one target, and one Scoring Scale revision.**
+
+18. **A local Score must not be emitted or interpreted as a direct standards result.**
+
+19. **Review, Moderation, Scoring, Grading, mastery determination, and Reporting remain separate.**
+
+20. **Review readiness does not create a Score.**
+
+21. **Moderation acceptance does not determine a Score value.**
+
+22. **Selecting a Focus Standard, printing a rubric, or receiving an Artifact does not create a standards result.**
+
+23. **Evidence and Scores have a many-to-many relationship.**
+
+24. **Group evidence does not automatically produce individual Scores.**
+
+25. **An individual Score requires an explicit teacher judgment.**
+
+26. **A Group standards Score does not populate individual standards Scores.**
+
+27. **Missing evidence is not negative evidence.**
+
+28. **Exceptional states do not automatically become zero or the lowest performance level.**
+
+29. **A non-score disposition for a Focus Standard is not a low standards rating.**
+
+30. **External failure is not poor performance.**
+
+31. **Corrections, rescans, revised attribution, revised Moderation, and revised Scores preserve history.**
+
+32. **Definitions, standards references, Criteria, Scoring Scale revisions, and Scores used by evidence or reporting remain reproducible.**
+
+33. **Different Scoring Scales are not presumed equivalent merely because their values look similar.**
+
+34. **Activity-specific structures remain optional.**
+
+35. **External systems remain authoritative for their own records.**
+
+36. **Concord does not introduce mandatory runtime dependencies on ScoreForm or Quillan.**
+
+37. **External ScoreForm or Quillan results may support a Concord Score only through explicit evidence relationships and teacher judgment.**
+
+38. **Only standard-backed Scores enter direct standards-result handoff.**
+
+39. **Standards-result handoff does not calculate mastery, weights, averages, Grades, or longitudinal growth.**
+
+40. **A record may become more private than its parent but not less private automatically.**
+
+41. **Access to a Score does not imply access to every supporting evidence source.**
+
+42. **A display label, standard code, profile title, or scale label is never a durable identity.**
+
+## 21. Decisions reached in this contract
+
+The initial conceptual contracts adopt the following decisions.
+
+1. `activity_id` is Concord’s Core `work_id`.
+
+2. The normal PDS2 route target is `artifact_page`.
+
+3. QR and route identity remain separate from Authors, Subjects, participants, score targets, Criteria, and standards.
+
+4. Actor identity uses a typed Actor Reference; a mandatory Concord-local actor registry is deferred.
+
+5. Session references are the primary temporal unit for Membership, Role, and Responsibility applicability.
+
+6. Activity Markers and sequence positions may refine temporal context.
+
+7. Packet Definition and Packet Version are separate records.
+
+8. Long-running Activities may use either one continuing Packet Instance or several linked Packet Instances.
+
+9. Concord is predominantly standards-based but not standards-exclusive.
+
+10. Every Activity declares one scoring orientation: `evidence_only`, `standards_based`, `mixed`, or `local_criteria_only`.
+
+11. Standards-based and mixed Activities select one Core standards profile and an ordered nonempty Focus Standard collection.
+
+12. Core owns standards definitions, profiles, durable IDs, display metadata, and module-neutral validation.
+
+13. Concord owns Activity Focus Standard selection and module-specific standards scoring semantics.
+
+14. Every scored Criterion is classified as `standard_backed` or `local`.
+
+15. A standard-backed Criterion governs exactly one `standard_id`.
+
+16. A local Criterion has no governing standard; optional standards alignment is non-governing.
+
+17. One direct standards judgment uses one standard-backed Criterion and one Score Record.
+
+18. One holistic Score must not be split automatically across several standards.
+
+19. Every Score is classified as `standard_backed` or `local`, matching its Criterion.
+
+20. A standard-backed Score stores its governing `standard_id` directly and must match the immutable Criterion.
+
+21. A local Score has no governing `standard_id` and is excluded from direct standards-result handoff.
+
+22. Group standards Scores and individual standards Scores remain distinct.
+
+23. An individual standards Score may use Group or multi-subject evidence only through deliberate relevance and explicit teacher judgment.
+
+24. Criterion Sets and Scoring Scales use immutable revision records with stable lineage identifiers.
+
+25. Criteria are immutable once used by a Score.
+
+26. Different Scoring Scale revisions are not assumed equivalent.
+
+27. Correction uses a hybrid model: same-type supersession plus a generic Correction Record.
+
+28. The foundation defines minimum privacy semantics while allowing later Core coordination.
+
+29. A Score may have zero evidence links only when scorer provenance and an adequate professional-judgment rationale are retained.
+
+30. External digital locations use provider-neutral External Locators.
+
+31. Structural status and standards-semantic vocabularies are controlled; classroom taxonomy vocabularies are extensible through namespaced keys.
+
+32. Activity Event begins as one generic typed envelope.
+
+33. Specialized event contracts require demonstrated cross-case need.
+
+34. Attachments remain distinct from Artifact Pages and Scan References.
+
+35. Physical packet assembly does not transfer component ownership among PDS modules.
+
+36. A future Standards Result Handoff Projection is derived from canonical standard-backed Score Records.
+
+37. The future grading and reporting module—not Concord—owns cross-Activity and cross-module aggregation, scale conversion, mastery policy, weighting, Grade calculation, and longitudinal reporting.
+
+## 22. Deferred implementation questions
+
+The following questions do not block the conceptual foundation and belong to later schema or implementation work.
+
+1. What exact serialized envelope and schema-version field will every Concord record use?
+
+2. Will Actor References initially resolve through a Core identity contract, a local configuration file, or an application-level identity service?
+
+3. What identifier-generation API will Core expose to Concord?
+
+4. How will current-versus-superseded records be indexed efficiently?
+
+5. Which privacy values should move into a suite-wide Core contract?
+
+6. What exact path layout will Concord use beneath the Core module work root?
+
+7. Which records will be stored individually and which may be grouped in manifests?
+
+8. How will append-only writes and atomic replacement be implemented on the local filesystem?
+
+9. Which record relationships require eager validation and which permit temporarily unresolved references?
+
+10. What exact JSON representation will be used for typed references?
+
+11. How will namespaced extension vocabularies be registered and validated?
+
+12. What route-handler result object will represent successful Concord dispatch before Scan Reference persistence?
+
+13. Which application service creates Scan References after Core dispatch?
+
+14. How will optional sibling-module adapters validate ScoreForm and Quillan references?
+
+15. Which records require formal JSON Schemas in the first implementation milestone?
+
+16. Which indexes or manifests are required for efficient Activity, Subject, Author, Score, Focus Standard, and target lookup?
+
+17. At which workflow boundaries will Concord validate `standards_profile_id`, Focus Standards, Criterion standards, and inactive or deprecated references?
+
+18. How will the teacher-facing interface distinguish standard-backed Criteria, local Criteria, and non-governing alignment?
+
+19. Will reusable standard-backed Criterion Sets be profile-bound, profile-neutral with later validation, or support both forms?
+
+20. What exact serialized schema will represent the Standards Result Handoff Projection?
+
+21. Will standards-result handoff be a generated manifest, an export, an event stream, an application query, or more than one supported interface?
+
+22. How will current and superseded standards Scores be selected for a specific handoff without deleting historical results?
+
+23. Which safe display metadata, if any, should be snapshotted with standards references for historical readability?
+
+24. How will optional Quillan and ScoreForm adapters expose public standards-related results without transferring ownership?
+
+These questions must not be resolved by weakening the semantic invariants in this document.
+
+The following are deliberately deferred to the future grading and reporting module rather than treated as Concord implementation questions:
+
+* cross-Activity aggregation;
+* cross-module aggregation;
+* standards mastery policy;
+* score weighting;
+* scale normalization or conversion;
+* marking-period and course-grade calculation;
+* longitudinal growth;
+* report cards;
+* and parent or administrator reporting.
+
+## 23. Acceptance assessment
+
+This document satisfies the conceptual-contract issue when:
+
+* [x] shared identifier and reference conventions are defined;
+* [x] Actor, Participant, Subject, Score-Target, and Evidence References are distinguished;
+* [x] Core standards-profile, standard, Focus Standard, and non-governing alignment references are distinguished;
+* [x] provenance, privacy, status reasons, effective context, and external locators are defined;
+* [x] Activity and Session contracts are defined;
+* [x] every Activity declares a scoring orientation;
+* [x] standards-based and mixed Activity requirements are defined;
+* [x] evidence-only and local-criteria-only Activity requirements are defined;
+* [x] Group, Group Membership, Role Assignment, and Responsibility Assignment contracts are defined;
+* [x] Template Definition and Template Version contracts are defined;
+* [x] Packet Definition, Packet Version, Packet Component, and Packet Instance contracts are defined;
+* [x] Artifact Instance and Artifact Page contracts are defined;
+* [x] Artifact Author and Artifact Subject are separate association contracts;
+* [x] Scan Reference, Artifact Review, Moderation Record, and Correction Record contracts are defined;
+* [x] standard-backed and local Criterion semantics are defined;
+* [x] one governing standard per standard-backed Criterion is required;
+* [x] non-governing alignment on local Criteria is distinguished from direct standards scoring;
+* [x] Scoring Scale revision and cross-scale non-equivalence are defined;
+* [x] standard-backed and local Score semantics are defined;
+* [x] direct `standard_id` requirements for standard-backed Scores are defined;
+* [x] Group and individual standards Scores remain distinct;
+* [x] Group evidence may support an individual standards Score only through explicit teacher judgment;
+* [x] Score Evidence Link many-to-many relationships are defined;
+* [x] the future Standards Result Handoff Projection is defined conceptually;
+* [x] local Scores are excluded from direct standards-result handoff;
+* [x] Attachment and External Reference contracts are defined;
+* [x] optional Activity Marker, Work Item, Dependency, Event, and Contribution Claim contracts are defined;
+* [x] PDS2 route identity is separated from semantic context;
+* [x] `activity_id` is documented as Concord’s Core `work_id`;
+* [x] Artifact Page is documented as the normal route target;
+* [x] Core-retained source scans remain canonical evidence;
+* [x] Review, Moderation, Scoring, Grading, mastery determination, and Reporting remain separate;
+* [x] standards selection and alignment do not create Scores;
+* [x] evidence-to-Score relationships support many-to-many cardinality;
+* [x] exceptional states remain distinct from low Scores;
+* [x] non-score Focus Standard dispositions remain distinct from low standards ratings;
+* [x] correction and supersession preserve history;
+* [x] sibling-module records are referenced without duplication;
+* [x] optional Activity structures remain optional;
+* [x] grading and reporting policies are deferred without losing necessary standards semantics;
+* [x] blocking conceptual decisions are resolved;
+* [x] implementation details are explicitly deferred;
+* [x] the contracts are sufficiently precise for representative records in issue `#12`;
+* [x] and a future grading and reporting module can distinguish direct standards Scores, local Scores, evidence-only records, non-score dispositions, Group targets, individual targets, and superseded results without heuristic interpretation.
+
+## 24. Next step
+
+Issue `#12` should create complete representative record sets for:
+
+1. a Socratic seminar;
+2. a laboratory investigation;
+3. a collaborative programming or engineering project.
+
+Collectively, those examples should test:
+
+* one standards-based Activity;
+* one mixed Activity containing standard-backed and local Criteria;
+* one evidence-only Activity or evidence-only component;
+* explicit `standards_profile_id` and ordered `focus_standard_ids`;
+* separate standard-backed Criteria when one behavior or Artifact relates to several standards;
+* a local Criterion with optional non-governing alignment;
+* an individual standards Score;
+* a Group standards Score;
+* a local Score;
+* an explicit non-score disposition for a Focus Standard;
+* Group or multi-subject evidence supporting an individual standards Score through explicit teacher judgment;
+* one evidence source supporting several standard-backed Scores;
+* changing Group Membership;
+* rotating Roles;
+* recorder-versus-Group authorship;
+* multi-subject teacher evidence;
+* mixed-batch and duplicate scans;
+* unreadable and missing evidence;
+* moderated peer claims;
+* Group and individual Scores using overlapping evidence;
+* professional judgment without one controlling Artifact;
+* an external ScoreForm result used as supporting evidence;
+* an external Quillan standards result used as supporting evidence;
+* Attachments;
+* Work Items and dependencies;
+* Activity-specific optional structures;
+* correction and supersession of a standards Score;
+* and a sample Standards Result Handoff Projection that excludes local Scores and preserves non-score dispositions.
+
+Any case that cannot be represented without a workaround should produce either:
+
+* a correction to this conceptual contract;
+* a new ADR;
+* or an explicit deferral before foundation approval.
+
+Issue `#13` should then verify that the foundation allows a future grading and reporting module to distinguish:
+
+* direct standard-backed Scores;
+* local Criterion Scores;
+* evidence-only records;
+* standard alignment without judgment;
+* non-score dispositions;
+* Group versus individual targets;
+* current versus superseded Scores;
+* exact Scoring Scale revisions;
+* and external evidence versus Concord-owned judgments.

--- a/docs/design/cross-case-requirements.md
+++ b/docs/design/cross-case-requirements.md
@@ -1,10 +1,12 @@
 # Cross-Case Requirements Matrix
 
-**Status:** Draft for domain-model design
-**Project:** Paper Data Suite
-**Module:** `pds-concord`
-**Issue:** #7
-**Date:** July 13, 2026
+**Status:** Revised for conceptual-contract consistency  
+**Project:** Paper Data Suite  
+**Module:** `pds-concord`  
+**Original issue:** #7  
+**Original date:** July 13, 2026  
+**Revision date:** July 22, 2026  
+**Revision:** 2 — reconciled with PDS Core 0.5/PDS2, ADR 0014, the revised Concord domain model, and the initial conceptual data contracts
 
 ## 1. Purpose
 
@@ -14,229 +16,422 @@ This document compares the three representative Concord packet models:
 * [Science Laboratory Group Packet Model](../packet_models/science-laboratory-group-packet-model.md); and
 * [Collaborative Programming or Engineering Project Packet Model](../packet_models/collaborative-programming_engineering_project_packet_model.md).
 
-The comparison identifies which concepts belong in Concord’s shared foundation and which should remain optional, activity-specific, unresolved, or owned by another Paper Data Suite module.
+The comparison identifies which concepts belong in Concord’s shared foundation and which should remain optional, activity-specific, deferred, or owned by another Paper Data Suite module.
 
-This document refines the [Concord Conceptual Design](../concord-conceptual-design-revised.md). It does not define final JSON contracts, schemas, classes, database tables, or filesystem paths.
+This matrix originally supplied the basis for the initial Concord domain model. It has since been reconciled with later governing decisions, including:
+
+* the finalized PDS Core 0.5/PDS2 routing architecture;
+* [ADR 0014: Make Standards-Based Scoring the Primary Concord Scoring Model](../decisions/0014-make-standards-based-scoring-the-primary-concord-scoring-model.md);
+* the revised [Concord Conceptual Design](../concord-conceptual-design-revised.md);
+* the revised [Initial Concord Domain Model](initial-concord-domain-model.md);
+* the [PDS Core Integration Requirements](pds-core-integration-requirements.md); and
+* the [Initial Concord Conceptual Data Contracts](conceptual-data-contracts.md).
+
+The matrix therefore reflects both:
+
+1. requirements demonstrated across the seminar, laboratory, and project packet cases; and
+2. later suite-level architectural decisions that govern all Concord contract work.
+
+This document does not define final JSON contracts, Python classes, database tables, filesystem persistence, route handlers, packet rendering, or user-interface workflows. Detailed record-level semantics belong to the conceptual data contracts.
 
 ## 2. Classification Method
 
-The classification describes the level of support Concord needs, not whether every packet must use the feature.
+The classification describes the level of support Concord needs, not whether every packet or Activity must instantiate the feature.
 
 | Classification                                   | Meaning                                                                                                                           |
 | ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| **Universal Concord requirement**                | The foundational model or workflow must support it across activity types.                                                         |
-| **Common optional capability**                   | A reusable Concord capability needed by multiple activity types but not required in every activity.                               |
-| **Activity-specific extension**                  | A concept that should normally remain in a template, artifact subtype, or activity-specific extension rather than the base model. |
-| **Owned by another PDS module**                  | The capability belongs to Core, ScoreForm, Quillan, or a future PDS module. Concord may reference it but should not duplicate it. |
+| **Universal Concord requirement**                | The foundational model or workflow must support it across activity types. Individual Activities may omit it when their declared orientation or workflow does not require it. |
+| **Common optional capability**                   | A reusable Concord capability needed by multiple activity types but not required in every Activity.                               |
+| **Activity-specific extension**                  | A concept that should normally remain in a template, artifact subtype, configurable vocabulary, or activity-specific extension rather than the base model. |
+| **Owned by another PDS module**                  | The capability belongs to Core, ScoreForm, Quillan, or a future PDS module. Concord may reference it but must not duplicate it. |
 | **External institutional/system responsibility** | The capability belongs outside Paper Data Suite or in an existing institutional or technical system.                              |
-| **Unresolved**                                   | The requirement is established, but its exact representation or ownership still requires a design decision.                       |
+| **Deferred implementation detail**               | The conceptual requirement is settled, but its serialized form, interface, transport, or implementation mechanism belongs to later work. |
+| **Unresolved**                                   | A genuine architectural question remains. This classification must not be used for decisions already settled by an accepted ADR or finalized Core contract. |
 
 Case-column terms:
 
-* **Central:** a defining part of the packet;
+* **Central:** a defining part of the packet or its expected academic use;
 * **Present:** directly represented;
 * **Possible:** supported or anticipated but not central;
 * **Limited:** only a narrow form appears;
-* **External:** deliberately delegated elsewhere.
+* **Conditional:** required only under a declared Activity orientation or workflow;
+* **External:** deliberately delegated elsewhere;
+* **Excluded:** deliberately outside Concord.
 
 ## 3. Executive Conclusions
 
 The three cases support a common Concord foundation centered on:
 
-1. activities and sessions;
-2. session-contextual groups, memberships, and roles;
-3. reusable, versioned templates assembled into composable packets;
-4. generated artifact instances with stable page identity;
-5. authorship and subject relationships with flexible cardinality;
-6. retained paper evidence and provenance;
-7. human review and conditional moderation;
-8. criteria, scoring scales, and score records;
-9. many-to-many relationships between evidence and scores;
-10. privacy, exception, correction, and supersession states; and
-11. references to work owned by other PDS modules.
+1. Activities and Sessions;
+2. session-contextual Groups, Memberships, Roles, and optional Responsibilities;
+3. reusable Template Definitions and immutable Template Versions;
+4. reusable Packet Definitions and immutable Packet Versions;
+5. generated Packet, Artifact, and Artifact Page instances with stable identity;
+6. PDS2 route registrations that target existing Artifact Pages;
+7. Artifact Author and Artifact Subject relationships with flexible cardinality;
+8. retained paper evidence and end-to-end provenance;
+9. human Review and conditional Moderation;
+10. Activity scoring orientation;
+11. standards profiles and ordered Focus Standards for standards-based and mixed Activities;
+12. standard-backed and local Criteria;
+13. immutable Scoring Scale revisions and criterion-level Score Records;
+14. many-to-many relationships between evidence and Scores;
+15. explicit standards-result semantics for future grading and reporting;
+16. privacy, exception, correction, and supersession states; and
+17. references to work owned by other PDS modules or external systems.
 
-The comparison does **not** support making milestones, subteams, tasks, dependencies, trials, components, handoffs, or version labels mandatory for every Concord activity. These are recurring optional contexts that should be available without defining the base model around project-management or laboratory terminology.
+### 3.1 Standards-based but not standards-exclusive
+
+Concord’s primary academic scoring model is standards-based.
+
+The common foundation must support Activities with these scoring orientations:
+
+```text
+evidence_only
+standards_based
+mixed
+local_criteria_only
+```
+
+A `standards_based` or `mixed` Activity selects:
+
+* one Core-owned `standards_profile_id`;
+* one or more ordered `focus_standard_ids`;
+* and standard-backed Criteria whose governing standards belong to that selected scope.
+
+A standard-backed Criterion identifies exactly one governing Core `standard_id`.
+
+One teacher-approved Score against that Criterion is therefore one direct contextual judgment about one standard for one explicit target.
+
+Concord must also preserve local collaboration Criteria for Activity-specific, procedural, organizational, or process expectations that are not direct standards ratings.
+
+A local Criterion may carry non-governing standards-alignment metadata, but a Score against it must not be exported or interpreted as a direct standards result.
+
+### 3.2 Standards selection is not performance
+
+The matrix distinguishes:
+
+```text
+standards selection or alignment
+    != evidence
+    != teacher-approved standard-backed Score
+    != longitudinal mastery
+    != course Grade
+```
+
+Selecting a Focus Standard does not prove that it was taught, practiced, demonstrated, assessed, mastered, or graded.
+
+A direct Concord standards result exists only when an authorized scorer records a standard-backed Score Record.
+
+The future grading and reporting module—not Concord—will determine how results across Activities, modules, scales, and time are aggregated or reported.
+
+### 3.3 Settled PDS2 identity model
+
+For Concord:
+
+```text
+module_id = concord
+work_id   = activity_id
+```
+
+The effective module work identity is:
+
+```text
+module_id + class_id + work_id
+```
+
+The canonical work root is module-qualified:
+
+```text
+classes/<class_id>/modules/concord/work/<activity_id>/
+```
+
+The PDS2 QR grammar is:
+
+```text
+PDS2|m=<module_id>|c=<class_id>|w=<work_id>|r=<route_id>
+```
+
+A normal Concord route registration targets an existing Artifact Page:
+
+```text
+module_id: concord
+record_kind: artifact_page
+record_id: <artifact_page_id>
+```
+
+The QR identifies one expected physical page route. It does not identify an Author, Subject, student, Group, scorer, Score target, Criterion, standard, or Grade.
+
+### 3.4 Optional structures remain optional
+
+The comparison does **not** support making milestones, child Groups, Work Items, dependencies, trials, components, handoffs, Activity Events, Contribution Claims, or version labels mandatory for every Concord Activity.
+
+These are recurring optional contexts that should be available without defining the base model around project-management, laboratory, or seminar terminology.
 
 ## 4. Cross-Case Matrix
 
 ### 4.1 Activity and Collaboration Context
 
-| Requirement                                  | Seminar  | Laboratory | Project  | Classification                | Likely owner or treatment                               |
-| -------------------------------------------- | -------- | ---------- | -------- | ----------------------------- | ------------------------------------------------------- |
-| Activity                                     | Central  | Central    | Central  | Universal Concord requirement | Concord first-class concept                             |
-| One or more sessions per activity            | Present  | Present    | Central  | Universal Concord requirement | Concord first-class concept                             |
-| Multi-session chronology                     | Possible | Present    | Central  | Universal Concord requirement | Concord must preserve ordered session context when used |
-| Collaborative group                          | Central  | Central    | Central  | Universal Concord requirement | Concord activity-specific group                         |
-| Session-contextual group membership          | Central  | Central    | Central  | Universal Concord requirement | Concord membership record; class roster remains in Core |
-| Membership changes without rewriting history | Possible | Present    | Present  | Universal Concord requirement | Effective context and preserved history                 |
-| Contextual participant roles                 | Central  | Present    | Present  | Universal Concord requirement | Concord role assignment                                 |
-| Direct responsibility assignment             | Limited  | Central    | Central  | Common optional capability    | Concord responsibility assignment                       |
-| Role or responsibility rotation/reassignment | Possible | Central    | Central  | Common optional capability    | Preserve original and revised assignments               |
-| Stage or phase context                       | Limited  | Central    | Present  | Common optional capability    | Optional named context, not mandatory hierarchy         |
-| Milestone or checkpoint                      | Rare     | Possible   | Central  | Common optional capability    | Optional Concord context record                         |
-| Temporary subteam                            | Rare     | Possible   | Central  | Common optional capability    | Likely bounded child group; exact model unresolved      |
-| Task or component reference                  | Limited  | Possible   | Central  | Common optional capability    | Optional activity context                               |
-| Task dependency                              | Limited  | Possible   | Central  | Common optional capability    | Optional project/workflow extension                     |
-| Handoff between participants or subteams     | Limited  | Possible   | Central  | Common optional capability    | Optional typed event or relationship                    |
-| Trial, build, version, or iteration label    | Limited  | Central    | Central  | Common optional capability    | Human-entered context label; not source control         |
-| Equipment or environmental context           | Rare     | Central    | Possible | Activity-specific extension   | Laboratory or material-work templates                   |
-| Discussion structure or rotation             | Central  | Rare       | Rare     | Activity-specific extension   | Seminar packet/template configuration                   |
+| Requirement                                      | Seminar     | Laboratory  | Project     | Classification                | Likely owner or treatment                                      |
+| ------------------------------------------------ | ----------- | ----------- | ----------- | ----------------------------- | -------------------------------------------------------------- |
+| Activity                                         | Central     | Central     | Central     | Universal Concord requirement | Concord first-class concept; `activity_id` is PDS2 `work_id`   |
+| Declared Activity scoring orientation            | Central     | Central     | Central     | Universal Concord requirement | Concord Activity configuration                                 |
+| One or more Sessions per Activity                | Present     | Present     | Central     | Universal Concord requirement | Concord first-class concept                                    |
+| Multi-Session chronology                         | Possible    | Present     | Central     | Universal Concord requirement | Preserve ordered Session context when used                     |
+| Collaborative Group                              | Central     | Central     | Central     | Universal Concord requirement | Concord Activity-specific Group                                |
+| Session-contextual Group Membership              | Central     | Central     | Central     | Universal Concord requirement | Concord Membership; class roster remains in Core               |
+| Membership changes without rewriting history     | Possible    | Present     | Present     | Universal Concord requirement | Effective context and supersession                             |
+| Contextual participant Roles                     | Central     | Present     | Present     | Universal Concord requirement | Concord Role Assignment                                        |
+| Direct Responsibility Assignment                 | Limited     | Central     | Central     | Common optional capability    | Concord Responsibility Assignment                              |
+| Role or Responsibility rotation/reassignment     | Possible    | Central     | Central     | Common optional capability    | Preserve original and revised assignments                      |
+| Stage or phase context                           | Limited     | Central     | Present     | Common optional capability    | Optional Activity Marker, not mandatory hierarchy              |
+| Milestone or checkpoint                          | Rare        | Possible    | Central     | Common optional capability    | Optional Activity Marker                                       |
+| Temporary subteam                                | Rare        | Possible    | Central     | Common optional capability    | Child Group with parent Group and bounded Effective Context    |
+| Task or component reference                      | Limited     | Possible    | Central     | Common optional capability    | Optional Work Item                                             |
+| Task dependency                                  | Limited     | Possible    | Central     | Common optional capability    | Optional Work-Item Dependency                                  |
+| Handoff between participants or child Groups     | Limited     | Possible    | Central     | Common optional capability    | Optional Activity Event or relationship                        |
+| Trial, build, version, or iteration label        | Limited     | Central     | Central     | Common optional capability    | Activity Marker, Work Item, Event, or teacher-facing label     |
+| Equipment or environmental context               | Rare        | Central     | Possible    | Activity-specific extension   | Laboratory or material-work template context                   |
+| Discussion structure or rotation                 | Central     | Rare        | Rare        | Activity-specific extension   | Seminar packet or template configuration                       |
+| Absence, late arrival, interruption, reassignment | Present    | Present     | Present     | Universal Concord requirement | Explicit context/status; never inferred as poor performance    |
 
-### 4.2 Packet, Template, and Artifact Model
+### 4.2 Packet, Template, Artifact, and Routing Model
 
-| Requirement                                | Seminar  | Laboratory | Project  | Classification                               | Likely owner or treatment                                   |
-| ------------------------------------------ | -------- | ---------- | -------- | -------------------------------------------- | ----------------------------------------------------------- |
-| Composable packet definition               | Central  | Central    | Central  | Universal Concord requirement                | Concord first-class concept                                 |
-| Generated packet instance                  | Central  | Central    | Central  | Universal Concord requirement                | Concord first-class concept                                 |
-| Reusable template definition               | Central  | Central    | Central  | Universal Concord requirement                | Concord first-class concept                                 |
-| Immutable template version reference       | Present  | Present    | Present  | Universal Concord requirement                | Concord first-class concept                                 |
-| Generated artifact instance                | Central  | Central    | Central  | Universal Concord requirement                | Concord first-class concept                                 |
-| Stable artifact identifier                 | Central  | Central    | Central  | Universal Concord requirement                | Concord ID validated through Core conventions               |
-| Page-level identity                        | Central  | Central    | Central  | Universal Concord requirement                | Shared Core QR contract plus Concord artifact record        |
-| Human-readable fallback identifier         | Present  | Present    | Present  | Universal Concord requirement                | Concord generation using shared identifier rules            |
-| Page number and multi-page relationship    | Present  | Central    | Central  | Universal Concord requirement                | Artifact-page or page-manifest support                      |
-| Continuation pages                         | Possible | Central    | Central  | Common optional capability                   | Preserve sequence and logical artifact relationship         |
-| Structured Concord artifact                | Central  | Central    | Central  | Universal Concord requirement                | Concord-generated evidence artifact                         |
-| Attached physical or digital work          | Possible | Central    | Central  | Common optional capability                   | Concord attachment/external-artifact relationship           |
-| Artifact cover sheet or QR label           | Possible | Central    | Central  | Common optional capability                   | Concord routing aid                                         |
-| Non-returned instructional scaffold        | Possible | Possible   | Possible | Common optional capability                   | Template declares whether evidence is expected back         |
-| Activity-specific artifact subtype         | Central  | Central    | Central  | Universal Concord requirement                | Template taxonomy, not separate core schemas for every form |
-| Subject-specific worksheet or project file | External | External   | External | External institutional/system responsibility | Referenced or attached; not reimplemented by Concord        |
+| Requirement                                      | Seminar     | Laboratory  | Project     | Classification                               | Likely owner or treatment                                      |
+| ------------------------------------------------ | ----------- | ----------- | ----------- | -------------------------------------------- | -------------------------------------------------------------- |
+| Reusable Packet Definition                       | Central     | Central     | Central     | Universal Concord requirement                | Concord stable lineage                                         |
+| Immutable Packet Version                         | Present     | Present     | Present     | Universal Concord requirement                | Exact ordered composition used by Packet Instances             |
+| Ordered Packet Components                        | Central     | Central     | Central     | Universal Concord requirement                | Concord Packet Component records                               |
+| Generated Packet Instance                        | Central     | Central     | Central     | Universal Concord requirement                | Concord generated record                                       |
+| Reusable Template Definition                     | Central     | Central     | Central     | Universal Concord requirement                | Concord stable lineage                                         |
+| Immutable Template Version                       | Present     | Present     | Present     | Universal Concord requirement                | Exact printable revision                                       |
+| Generated Artifact Instance                      | Central     | Central     | Central     | Universal Concord requirement                | One generated copy of one Template Version                     |
+| Stable Artifact identifier                       | Central     | Central     | Central     | Universal Concord requirement                | Concord ID validated under Core rules                          |
+| Stable Artifact Page identity before rendering   | Central     | Central     | Central     | Universal Concord requirement                | Concord Artifact Page                                          |
+| PDS2 route identity before rendering              | Central     | Central     | Central     | Universal Concord requirement                | Core Route Registration targeting Artifact Page                |
+| Human-readable fallback identifier               | Present     | Present     | Present     | Universal Concord requirement                | Concord generation using safe identifiers                      |
+| Page number and multi-page relationship          | Present     | Central     | Central     | Universal Concord requirement                | Artifact Page and page manifest                                |
+| Continuation pages                               | Possible    | Central     | Central     | Common optional capability                   | Preserve sequence and logical Artifact relationship            |
+| Structured Concord Artifact                      | Central     | Central     | Central     | Universal Concord requirement                | Concord-generated evidence Artifact                            |
+| Attached physical or digital work                | Possible    | Central     | Central     | Common optional capability                   | Attachment or External Reference                               |
+| Artifact cover sheet or QR label                 | Possible    | Central     | Central     | Common optional capability                   | Concord routing aid                                            |
+| Non-returned instructional scaffold              | Possible    | Possible    | Possible    | Common optional capability                   | Template declares whether return and routing are required      |
+| Activity-specific Artifact subtype               | Central     | Central     | Central     | Universal Concord requirement                | Template taxonomy, not a schema per classroom form             |
+| Subject-specific worksheet or project file       | External    | External    | External    | External institutional/system responsibility | Referenced or attached; not reimplemented by Concord           |
+| Exact source scan retained before module filing  | Central     | Central     | Central     | Owned by another PDS module                  | Core source retention and provenance                           |
+| QR carries full Author/Subject/scoring semantics  | Excluded    | Excluded    | Excluded    | Universal Concord prohibition                | Resolve semantics from Artifact Page and linked Concord records |
 
-### 4.3 Authorship, Subjects, and Contribution
+### 4.3 Authorship, Subjects, Targets, and Contribution
 
-| Requirement                                                          | Seminar  | Laboratory | Project | Classification                | Likely owner or treatment                                  |
-| -------------------------------------------------------------------- | -------- | ---------- | ------- | ----------------------------- | ---------------------------------------------------------- |
-| Artifact author distinct from artifact subject                       | Central  | Present    | Central | Universal Concord requirement | Separate relationships                                     |
-| Zero, one, or several student subjects                               | Central  | Central    | Central | Universal Concord requirement | Flexible subject cardinality                               |
-| Individual, group, session, activity, or multi-subject scope         | Central  | Central    | Central | Universal Concord requirement | Typed subject references                                   |
-| One or several authors                                               | Present  | Central    | Central | Universal Concord requirement | Flexible author cardinality                                |
-| Group-representative authorship                                      | Central  | Central    | Central | Universal Concord requirement | Authorship mode plus recorder identity when applicable     |
-| Teacher-authored evidence                                            | Central  | Central    | Central | Universal Concord requirement | Authorized non-student author                              |
-| Recorder or physical writer not treated as sole contributor          | Possible | Central    | Central | Universal Concord requirement | Explicit contributor/authorship semantics                  |
-| Digital account or file ownership not treated as sole authorship     | Rare     | Rare       | Central | Universal Concord rule        | No automatic authorship inference                          |
-| Assigned role/responsibility distinct from demonstrated contribution | Present  | Central    | Central | Universal Concord requirement | Evidence must remain separate from assignment              |
-| Contribution type or category                                        | Limited  | Central    | Central | Common optional capability    | Configurable taxonomy; do not privilege visible production |
-| Contribution claim                                                   | Limited  | Possible   | Central | Common optional capability    | Student/group evidence requiring review                    |
-| Conflicting contribution claims                                      | Possible | Possible   | Central | Common optional capability    | Moderation workflow                                        |
-| Consensus or authorship representation status                        | Central  | Central    | Central | Common optional capability    | Useful for group reviews and retrospectives                |
-| Subteam, task, event, component, or external artifact as subject     | Rare     | Possible   | Central | Common optional capability    | Extend typed subject/context references                    |
+| Requirement                                                          | Seminar     | Laboratory  | Project     | Classification                | Likely owner or treatment                                      |
+| -------------------------------------------------------------------- | ----------- | ----------- | ----------- | ----------------------------- | -------------------------------------------------------------- |
+| Artifact Author distinct from Artifact Subject                       | Central     | Present     | Central     | Universal Concord requirement | Separate durable association records                            |
+| Artifact Author distinct from Score target                           | Central     | Central     | Central     | Universal Concord requirement | Independent typed relationships                                 |
+| Artifact Subject distinct from Score target                          | Central     | Central     | Central     | Universal Concord requirement | Subject context does not create a Score                          |
+| Zero, one, or several student Subjects                               | Central     | Central     | Central     | Universal Concord requirement | Flexible Subject cardinality                                    |
+| Individual, Group, Session, Activity, or multi-Subject scope         | Central     | Central     | Central     | Universal Concord requirement | Typed Subject References                                        |
+| One or several Authors                                               | Present     | Central     | Central     | Universal Concord requirement | Flexible Author cardinality                                     |
+| Group-representative authorship                                      | Central     | Central     | Central     | Universal Concord requirement | Authorship mode plus represented Group                           |
+| Teacher-authored evidence                                            | Central     | Central     | Central     | Universal Concord requirement | Typed authorized Actor                                          |
+| Recorder or physical writer not treated as sole contributor          | Possible    | Central     | Central     | Universal Concord requirement | Explicit authorship and contribution semantics                  |
+| Digital account or file ownership not treated as sole authorship     | Rare        | Rare        | Central     | Universal Concord rule        | No automatic authorship inference                               |
+| Assigned Role/Responsibility distinct from demonstrated contribution | Present     | Central     | Central     | Universal Concord requirement | Evidence remains separate from assignment                       |
+| Contribution type or category                                       | Limited     | Central     | Central     | Common optional capability    | Configurable taxonomy; do not privilege visible production      |
+| Contribution Claim                                                   | Limited     | Possible    | Central     | Common optional capability    | Student/Group evidence requiring Review or Moderation            |
+| Conflicting Contribution Claims                                     | Possible    | Possible    | Central     | Common optional capability    | Moderation workflow                                             |
+| Consensus or representation status                                  | Central     | Central     | Central     | Common optional capability    | Useful for Group-authored records and retrospectives            |
+| Child Group, Work Item, Event, component, or external record as Subject | Rare     | Possible    | Central     | Common optional capability    | Extend typed Subject/context references                         |
+| Group Score distinct from member Scores                             | Central     | Central     | Central     | Universal Concord requirement | No automatic propagation                                        |
 
-### 4.4 Evidence, Review, Moderation, and Privacy
+### 4.4 Evidence, Review, Moderation, Privacy, and Correction
 
-| Requirement                                                           | Seminar  | Laboratory | Project  | Classification                | Likely owner or treatment                            |
-| --------------------------------------------------------------------- | -------- | ---------- | -------- | ----------------------------- | ---------------------------------------------------- |
-| Scanned paper remains canonical evidence                              | Central  | Central    | Central  | Universal Concord requirement | Core retains source; Concord links routed evidence   |
-| Source-scan provenance                                                | Central  | Central    | Central  | Owned by another PDS module   | Core retention and provenance contract               |
-| Concord-specific identification and filing                            | Central  | Central    | Central  | Universal Concord requirement | Concord processing using Core contracts              |
-| Mixed-batch and multi-page intake                                     | Present  | Present    | Present  | Universal Concord requirement | Core intake retention; Concord page processing       |
-| Human review before consequential use                                 | Central  | Central    | Central  | Universal Concord requirement | Concord review record/workflow                       |
-| Filing-metadata correction without altering source                    | Central  | Central    | Central  | Universal Concord requirement | Concord review plus Core provenance                  |
-| Moderation of student-created evidence                                | Central  | Possible   | Present  | Universal Concord capability  | Invoked conditionally by evidence type               |
-| Peer observation                                                      | Central  | Optional   | Possible | Common optional capability    | Concord artifact type with moderation                |
-| Multi-subject teacher observation tracker                             | Central  | Central    | Central  | Universal Concord requirement | One source may support several subjects and scores   |
-| Teacher support/intervention reference                                | Possible | Central    | Central  | Common optional capability    | Evidence context, not automatic performance judgment |
-| Artifact-level privacy classification                                 | Central  | Central    | Central  | Universal Concord requirement | Concord use; shared vocabulary ownership unresolved  |
-| More restrictive privacy for disputes and teacher notes               | Present  | Present    | Present  | Universal Concord requirement | Record-specific override                             |
-| Missing, unreadable, duplicate, conflicting, or misrouted page states | Central  | Central    | Central  | Universal Concord requirement | Review and correction workflow                       |
-| Rescan, correction, replacement, or supersession                      | Central  | Central    | Central  | Universal Concord requirement | Preserve history and source provenance               |
-| Chronology of revised decisions or evidence                           | Possible | Central    | Central  | Universal Concord requirement | Supersession must not erase earlier records          |
-| Handwriting, diagram, or digital-content interpretation               | Excluded | Excluded   | Excluded | External/out of scope         | Human interpretation only                            |
+| Requirement                                                           | Seminar     | Laboratory  | Project     | Classification                | Likely owner or treatment                                      |
+| --------------------------------------------------------------------- | ----------- | ----------- | ----------- | ----------------------------- | -------------------------------------------------------------- |
+| Scanned paper remains canonical evidence                              | Central     | Central     | Central     | Universal Concord requirement | Core retains source; Concord links routed evidence             |
+| Source-scan and source-page provenance                                | Central     | Central     | Central     | Owned by another PDS module   | Core retention and provenance contract                         |
+| Concord Scan Reference to Artifact Page                               | Central     | Central     | Central     | Universal Concord requirement | Concord association after Core dispatch                        |
+| Concord-specific identification and filing                            | Central     | Central     | Central     | Universal Concord requirement | Concord processing after PDS2 routing                           |
+| Mixed-batch and multi-page intake                                     | Present     | Present     | Present     | Universal Concord requirement | Core retention; module-qualified dispatch                       |
+| Human Review before consequential use                                 | Central     | Central     | Central     | Universal Concord requirement | Concord Artifact Review                                         |
+| Filing-metadata correction without altering source                    | Central     | Central     | Central     | Universal Concord requirement | Review, replacement associations, and Correction Record         |
+| Moderation of student-created evidence                                | Central     | Possible    | Present     | Universal Concord capability  | Invoked conditionally by evidence type                          |
+| Peer observation                                                      | Central     | Optional    | Possible    | Common optional capability    | Concord Artifact type with Moderation                           |
+| Multi-Subject teacher observation tracker                             | Central     | Central     | Central     | Universal Concord requirement | One source may support several Subjects and Scores              |
+| Teacher support/intervention reference                                | Possible    | Central     | Central     | Common optional capability    | Evidence context, not automatic performance judgment            |
+| Record-level Privacy Policy                                           | Central     | Central     | Central     | Universal Concord requirement | Concord use; vocabulary may later move to Core                  |
+| More restrictive privacy for disputes and teacher notes               | Present     | Present     | Present     | Universal Concord requirement | Child record may be more restrictive                            |
+| Missing, unreadable, duplicate, conflicting, or misrouted page states | Central     | Central     | Central     | Universal Concord requirement | Explicit routing, filing, Review, and correction states          |
+| Rescan, correction, replacement, or supersession                      | Central     | Central     | Central     | Universal Concord requirement | Preserve source and decision history                            |
+| Chronology of revised decisions or evidence                           | Possible    | Central     | Central     | Universal Concord requirement | Supersession must not erase earlier records                     |
+| Handwriting, diagram, or digital-content interpretation               | Excluded    | Excluded    | Excluded    | External/out of scope         | Human interpretation only                                      |
+| Review creates a Score                                                | Excluded    | Excluded    | Excluded    | Universal Concord prohibition | Review establishes readiness, not performance                   |
+| Moderation acceptance creates a Score                                 | Excluded    | Excluded    | Excluded    | Universal Concord prohibition | Authorized scorer still makes the judgment                     |
 
-### 4.5 Criteria, Scores, and Exceptional States
+### 4.5 Standards, Criteria, Scores, and Exceptional States
 
-| Requirement                                                                           | Seminar  | Laboratory | Project  | Classification                | Likely owner or treatment                                           |
-| ------------------------------------------------------------------------------------- | -------- | ---------- | -------- | ----------------------------- | ------------------------------------------------------------------- |
-| Criterion definitions and selected criterion sets                                     | Central  | Central    | Central  | Universal Concord requirement | Concord first-class concepts                                        |
-| Teacher-defined scoring scale                                                         | Central  | Central    | Central  | Universal Concord requirement | Concord first-class concept                                         |
-| Criterion-level score record                                                          | Central  | Central    | Central  | Universal Concord requirement | Concord first-class concept                                         |
-| Individual score target                                                               | Central  | Central    | Central  | Universal Concord requirement | Concord score subject                                               |
-| Group score target                                                                    | Central  | Central    | Central  | Universal Concord requirement | Concord score subject                                               |
-| Subteam score target                                                                  | Rare     | Rare       | Present  | Common optional capability    | Optional score subject                                              |
-| One score supported by several evidence sources                                       | Central  | Central    | Central  | Universal Concord requirement | Many-to-many evidence links                                         |
-| One artifact supporting several scores                                                | Central  | Central    | Central  | Universal Concord requirement | Many-to-many evidence links                                         |
-| External ScoreForm or Quillan evidence reference                                      | Present  | Present    | Present  | Universal Concord requirement | Shared cross-module reference contract                              |
-| Teacher judgment without one controlling artifact                                     | Present  | Present    | Present  | Universal Concord requirement | Record rationale/provenance                                         |
-| Review or moderation distinct from scoring                                            | Central  | Central    | Central  | Universal Concord requirement | Separate records and states                                         |
-| Score distinct from course grade                                                      | Central  | Central    | Central  | Owned by another PDS module   | Future gradebook/reporting module owns grade calculation            |
-| Group evidence not automatically propagated to individual scores                      | Central  | Central    | Central  | Universal Concord rule        | Requires explicit teacher judgment                                  |
-| Missing evidence distinct from negative evidence                                      | Central  | Central    | Central  | Universal Concord requirement | Explicit non-score states                                           |
-| Absent, excused, not observed, insufficient evidence, not applicable, deferred        | Central  | Central    | Central  | Universal Concord requirement | Shared status vocabulary                                            |
-| Blocked, interrupted, equipment failure, dependency failure, or external tool failure | Possible | Central    | Central  | Common optional capability    | Contextual exception reasons, not low scores                        |
-| Automated behavioral scoring or inferred engagement                                   | Excluded | Excluded   | Excluded | External/out of scope         | Prohibited Concord behavior                                         |
-| Paper scoring form and digital score entry producing same conceptual record           | Possible | Possible   | Possible | Unresolved                    | Interaction design decision; contract should remain surface-neutral |
+| Requirement                                                                                  | Seminar     | Laboratory  | Project     | Classification                | Likely owner or treatment                                               |
+| -------------------------------------------------------------------------------------------- | ----------- | ----------- | ----------- | ----------------------------- | ----------------------------------------------------------------------- |
+| Activity scoring orientation                                                                 | Central     | Central     | Central     | Universal Concord requirement | Concord Activity configuration                                          |
+| `evidence_only` orientation                                                                  | Possible    | Possible    | Possible    | Universal Concord capability  | No Criteria or Scores required                                          |
+| `standards_based` orientation                                                                | Central     | Central     | Central     | Universal Concord capability  | Primary academic scoring model                                          |
+| `mixed` orientation                                                                          | Possible    | Central     | Central     | Universal Concord capability  | Standard-backed and local Criteria                                      |
+| `local_criteria_only` orientation                                                            | Possible    | Possible    | Possible    | Universal Concord capability  | Scores are not direct standards results                                 |
+| Core standards profile identity                                                              | Conditional | Conditional | Conditional | Owned by another PDS module   | Required for `standards_based` and `mixed`; Core owns `profile_id`       |
+| Ordered Activity Focus Standards                                                             | Conditional | Conditional | Conditional | Universal Concord requirement | Concord selects durable Core `standard_id` values                        |
+| Standard-backed Criterion                                                                    | Central     | Central     | Central     | Universal Concord requirement | Exactly one governing `standard_id`                                     |
+| Local Criterion                                                                              | Present     | Present     | Present     | Universal Concord requirement | Activity-specific or process judgment, not direct standards result       |
+| Non-governing standards alignment for a local Criterion                                      | Possible    | Possible    | Possible    | Common optional capability    | Alignment metadata only                                                  |
+| Multi-standard holistic Criterion treated as several direct ratings                          | Excluded    | Excluded    | Excluded    | Universal Concord prohibition | Use separate standard-backed Criteria or retain as local                 |
+| Criterion definitions and immutable Criterion Set revisions                                 | Central     | Central     | Central     | Universal Concord requirement | Concord first-class concepts                                             |
+| Teacher-selected immutable Scoring Scale revision                                           | Central     | Central     | Central     | Universal Concord requirement | Concord first-class concept                                              |
+| Standard-backed Score Record                                                                 | Central     | Central     | Central     | Universal Concord requirement | Direct contextual judgment about one standard                            |
+| Local Score Record                                                                           | Present     | Present     | Present     | Universal Concord requirement | Valid Concord Score, not a direct standard rating                         |
+| Individual Score target                                                                      | Central     | Central     | Central     | Universal Concord requirement | Typed Score-Target Reference                                             |
+| Group Score target                                                                           | Central     | Central     | Central     | Universal Concord requirement | Group judgment remains distinct from member judgments                     |
+| Child-Group Score target                                                                     | Rare        | Rare        | Present     | Common optional capability    | Group target with bounded context                                        |
+| Session, Activity, Artifact, Work Item, or component target                                  | Possible    | Possible    | Possible    | Universal Concord capability  | Only when permitted by selected Criterion                                |
+| One Score supported by several evidence sources                                              | Central     | Central     | Central     | Universal Concord requirement | Many-to-many Score Evidence Links                                        |
+| One Artifact or source supporting several Scores                                             | Central     | Central     | Central     | Universal Concord requirement | Deliberate link per use                                                   |
+| One source supporting several standards Scores                                               | Central     | Central     | Central     | Universal Concord requirement | Separate standard-backed Criteria and Score Records                       |
+| External ScoreForm or Quillan evidence reference                                             | Present     | Present     | Present     | Universal Concord requirement | Module-qualified public reference                                        |
+| External result automatically becomes a Concord Score                                        | Excluded    | Excluded    | Excluded    | Universal Concord prohibition | Explicit Concord teacher judgment required                               |
+| Teacher professional judgment without one controlling Artifact                               | Present     | Present     | Present     | Universal Concord requirement | Rationale and scorer provenance                                          |
+| Group or multi-Subject evidence supporting an individual standards Score                     | Present     | Present     | Present     | Universal Concord requirement | Explicit teacher judgment and relevance explanation                      |
+| Group evidence automatically propagated to individual Scores                                 | Excluded    | Excluded    | Excluded    | Universal Concord prohibition | Never automatic                                                          |
+| Review or Moderation distinct from Scoring                                                   | Central     | Central     | Central     | Universal Concord requirement | Separate records and states                                               |
+| Score distinct from mastery, Grade, and longitudinal report                                  | Central     | Central     | Central     | Owned by another PDS module   | Future grading/reporting module owns aggregation and policy               |
+| Standards alignment distinct from direct standards judgment                                 | Central     | Central     | Central     | Universal Concord requirement | Prevent inference from metadata alone                                     |
+| Standards-result handoff preserves standard, target, scale, context, and supersession        | Central     | Central     | Central     | Universal Concord requirement | Conceptual handoff projection; serialization deferred                     |
+| Missing evidence distinct from negative evidence                                             | Central     | Central     | Central     | Universal Concord requirement | Explicit non-score states                                                 |
+| `absent`, `excused`, `not_observed`, `insufficient_evidence`, `not_applicable`, `deferred`    | Central     | Central     | Central     | Universal Concord requirement | Score disposition vocabulary                                              |
+| Blocked, interrupted, equipment failure, dependency failure, or external tool failure        | Possible    | Central     | Central     | Common optional capability    | Contextual reasons, not low Scores                                        |
+| Automated behavioral scoring or inferred engagement                                          | Excluded    | Excluded    | Excluded    | Universal Concord prohibition | Human-reviewed, teacher-approved judgments only                           |
+| Paper scoring form and digital entry producing the same conceptual Score Record              | Possible    | Possible    | Possible    | Universal Concord requirement | Surface-neutral conceptual contract                                      |
 
 ### 4.6 Module and System Ownership
 
-| Capability                                                                                     | Seminar  | Laboratory | Project  | Classification                               | Owner                             |
-| ---------------------------------------------------------------------------------------------- | -------- | ---------- | -------- | -------------------------------------------- | --------------------------------- |
-| Workspace root and canonical shared paths                                                      | Required | Required   | Required | Owned by another PDS module                  | `pds-core`                        |
-| Durable class, roster, and student identity                                                    | Required | Required   | Required | Owned by another PDS module                  | `pds-core`                        |
-| Shared identifier validation and safe paths                                                    | Required | Required   | Required | Owned by another PDS module                  | `pds-core`                        |
-| Shared `PDS1` QR construction, parsing, and routing contract                                   | Required | Required   | Required | Owned by another PDS module                  | `pds-core`                        |
-| Source-scan retention and shared provenance                                                    | Required | Required   | Required | Owned by another PDS module                  | `pds-core`                        |
-| Shared routing failure/resolution metadata                                                     | Required | Required   | Required | Owned by another PDS module                  | `pds-core`                        |
-| Standards library, profiles, and durable standards IDs                                         | Optional | Optional   | Optional | Owned by another PDS module                  | `pds-core`                        |
-| Activity-specific groups, sessions, roles, packets, artifacts, review, moderation, and scoring | Required | Required   | Required | Universal Concord requirement                | `pds-concord`                     |
-| OMR and machine-readable checks                                                                | External | External   | External | Owned by another PDS module                  | `pds-scoreform`                   |
-| Focused or extended written responses                                                          | External | External   | External | Owned by another PDS module                  | `pds-quillan`                     |
-| Objectives, instructional sequence, materials, timing, and lesson plans                        | External | External   | External | Owned by another PDS module                  | Future lesson-planning module     |
-| Course grades, weighting, reporting, and parent-facing output                                  | External | External   | External | Owned by another PDS module                  | Future gradebook/reporting module |
-| Formal safety, medical, disciplinary, or incident record                                       | Rare     | Possible   | Possible | External institutional/system responsibility | School or district system         |
-| Source control, repository history, CAD/project-file management, and digital edit history      | Rare     | Rare       | Central  | External institutional/system responsibility | Existing technical systems        |
+| Capability                                                                                                      | Seminar     | Laboratory  | Project     | Classification                               | Owner or treatment                              |
+| --------------------------------------------------------------------------------------------------------------- | ----------- | ----------- | ----------- | -------------------------------------------- | ----------------------------------------------- |
+| Workspace root and canonical class identity                                                                     | Required    | Required    | Required    | Owned by another PDS module                  | `pds-core`                                      |
+| Durable roster and student identity                                                                              | Required    | Required    | Required    | Owned by another PDS module                  | `pds-core`                                      |
+| Shared identifier validation and safe path helpers                                                               | Required    | Required    | Required    | Owned by another PDS module                  | `pds-core`                                      |
+| Module-qualified work identity and work-root helpers                                                             | Required    | Required    | Required    | Owned by another PDS module                  | `pds-core`                                      |
+| PDS2 QR parsing, serialization, Route Registration, and generic dispatch                                         | Required    | Required    | Required    | Owned by another PDS module                  | `pds-core`                                      |
+| Source-scan retention and shared provenance                                                                     | Required    | Required    | Required    | Owned by another PDS module                  | `pds-core`                                      |
+| Shared routing failure and resolution metadata                                                                  | Required    | Required    | Required    | Owned by another PDS module                  | `pds-core`                                      |
+| Standards library, profiles, durable `standard_id`, and durable `profile_id`                                    | Conditional | Conditional | Conditional | Owned by another PDS module                  | `pds-core`; required when Activity uses standards |
+| Activity scoring orientation and Focus Standard selection                                                       | Central     | Central     | Central     | Universal Concord requirement                | `pds-concord`                                   |
+| Standard-backed/local Criterion semantics and Score Records                                                     | Central     | Central     | Central     | Universal Concord requirement                | `pds-concord`                                   |
+| Activity-specific Groups, Sessions, Roles, Packets, Artifacts, Review, Moderation, and evidence linkage         | Required    | Required    | Required    | Universal Concord requirement                | `pds-concord`                                   |
+| OMR and machine-readable checks                                                                                  | External    | External    | External    | Owned by another PDS module                  | `pds-scoreform`                                 |
+| Focused or extended written responses                                                                           | External    | External    | External    | Owned by another PDS module                  | `pds-quillan`                                   |
+| Cross-Activity or cross-module standards aggregation, weighting, mastery policy, grades, and reporting          | External    | External    | External    | Owned by another PDS module                  | Future grading/reporting module                 |
+| Objectives, instructional sequence, materials, timing, lesson plans, and unit plans                            | External    | External    | External    | Owned by another PDS module                  | Future lesson-planning module                   |
+| Formal safety, medical, disciplinary, or incident record                                                        | Rare        | Possible    | Possible    | External institutional/system responsibility | School or district system                       |
+| Source control, repository history, CAD/project-file management, and digital edit history                       | Rare        | Rare        | Central     | External institutional/system responsibility | Existing technical systems                      |
 
 ## 5. Universal Concord Requirements
 
-The following should be treated as foundation-level requirements for the initial domain model:
+The following are foundation-level requirements for the Concord domain and conceptual contracts:
 
-* activity and session identity;
-* activity-specific groups and session-contextual membership;
-* contextual role assignment;
-* composable packet definitions and generated packet instances;
-* reusable templates with immutable version references;
-* stable artifact and page identity;
-* flexible artifact author and subject relationships;
-* individual, group, session, activity, and multi-subject scope;
-* structured Concord artifacts and their scans;
-* source provenance through Core;
-* human review, metadata correction, and scoring readiness;
-* conditional moderation of peer, disputed, or student-created evidence;
-* artifact-level privacy;
-* criteria, criterion sets, scoring scales, and score records;
-* many-to-many evidence-to-score relationships;
-* individual and group score targets;
-* explicit non-score and exception states;
-* corrections, rescans, revisions, and superseding records that preserve history; and
-* cross-module references to ScoreForm, Quillan, Core standards, and future systems.
+### 5.1 Activity, collaboration, and identity
 
-A universal capability does not imply that every packet must instantiate it. For example, moderation must exist in the foundational model even though many teacher-authored artifacts will not need a separate moderation step.
+* Activity and Session identity;
+* `activity_id` as Concord’s Core routing `work_id`;
+* module-qualified work identity and paths;
+* Activity-specific Groups and Session-contextual Membership;
+* contextual Role Assignment;
+* optional Responsibility Assignment;
+* typed participant, Actor, Subject, and Score-Target References;
+* and historical preservation of Membership, Role, and Responsibility changes.
+
+### 5.2 Definitions, generated records, and routing
+
+* reusable Template Definitions with immutable Template Versions;
+* reusable Packet Definitions with immutable Packet Versions;
+* ordered Packet Components;
+* generated Packet Instances;
+* generated Artifact Instances;
+* one or more Artifact Pages per Artifact;
+* durable page and route identity before rendering;
+* PDS2 Route Registration targeting an existing Artifact Page;
+* human-readable fallback identification;
+* and semantic resolution through linked Concord records rather than QR metadata.
+
+### 5.3 Evidence and judgment
+
+* flexible Artifact Author and Artifact Subject relationships;
+* individual, Group, Session, Activity, Work Item, Event, Artifact, and multi-Subject scope;
+* retained source evidence and provenance through Core;
+* Concord Scan References;
+* human Review, metadata correction, and scoring readiness;
+* conditional Moderation of peer, disputed, or student-created evidence;
+* record-level privacy;
+* many-to-many evidence-to-Score relationships;
+* explicit professional-judgment rationale when no formal evidence link controls the Score;
+* and non-destructive correction and supersession.
+
+### 5.4 Standards and scoring
+
+* Activity scoring orientation;
+* support for `evidence_only`, `standards_based`, `mixed`, and `local_criteria_only`;
+* Core standards profile references for `standards_based` and `mixed` Activities;
+* ordered Focus Standard IDs;
+* standard-backed Criteria with exactly one governing `standard_id`;
+* local Criteria that remain distinguishable from direct standards judgments;
+* optional non-governing alignment metadata for local Criteria;
+* immutable Criterion Set, Criterion, and Scoring Scale revisions;
+* standard-backed and local Score semantics;
+* individual and Group Score targets;
+* explicit standards-specific non-score dispositions;
+* one standard-backed Score representing one Criterion, one governing standard, one target, and one exact scale revision;
+* standards-result handoff semantics sufficient for future reporting;
+* and the separation of Score from mastery, Grade, and reporting policy.
+
+A universal capability does not imply that every Activity must instantiate it.
+
+For example:
+
+* an `evidence_only` Activity may use no Criteria or Scores;
+* a `local_criteria_only` Activity may produce Scores without standards results;
+* and Moderation must exist in the foundation even though many teacher-authored sources will not require it.
 
 ## 6. Common Optional Capabilities
 
-These capabilities recur across multiple cases and should be supported without becoming mandatory parts of every activity:
+These capabilities recur across multiple cases and should be supported without becoming mandatory parts of every Activity:
 
-* responsibility assignments separate from roles;
-* activity stages or phases;
-* milestones or checkpoints;
-* temporary subteams;
-* tasks and components;
-* dependencies and handoffs;
-* trial, build, version, or iteration labels;
-* typed events for decisions, troubleshooting, testing, revision, and handoff;
-* role and responsibility reassignment;
-* contribution categories and contribution claims;
-* group consensus or representation status;
+* Responsibility Assignments separate from Roles;
+* Activity Markers for stages, phases, milestones, checkpoints, rotations, or iterations;
+* child Groups for temporary subteams;
+* Work Items and bounded components;
+* Work-Item Dependencies;
+* typed Activity Events for decisions, troubleshooting, testing, revision, handoff, interruption, and teacher intervention;
+* Role and Responsibility reassignment;
+* contribution categories and Contribution Claims;
+* Group consensus or representation status;
 * teacher assistance or intervention references;
-* external artifact attachments and cover sheets;
+* Attachments and Artifact cover sheets;
 * continuation pages and long-lived logs;
-* subteam score targets; and
-* contextual exception reasons such as equipment failure, interrupted work, or dependency blockage.
+* long-running Packet series;
+* child-Group Score targets;
+* contextual exception reasons such as equipment failure, interrupted work, or dependency blockage;
+* local Criteria alongside standard-backed Criteria;
+* non-governing standards alignment for local Criteria;
+* ScoreForm result references as supporting evidence;
+* Quillan result references as supporting evidence;
+* and standards-result export or handoff adapters.
 
-These features should be optional records or extensions around the universal activity-artifact-evidence model. Concord should not become a general project-management application merely because it can document tasks, milestones, or dependencies.
+These features should be optional records, relationships, or controlled extensions around the universal Activity–Artifact–Evidence–Judgment model.
+
+Concord should not become:
+
+* a general project-management application merely because it can document Work Items or dependencies;
+* a general lesson-planning application merely because Activities select standards;
+* or a gradebook merely because it records standard-backed Scores.
 
 ## 7. Activity-Specific Extensions
 
-The following concepts should normally remain in templates, artifact subtypes, configurable vocabularies, or activity-specific metadata.
+The following concepts should normally remain in Templates, Artifact subtypes, configurable vocabularies, or Activity-specific metadata.
 
 ### Seminar-specific
 
@@ -244,17 +439,20 @@ The following concepts should normally remain in templates, artifact subtypes, c
 * discussion moves;
 * speaker-response maps;
 * observer-target pairings;
-* seminar prompts and text references; and
-* discussion-map legends.
+* seminar prompts and text references;
+* discussion-map legends;
+* textual-evidence locators;
+* and seminar-specific descriptions of selected speaking, listening, reading, or evidence-use standards.
 
 ### Laboratory-specific
 
 * trial numbering;
-* apparatus, material, or sample references;
+* apparatus, material, sample, or environmental references;
 * measurement-table layouts;
 * invalid-trial reasons;
-* routine safety prompts; and
-* laboratory-specific procedure or data organizers.
+* routine safety prompts;
+* procedure and data organizers;
+* and laboratory-specific descriptions of selected science-practice or engineering standards.
 
 ### Programming or engineering project-specific
 
@@ -262,158 +460,316 @@ The following concepts should normally remain in templates, artifact subtypes, c
 * software test-case fields;
 * regression or severity labels;
 * component-integration terminology;
-* repository or project-file locations; and
-* domain-specific design-review fields.
+* repository or project-file locations;
+* domain-specific design-review fields;
+* and project-specific descriptions of selected computing, engineering, or design-practice standards.
 
-The base model may provide generic context references, but it should not encode subject-specific vocabulary as mandatory fields.
+The base model may provide generic context and standards references, but it must not encode subject-specific vocabulary as mandatory fields.
 
 ## 8. Consolidated Ownership Boundaries
 
 ### 8.1 Concord owns
 
-* packet, template, artifact, review, moderation, criterion, and score contracts;
-* activity-specific sessions, groups, memberships, roles, and optional responsibilities;
-* artifact authorship and subject relationships;
-* Concord artifact layouts and packet manifests;
-* Concord-specific QR extraction, page splitting, filing, and review interfaces;
+* Activity and Session contracts;
+* Activity scoring orientation;
+* selection of Focus Standards for Concord Activities;
+* Activity-specific Groups, Memberships, Roles, and optional Responsibilities;
+* Packet, Template, Artifact, Review, Moderation, Criterion, Scoring Scale, and Score contracts;
+* standard-backed and local Criterion semantics;
+* teacher-approved standard-backed and local Score Records;
+* Score Evidence Links;
+* Artifact Author and Artifact Subject relationships;
+* Concord Artifact layouts and Packet manifests;
+* creation of Artifact Pages before rendering;
+* Concord-specific page validation, filing, Review, and correction behavior after Core dispatch;
+* Concord Scan References to Core-retained source pages;
 * routed Concord evidence and result records;
-* privacy use within Concord; and
-* score entry and evidence linkage.
+* privacy use within Concord;
+* standards-result handoff projections or exports; and
+* Score entry and evidence linkage.
 
 ### 8.2 Core owns
 
 * workspace resolution;
-* canonical class, roster, assignment-route, and student identity conventions;
-* identifier validation and safe path construction;
-* the shared `PDS1` QR contract;
-* source-scan retention and provenance;
-* shared scan-routing failure and resolution metadata;
-* standards libraries and durable standards/profile IDs;
-* shared navigation and local file-opening behavior.
+* canonical class, roster, and student identity;
+* shared identifier validation;
+* module-qualified work references and safe work-root construction;
+* PDS2 QR construction, parsing, and validation;
+* Route Locator and Route Registration contracts;
+* module-profile recognition and generic dispatch;
+* source-scan retention and source-page provenance;
+* shared routing failure and resolution metadata;
+* standards libraries;
+* standards profiles;
+* durable `standard_id` and `profile_id` values;
+* standards selection and reference validation support;
+* shared contract-version information;
+* and shared navigation or local file-opening behavior where provided.
 
-Core must eventually register `module=concord` and support artifact routing that does not require one student subject.
+Core does not own:
+
+* Concord Activity scoring orientation;
+* Focus Standard ordering within a Concord Activity;
+* Concord Criteria;
+* Concord scoring semantics;
+* Score targets;
+* or standards-result interpretation.
 
 ### 8.3 ScoreForm owns
 
-* OMR;
+* OMR instruments;
 * bubble ratings;
 * machine-readable checklists;
-* structured accountability checks; and
-* ScoreForm result processing.
+* selected-response processing;
+* ScoreForm attempts;
+* question-level standards alignment;
+* and ScoreForm result records.
+
+A ScoreForm result may support a Concord Score through an explicit External Reference, Evidence Reference, and Score Evidence Link.
+
+It does not automatically become a Concord standard-backed Score.
 
 ### 8.4 Quillan owns
 
-* extended reflection;
-* focused written analysis;
-* substantial peer feedback;
-* written defense or explanation; and
-* Quillan review and scoring workflows.
+* focused and extended written responses;
+* Quillan assignment Focus Standards;
+* review-unit observations;
+* Quillan overall standard ratings;
+* written feedback;
+* and Quillan result records.
+
+A Quillan standards result may support a Concord Score through an explicit external evidence relationship.
+
+It does not automatically determine a Concord Score.
 
 ### 8.5 Future or external systems own
 
 * lesson and unit planning;
-* grade calculation and reporting;
+* cross-Activity and cross-module standards aggregation;
+* scale conversion and normalization;
+* weighting;
+* longitudinal mastery policy;
+* marking-period and course-grade calculation;
+* reporting and parent communication;
 * formal safety or disciplinary incidents;
 * source control and commit attribution;
-* CAD, engineering-file, or project-file management; and
-* authoritative cloud-document histories.
+* CAD, engineering-file, or project-file management;
+* and authoritative cloud-document histories.
 
-## 9. Unresolved Design Questions
+## 9. Settled Decisions and Remaining Deferred Questions
 
-The comparison establishes the need for the following decisions but does not settle their final contract representation:
+The original matrix identified several questions that have since been settled.
 
-1. **Activity identity:** Does Concord’s `activity_id` map directly to Core’s current `assignment_id`, or is a separate Concord identifier linked to the canonical assignment route?
-2. **QR subject model:** How should the shared `PDS1` contract represent pages with group, session, activity, event, artifact, or multi-subject scope and no required `student_id`?
-3. **QR payload size:** Which context belongs in the QR payload and which should be resolved through the artifact-instance record?
-4. **Multi-subject evidence:** Is a teacher tracker one artifact with many subjects, one scan with derived evidence entries, or both?
-5. **Temporal precision:** Do membership, role, and responsibility changes require session, sequence, stage, or timestamp precision?
-6. **Roles, responsibilities, tasks, and contributions:** These are semantically distinct, but which require first-class records in the initial contract set?
-7. **Subteams:** Should a subteam be a group with a parent group and bounded lifespan, or a separate project-specific concept?
-8. **Events:** Should decisions, troubleshooting incidents, tests, revisions, and handoffs share one typed activity-event envelope or use separate record types?
-9. **Attachments:** Should scans, photographs, external files, and teacher-entered locations use one attachment model or several evidence-reference types?
-10. **Privacy vocabulary:** Which privacy values should be shared by Core, and which should remain Concord-specific?
-11. **Scoring surface:** Should paper rubrics, digital entry, or both be first-class workflows if they produce the same score contract?
-12. **Individual scoring sufficiency:** Must an individual score cite at least one individual-specific evidence source, or may reviewed group evidence and teacher judgment be sufficient?
-13. **Long-lived packets:** Should milestone or multi-session work use one packet instance with continuing artifacts or several linked packet instances?
-14. **Starter taxonomies:** Which roles, criteria, contribution types, event types, and artifact templates should ship as defaults without becoming contract requirements?
+### 9.1 Settled decisions
 
-## 10. Recommendations for the Initial Domain Model
+1. **Activity identity:** Concord’s `activity_id` is the Core routing `work_id`. It is not a required Core `assignment_id`.
 
-Issue #8 should begin with the following likely first-class concepts:
+2. **QR model:** Concord uses PDS2:
+
+   ```text
+   PDS2|m=<module_id>|c=<class_id>|w=<work_id>|r=<route_id>
+   ```
+
+   The QR carries no required student, Group, Author, Subject, standard, Criterion, or Score semantics.
+
+3. **Route target:** A normal Concord Route Registration targets an existing Artifact Page.
+
+4. **Semantic resolution:** Author, Subject, participant, Group, template, standard, Criterion, and Score context resolve from module-owned records.
+
+5. **Multi-Subject evidence:** A teacher tracker may remain one Artifact with several Artifact Subject associations. One source may support several Scores through separate Score Evidence Links.
+
+6. **Temporal precision:** Session identity is the primary effective unit for Membership, Role, and Responsibility relationships. Activity Markers or sequence positions may refine it where needed.
+
+7. **Roles, Responsibilities, Work Items, and Contributions:** These remain semantically distinct. Role is universal; Responsibility is optional first-class; Work Item and Contribution Claim are optional.
+
+8. **Child Groups:** Temporary subteams use Groups with optional parent Group and bounded Effective Context.
+
+9. **Activity Events:** A typed general Activity Event envelope is used initially. Specialized event contracts require demonstrated repeated invariants.
+
+10. **Attachments:** Attachment is distinct from Artifact Page and Scan Reference. External records use External References and provider-neutral locators.
+
+11. **Scoring surface:** Paper and digital entry may produce the same conceptual Score Record.
+
+12. **Individual scoring sufficiency:** Individual Scores may use relevant Group or multi-Subject evidence when the teacher makes an explicit individual judgment and records relevance. Individual-specific evidence is not universally required.
+
+13. **Long-running Packets:** One continuing Packet Instance or several linked Packet Instances are both permitted under explicit generation semantics.
+
+14. **Packet versioning:** Packet Definition and immutable Packet Version are separate concepts.
+
+15. **Criterion and scale revisioning:** Criterion Sets, Criteria, and Scoring Scales use immutable revision identities sufficient to reproduce historical Scores.
+
+16. **Correction:** Concord uses same-type supersession relationships plus a generic Correction Record.
+
+17. **Standards model:** Standards-based scoring is the primary academic model, but evidence-only, mixed, and local-criteria-only Activities remain valid.
+
+18. **Governing standard:** A standard-backed Criterion has exactly one governing `standard_id`.
+
+19. **Local Criteria:** Local collaboration Criteria remain valid and may carry non-governing alignment metadata.
+
+20. **Grade boundary:** Concord records contextual Scores, not mastery, course Grades, or longitudinal reports.
+
+### 9.2 Remaining deferred questions
+
+The following do not block the conceptual foundation:
+
+1. What exact serialized schemas and contract versions will implement each record?
+
+2. What storage layout will Concord use beneath the Core module-qualified work root?
+
+3. What user-interface controls will distinguish standard-backed Criteria, local Criteria, Focus Standards, and scoring orientations?
+
+4. What exact export file, event, manifest, or API shape will carry the standards-result handoff to the future grading and reporting module?
+
+5. Which privacy vocabulary values will ultimately remain Concord-specific and which may move into Core?
+
+6. Which role, Criterion, contribution, Event, status, artifact, and template vocabularies should ship as starter data?
+
+7. Which optional Activity-specific structures will prove necessary in the representative issue #12 examples?
+
+8. What future compatibility policy will govern comparisons among different Scoring Scale revisions?
+
+9. What optional adapters will resolve ScoreForm and Quillan public records without mandatory sibling-package dependencies?
+
+10. What minimal review and scoring interfaces will be implemented first?
+
+## 10. Requirements Carried into the Domain Model and Conceptual Contracts
+
+The Concord foundation includes these first-class or explicitly contracted concepts:
 
 * `activity`;
 * `session`;
 * `group`;
 * `group_membership`;
 * `role_assignment`;
-* `packet_definition`;
-* `packet_instance`;
+* `responsibility_assignment`;
 * `template_definition`;
 * `template_version`;
+* `packet_definition`;
+* `packet_version`;
+* `packet_component`;
+* `packet_instance`;
 * `artifact_instance`;
-* `artifact_page` or equivalent page manifest;
-* `artifact_author` relationship;
-* `artifact_subject` relationship;
-* `scan_reference` or routed evidence reference;
+* `artifact_page`;
+* `artifact_author`;
+* `artifact_subject`;
+* `scan_reference`;
 * `artifact_review`;
 * `moderation_record`;
-* `criterion_set` and `criterion`;
+* `correction_record`;
+* `criterion_set`;
+* `criterion`;
 * `scoring_scale`;
 * `score_record`;
-* `score_evidence_link`; and
-* `external_reference`.
+* `score_evidence_link`;
+* `attachment`;
+* and `external_reference`.
 
-The following should be evaluated as optional first-class records or extensible context structures rather than assumed universal entities:
+The following are defined as optional first-class records or controlled extensions:
 
-* `responsibility_assignment`;
-* `activity_phase`;
-* `milestone`;
-* `subteam`;
-* `task` or `component`;
+* `activity_marker`;
+* `work_item`;
+* `work_item_dependency`;
 * `activity_event`;
-* `dependency`;
-* `handoff`;
-* `contribution_claim`; and
-* `attachment`.
+* and `contribution_claim`.
 
-The contract work should preserve these invariants:
+The shared conceptual primitives include:
 
-1. source evidence is never silently altered or replaced;
-2. author and subject are never implicitly assumed to be the same;
-3. recorder, handwriting, account ownership, or file ownership never establishes sole authorship automatically;
-4. assignment of a role or responsibility never proves fulfillment or contribution;
-5. a blank field or missing artifact never becomes a low score automatically;
-6. group evidence or group scores never propagate to individual scores without an explicit teacher judgment;
-7. evidence, review, moderation, score, grade, and report remain separate concepts; and
-8. activity-specific vocabulary does not become mandatory base-schema vocabulary.
+* Concord Record Reference;
+* Module Record Reference;
+* Participant Reference;
+* Actor Reference;
+* Subject Reference;
+* Score-Target Reference;
+* Evidence Reference;
+* Evidence Locator;
+* Provenance;
+* Effective Context;
+* Privacy Policy;
+* Status Reason;
+* External Locator;
+* scoring orientation;
+* Criterion classification;
+* standard-backed Score semantics;
+* and standards-result handoff projection.
 
-## 11. Updated Provisional Findings
+Representative records in issue #12 should test at least:
 
-* authors and subjects are separate relationships with independent cardinality;
-* artifacts may have zero, one, or several student subjects and may instead concern a group, session, activity, event, component, or external artifact;
-* physical writer, recorder, account owner, and file owner are not reliable proxies for sole authorship or contribution;
-* activities, sessions, groups, memberships, and contextual roles belong in Concord’s shared foundation;
-* roles, responsibilities, tasks, and contributions are distinct concepts, although not all must be mandatory records;
-* responsibilities may change by stage, trial, milestone, or work period, and changes must preserve history;
-* assigned responsibility is not evidence of fulfillment;
-* peer evidence and disputed contribution claims require human moderation;
-* teacher observation artifacts may span several students, groups, sessions, or contextual units;
-* decisions, trials, troubleshooting, testing, revision, and handoffs can be represented as typed evidence-bearing events;
-* failure, interruption, or blocked work must remain separate from poor performance;
-* nonverbal, technical, organizational, testing, integration, support, and material work are valid contribution types;
-* external physical or digital work may be linked without Concord inspecting or managing its native system;
-* scores and evidence have a many-to-many relationship;
-* individual, subteam, and group scores may use overlapping evidence but remain distinct judgments;
-* group evidence never automatically establishes an individual score;
-* missing evidence and exceptional circumstances are explicit states, not negative scores;
-* corrections, rescans, revised decisions, and superseding records preserve the earlier history;
-* extended writing belongs to Quillan;
-* OMR belongs to ScoreForm;
-* lesson planning, grade calculation, reporting, formal incident management, and source-control attribution remain outside Concord; and
-* Core’s QR contract must support Concord artifacts with non-student, group, session, event, artifact, and multi-subject scope.
+1. a `standards_based` seminar Activity;
+2. a `mixed` laboratory Activity;
+3. a `mixed` or `standards_based` programming/engineering Activity;
+4. an `evidence_only` Activity or Activity component;
+5. standard-backed Criteria with one governing standard each;
+6. local collaboration Criteria that are not direct standards ratings;
+7. an individual standards Score;
+8. a Group standards Score;
+9. Group evidence supporting an individual Score through explicit teacher judgment;
+10. one source supporting several standard-backed Scores;
+11. a non-score disposition for a Focus Standard;
+12. a ScoreForm result used as supporting evidence;
+13. a Quillan standards result used as supporting evidence;
+14. PDS2 routing to an Artifact Page with no student Subject;
+15. and correction or supersession that preserves the prior record.
+
+## 11. Confirmed Cross-Case Findings
+
+* Authors and Subjects are separate relationships with independent cardinality.
+* Authors, Subjects, Score targets, scorers, and standards are distinct concepts.
+* Artifacts may have zero, one, or several student Subjects and may instead concern a Group, Session, Activity, Event, Work Item, component, Attachment, or external record.
+* Physical writer, recorder, account owner, file owner, and scanner are not reliable proxies for sole authorship or contribution.
+* Activities, Sessions, Groups, Memberships, and contextual Roles belong in Concord’s shared foundation.
+* Roles, Responsibilities, Work Items, and contributions are distinct, although not all are mandatory for every Activity.
+* Responsibilities may change by Session, marker, stage, trial, milestone, or work period, and changes preserve history.
+* Assigned Responsibility is not evidence of fulfillment.
+* Peer evidence and disputed Contribution Claims may require human Moderation.
+* Teacher observation Artifacts may span several students, Groups, Sessions, or contextual units.
+* One source may support several Subjects and several Scores without being duplicated.
+* Decisions, trials, troubleshooting, testing, revision, and handoffs can be represented as typed evidence-bearing Events.
+* Failure, interruption, blocked work, missing files, and equipment problems remain separate from poor performance.
+* Nonverbal, technical, organizational, testing, integration, support, and material work are valid contribution forms.
+* External physical or digital work may be linked without Concord inspecting or managing its native system.
+* Scores and evidence have a many-to-many relationship.
+* Individual, child-Group, and Group Scores may use overlapping evidence but remain distinct judgments.
+* Group evidence never automatically establishes an individual Score.
+* Missing evidence and exceptional circumstances are explicit dispositions or context states, not negative Scores.
+* Corrections, rescans, revised decisions, and superseding records preserve earlier history.
+* Standards-based scoring is Concord’s primary academic scoring model.
+* Standards-based scoring does not require every Activity to produce a Score.
+* `standards_based` and `mixed` Activities use a Core standards profile and ordered Focus Standards.
+* A standard-backed Criterion identifies exactly one governing standard.
+* A standard-backed Score is one contextual teacher-approved judgment about that standard for one target.
+* Local collaboration Criteria remain supported.
+* Standards alignment alone is not a direct standards result.
+* A standard-backed Concord Score is not, by itself, longitudinal mastery or a course Grade.
+* Extended written-response review belongs to Quillan.
+* OMR and selected-response processing belong to ScoreForm.
+* Lesson planning, grade calculation, reporting, formal incident management, and source-control attribution remain outside Concord.
+* PDS2 routes identify physical page routes and resolve to Artifact Pages; they do not identify students or semantic scoring context directly.
 
 ## 12. Completion Assessment
 
-The three packet models have now been compared systematically. Universal requirements, optional capabilities, activity-specific extensions, cross-module ownership, unresolved questions, and initial domain-model recommendations are documented.
+The three packet models have been compared systematically and the matrix has been reconciled with the later Concord and Core architecture.
 
-This matrix provides the required basis for issue #8: **Define the initial Concord domain model**.
+The revised matrix now distinguishes:
+
+* universal foundation requirements from per-Activity optional use;
+* reusable definitions from generated records;
+* Activity identity from generic assignment assumptions;
+* PDS2 route identity from Artifact semantics;
+* Authors from Subjects and Score targets;
+* evidence from Review, Moderation, and Scoring;
+* standard-backed Criteria from local Criteria;
+* standards alignment from direct standards judgments;
+* individual Scores from Group Scores;
+* contextual standards Scores from mastery and course Grades;
+* and universal concepts from seminar-, laboratory-, and project-specific extensions.
+
+This document now supports:
+
+* the revised initial Concord domain model;
+* the initial conceptual data contracts;
+* ADR 0014;
+* issue #11 documentation consistency;
+* issue #12 representative contract examples;
+* and issue #13 skeptical foundation review.
+
+It does not replace the detailed record contracts. When this matrix conflicts with an accepted ADR, the finalized PDS Core contract, or the current conceptual data contracts, the later governing source controls.

--- a/docs/design/initial-concord-domain-model.md
+++ b/docs/design/initial-concord-domain-model.md
@@ -1,51 +1,98 @@
 # Initial Concord Domain Model
 
-**Status:** Draft for conceptual contract design
+**Status:** Revised draft for conceptual contract design
 **Project:** Paper Data Suite
 **Module:** `pds-concord`
 **Issue:** #8
-**Date:** July 13, 2026
-
+**Date:** July 22, 2026
+**Revision:** 2 — aligned with PDS2, the initial conceptual data contracts, and ADR 0014
 ## 1. Purpose
 
 This document defines the initial conceptual domain model for `pds-concord`.
 
-It translates the findings from the following documents into a coherent set of domain concepts and relationships:
+It translates the findings and decisions from the following documents into a coherent set of domain concepts and relationships:
 
 * [Concord Conceptual Design](../concord-conceptual-design-revised.md);
 * [Cross-Case Requirements Matrix](cross-case-requirements.md);
+* [Initial Concord Conceptual Data Contracts](conceptual-data-contracts.md);
 * [Socratic Seminar Packet Model](../packet_models/socratic-seminar-packet-model.md);
-* [Science Laboratory Group Packet Model](../packet_models/science-laboratory-group-packet-model.md); and
-* [Collaborative Programming or Engineering Project Packet Model](../packet_models/collaborative-programming_engineering_project_packet_model.md).
+* [Science Laboratory Group Packet Model](../packet_models/science-laboratory-group-packet-model.md);
+* [Collaborative Programming or Engineering Project Packet Model](../packet_models/collaborative-programming_engineering_project_packet_model.md);
+* the accepted Concord architecture decisions through ADR 0014;
+* and the released `pds-core` 0.5/PDS2 contracts.
 
 The model is implementation-neutral. It does not prescribe:
 
 * Python classes;
 * JSON Schema structure;
 * database tables;
-* filesystem layout;
-* QR payload syntax;
+* final filesystem layout beneath the module-qualified Concord work root;
 * user-interface design;
 * or public API stability.
 
-Its purpose is to establish the concepts, relationships, cardinalities, ownership boundaries, and invariants that later contracts and implementations must preserve.
+Its purpose is to establish the concepts, relationships, cardinalities, ownership boundaries, standards semantics, and invariants that later contracts and implementations must preserve.
 
+When this document conflicts with an accepted Concord ADR, the ADR governs unless a later ADR explicitly supersedes it.
+
+When an earlier design assumption conflicts with the finalized PDS2 architecture, the finalized Core contract governs.
 ## 2. Domain Definition
 
 Concord is a paper-based collaborative-evidence system.
 
-Its domain begins with an already-planned collaborative classroom activity and covers:
+Its domain begins with an already-planned collaborative classroom Activity and covers:
 
-1. configuring the activity context;
-2. generating packets and artifacts;
-3. identifying artifact authors and subjects;
-4. receiving and filing scans;
-5. reviewing and moderating evidence;
-6. recording criterion-level scores; and
-7. linking Concord evidence and scores to records owned elsewhere.
+1. configuring the Activity context;
+2. declaring whether the Activity is evidence-only, standards-based, mixed, or local-criteria-only;
+3. selecting a Core standards profile and ordered Focus Standards when standards-based scoring applies;
+4. generating Packets and Artifacts;
+5. identifying Artifact Authors and Subjects;
+6. receiving and filing scans through PDS2 routing;
+7. reviewing and moderating evidence;
+8. recording criterion-level teacher judgments;
+9. distinguishing direct standard-backed Scores from local Concord Scores;
+10. preserving a future standards-result handoff without calculating mastery or Grades; and
+11. linking Concord evidence and Scores to records owned elsewhere.
 
-Concord does not own lesson planning, OMR, extended written-response evaluation, course-grade calculation, formal incident management, or external project-file systems.
+Concord’s primary academic scoring model is standards-based.
 
+Concord is not standards-exclusive. It also supports:
+
+* evidence-only Activities;
+* local procedural or collaborative Criteria;
+* Group-process Criteria;
+* Activity-component Criteria;
+* formative evidence that produces no Score;
+* and nonacademic or locally defined collaborative contexts.
+
+The central standards-based relationship is:
+
+```text
+collaborative evidence
+    -> standard-backed Criterion
+    -> teacher-approved Score
+    -> future standards-based grading and reporting
+```
+
+The local-criterion relationship is:
+
+```text
+collaborative evidence
+    -> local Criterion
+    -> teacher-approved local Score
+```
+
+A local Score is not a direct standards result merely because the local Criterion carries optional standards-alignment metadata.
+
+Concord does not own:
+
+* lesson planning;
+* optical mark recognition;
+* extended written-response evaluation;
+* course-grade calculation;
+* cross-Activity or cross-module mastery determination;
+* longitudinal reporting;
+* formal incident management;
+* or external project-file systems.
 ## 3. Modeling Conventions
 
 ### 3.1 First-class entity
@@ -54,10 +101,10 @@ A first-class entity:
 
 * has a durable identity;
 * has an independent lifecycle;
-* may be referenced by other records; and
-* must remain distinguishable from similar entities over time.
+* may be referenced by other records;
+* and must remain distinguishable from similar entities over time.
 
-Examples include an activity, session, artifact instance, review, or score record.
+Examples include an Activity, Session, Artifact Instance, Review, Criterion, or Score Record.
 
 ### 3.2 Association record
 
@@ -68,9 +115,19 @@ It should have its own durable identity when the relationship:
 * changes over time;
 * carries metadata;
 * may be corrected or superseded;
+* may be disputed;
 * or must be cited as evidence.
 
-Examples include group membership, role assignment, artifact authorship, artifact subject assignment, and score-evidence linkage.
+Examples include:
+
+* Group Membership;
+* Role Assignment;
+* Responsibility Assignment;
+* Artifact Author;
+* Artifact Subject;
+* Score Evidence Link;
+* Work-Item Dependency;
+* and External Reference.
 
 ### 3.3 Typed reference
 
@@ -79,16 +136,19 @@ A typed reference identifies something owned either by Concord or another module
 Examples include:
 
 * Core student reference;
-* Concord group reference;
-* Concord session reference;
+* Concord Group reference;
+* Concord Session reference;
+* Core standard reference;
 * ScoreForm result reference;
-* Quillan response reference;
-* or future gradebook record reference.
+* Quillan result reference;
+* or future grading and reporting record reference.
 
-A typed reference identifies both:
+A typed reference identifies:
 
-* the kind of target; and
-* the durable identifier of that target.
+* the owning system;
+* the kind of target;
+* the durable identifier of that target;
+* and, where needed, the public contract version.
 
 ### 3.4 Value object
 
@@ -96,31 +156,34 @@ A value object has meaning but does not require independent identity.
 
 Examples include:
 
-* privacy classification;
+* privacy policy;
 * evidence locator;
 * role key;
-* score disposition;
+* Score disposition;
 * authorship mode;
 * page position;
-* and status reason.
+* Activity scoring orientation;
+* Criterion classification;
+* and Status Reason.
 
-### 3.5 Definitions and instances
+### 3.5 Definitions, versions, and instances
 
-Reusable definitions must remain separate from generated classroom records.
+Reusable definitions must remain separate from immutable versions and generated classroom records.
 
 Examples:
 
-* a template definition is reusable;
-* a template version is an immutable revision;
-* an artifact instance is one generated copy of that version;
-* a packet definition is reusable;
-* a packet instance is generated for a specific activity context.
+* a Template Definition is a reusable lineage;
+* a Template Version is one immutable revision;
+* an Artifact Instance is one generated copy of that version;
+* a Packet Definition is a reusable lineage;
+* a Packet Version is one immutable composition;
+* and a Packet Instance is generated for a specific Activity context.
 
 ### 3.6 Historical preservation
 
-Records that have been used as evidence must not be silently rewritten.
+Records that have been printed, distributed, scanned, reviewed, moderated, scored, exported, reported, or used as evidence must not be silently rewritten.
 
-Corrections, rescans, reassignments, revised scores, and superseding decisions must preserve the earlier state and explain what changed.
+Corrections, rescans, reassignments, revised Scores, revised standards relationships, and superseding decisions must preserve the earlier state and explain what changed.
 
 ### 3.7 Surface neutrality
 
@@ -129,51 +192,116 @@ The conceptual model must not depend on whether a teacher completes a step:
 * on paper;
 * in a terminal interface;
 * in a future graphical interface;
-* or through another local workflow.
+* through an import;
+* or through another authorized local workflow.
 
-For example, a scanned paper rubric and a digitally entered rubric should be capable of producing the same conceptual score record.
+For example, a scanned paper rubric and a digitally entered rubric should be capable of producing equivalent Score Records when they represent the same teacher judgment.
 
+### 3.8 Standards semantics
+
+Core owns shared standards identity, storage, profiles, display metadata, and module-neutral validation.
+
+Concord owns:
+
+* Activity Focus Standard selection;
+* standard-backed Criterion meaning;
+* local Criterion meaning;
+* teacher-approved Score Records;
+* evidence relationships;
+* and Concord-specific standards-result handoff semantics.
+
+The following are distinct:
+
+```text
+Focus Standard selection
+standards alignment
+standard-backed Criterion
+teacher-approved standard-backed Score
+future mastery or Grade determination
+```
+
+Selecting a Focus Standard does not prove that it was taught, practiced, assessed, demonstrated, or mastered.
+
+A direct Concord standards result exists only through an explicit teacher-approved standard-backed Score Record.
 ## 4. Ownership Boundaries
 
 ### 4.1 Concord-owned concepts
 
 Concord owns:
 
-* activities;
-* sessions;
-* activity-specific groups;
-* group membership;
-* contextual roles;
-* optional responsibilities;
-* packet and template definitions;
-* generated packet and artifact instances;
-* artifact authorship and subject relationships;
-* Concord-specific routed evidence references;
-* artifact review and moderation;
-* criteria and scoring scales;
-* score records;
-* score-evidence relationships;
-* external-module relationships;
-* and Concord-specific corrections and supersession history.
+* Activities;
+* Sessions;
+* Activity-specific Groups;
+* Group Membership;
+* contextual Roles;
+* optional Responsibilities;
+* Activity scoring orientation;
+* Activity Focus Standard selection;
+* Criterion Sets;
+* standard-backed and local Criteria;
+* Scoring Scales;
+* Score Records;
+* standards-result handoff projections derived from Concord Scores;
+* Packet and Template Definitions;
+* Packet and Template Versions;
+* generated Packet and Artifact Instances;
+* Artifact Authors and Subjects;
+* Concord-specific routed Scan References;
+* Artifact Review and Moderation;
+* Score Evidence Links;
+* External References;
+* Attachments;
+* optional Activity Markers, Work Items, Events, and Contribution Claims;
+* and Concord-specific correction and supersession history.
 
-### 4.2 Core-owned concepts
+### 4.2 Core-owned concepts and capabilities
 
 `pds-core` owns:
 
 * workspace resolution;
 * canonical class identity;
 * roster and student identity;
-* canonical assignment-routing conventions;
 * shared identifier validation;
-* safe path construction;
-* shared `PDS1` QR contracts;
+* module-qualified work-path construction;
+* the PDS2 locator grammar;
+* PDS2 parsing and serialization;
+* Route Registrations;
+* shared Module Record References;
 * source-scan retention;
 * source-scan provenance;
-* shared routing-failure and resolution metadata;
-* standards libraries and standards profiles;
+* generic routing-failure and resolution metadata;
+* module-profile dispatch;
+* standards libraries;
+* standards profiles;
+* durable `standard_id` and `profile_id` identity;
+* standards browsing and selection helpers;
+* standards profile-membership validation;
+* standards display metadata;
+* active, inactive, and deprecated status;
 * and shared navigation behavior.
 
-Concord references these records rather than duplicating them.
+For Concord’s top-level module work identity:
+
+```text
+module_id = concord
+class_id  = <Core class identifier>
+work_id   = <Concord activity_id>
+```
+
+Therefore:
+
+```text
+work_id = activity_id
+```
+
+Concord references Core-owned records and capabilities rather than duplicating them.
+
+Concord must not create:
+
+* a competing standards library;
+* a competing class or roster model;
+* a separate QR grammar;
+* or a second source-scan authority.
 
 ### 4.3 ScoreForm-owned concepts
 
@@ -183,7 +311,15 @@ Concord references these records rather than duplicating them.
 * machine-readable answer sheets;
 * bubble ratings;
 * structured machine-readable checks;
+* answer keys;
+* OMR scoring;
+* question-level standards alignment;
+* attempts;
 * and ScoreForm result records.
+
+A ScoreForm result may support a Concord judgment through an External Reference and Score Evidence Link.
+
+It does not become a Concord Score automatically.
 
 ### 4.4 Quillan-owned concepts
 
@@ -193,25 +329,50 @@ Concord references these records rather than duplicating them.
 * extended reflections;
 * substantial written peer feedback;
 * written explanations and defenses;
-* and Quillan review and scoring records.
+* writing-assignment Focus Standards;
+* Quillan review-unit observations;
+* Quillan overall Focus Standard ratings;
+* Quillan feedback;
+* and Quillan result and reporting records.
+
+A Quillan result may support a Concord judgment through an External Reference and Score Evidence Link.
+
+It does not become a Concord Score automatically.
 
 ### 4.5 Future or external ownership
 
-Other systems own:
+A future Paper Data Suite grading and reporting module owns or is expected to own:
+
+* cross-Activity aggregation;
+* cross-module aggregation;
+* marking-period and course-grade calculation;
+* scale normalization;
+* weighting;
+* attempt selection;
+* longitudinal standards analysis;
+* mastery determination;
+* report-card output;
+* parent communication;
+* and broader student, class, course, term, and school-year reporting.
+
+Other external systems remain authoritative for:
 
 * lesson and unit plans;
-* course-grade calculation;
-* reporting and communication;
 * formal safety or disciplinary incidents;
+* medical and accommodation records;
 * source-control history;
 * CAD and engineering files;
-* and authoritative cloud-document histories.
+* cloud-document history;
+* and institutional records.
 
+Concord supplies contextual Scores and evidence relationships. It does not determine final mastery or Grades.
 ## 5. Conceptual Overview
 
 ```mermaid
 erDiagram
     CORE_CLASS ||--o{ ACTIVITY : contains
+    CORE_STANDARDS_PROFILE ||--o{ ACTIVITY : governs_when_selected
+    CORE_STANDARD }o--o{ ACTIVITY : selected_as_focus
     ACTIVITY ||--|{ SESSION : occurs_in
     ACTIVITY ||--o{ GROUP : defines
     GROUP ||--o{ GROUP_MEMBERSHIP : has
@@ -220,33 +381,55 @@ erDiagram
     GROUP_MEMBERSHIP ||--o{ RESPONSIBILITY_ASSIGNMENT : may_receive
 
     TEMPLATE_DEFINITION ||--|{ TEMPLATE_VERSION : versions
-    PACKET_DEFINITION ||--|{ PACKET_COMPONENT : contains
+    PACKET_DEFINITION ||--|{ PACKET_VERSION : versions
+    PACKET_VERSION ||--|{ PACKET_COMPONENT : contains
     TEMPLATE_VERSION ||--o{ PACKET_COMPONENT : selected_by
 
     ACTIVITY ||--o{ PACKET_INSTANCE : generates
-    PACKET_DEFINITION ||--o{ PACKET_INSTANCE : instantiates
+    PACKET_VERSION ||--o{ PACKET_INSTANCE : instantiates
     PACKET_INSTANCE ||--|{ ARTIFACT_INSTANCE : contains
     TEMPLATE_VERSION ||--o{ ARTIFACT_INSTANCE : generates
     ARTIFACT_INSTANCE ||--|{ ARTIFACT_PAGE : contains
+    CORE_ROUTE_REGISTRATION ||--|| ARTIFACT_PAGE : targets
 
     ARTIFACT_INSTANCE ||--o{ ARTIFACT_AUTHOR : has
     ARTIFACT_INSTANCE ||--o{ ARTIFACT_SUBJECT : concerns
     ARTIFACT_PAGE ||--o{ SCAN_REFERENCE : evidenced_by
+    CORE_SOURCE_SCAN ||--o{ SCAN_REFERENCE : retained_source
     ARTIFACT_INSTANCE ||--o{ ARTIFACT_REVIEW : reviewed_by
-    ARTIFACT_REVIEW ||--o{ MODERATION_RECORD : may_produce
+    EVIDENCE_REFERENCE ||--o{ MODERATION_RECORD : may_require
 
     CRITERION_SET ||--|{ CRITERION : contains
     ACTIVITY }o--o{ CRITERION_SET : selects
+    CORE_STANDARD ||--o{ CRITERION : governs_standard_backed
+    CORE_STANDARD }o--o{ CRITERION : may_align_local
     SCORING_SCALE ||--o{ SCORE_RECORD : governs
     CRITERION ||--o{ SCORE_RECORD : evaluated_by
     SCORE_RECORD ||--o{ SCORE_EVIDENCE_LINK : supported_by
+    SCORE_RECORD ||--o| STANDARDS_RESULT_HANDOFF : projects_when_standard_backed
 
     EXTERNAL_REFERENCE ||--o{ SCORE_EVIDENCE_LINK : may_support
     ARTIFACT_INSTANCE ||--o{ SCORE_EVIDENCE_LINK : may_support
 ```
 
-The diagram shows conceptual relationships only. It does not prescribe implementation aggregates or database foreign keys.
+The diagram shows conceptual relationships only.
 
+It does not prescribe:
+
+* implementation aggregates;
+* database foreign keys;
+* filesystem records;
+* or serialization nesting.
+
+The Core Route Registration points to an existing Artifact Page.
+
+The PDS2 locator identifies the route only:
+
+```text
+PDS2|m=<module_id>|c=<class_id>|w=<work_id>|r=<route_id>
+```
+
+The Artifact Page and linked Concord records supply the page’s complete semantic context.
 ## 6. Activity and Collaboration Context
 
 ### 6.1 Activity
@@ -267,34 +450,136 @@ An Activity should contain:
 * durable Concord `activity_id`;
 * required Core class reference;
 * title or short label;
-* activity type or teacher-defined category;
+* Activity type or teacher-defined category;
+* required scoring orientation;
+* conditional Core `standards_profile_id`;
+* conditional ordered `focus_standard_ids`;
 * lifecycle status;
-* optional Core assignment-routing reference;
-* optional selected criterion sets;
-* optional standards references;
+* optional selected Criterion Sets;
 * creation and update provenance;
+* optional privacy default;
 * and optional links to related module records.
 
-#### Identity recommendation
+#### Module work identity
 
-Concord should use its own durable `activity_id`.
+The Activity is Concord’s top-level Core work unit.
 
-The Activity should also reference the appropriate Core assignment-routing context when one exists. These identifiers serve different purposes:
+Its routing and workspace identity is:
 
-* `activity_id` identifies the Concord collaborative activity;
-* the Core assignment reference identifies its shared workspace or suite-level routing context.
+```text
+module_id = concord
+class_id  = <Core class identifier>
+work_id   = <activity_id>
+```
 
-A one-to-one mapping may be used initially, but the concepts should not be collapsed prematurely. One Core assignment may eventually contain several Concord activities, and one Concord activity may link to several ScoreForm or Quillan assignments.
+The Activity does not need a second Concord-versus-Core assignment identity for PDS2 routing.
+
+The complete module work identity is:
+
+```text
+module_id + class_id + activity_id
+```
+
+Concord’s canonical work root is conceptually:
+
+```text
+classes/<class_id>/modules/concord/work/<activity_id>/
+```
+
+The path must be constructed through Core helpers rather than unvalidated string concatenation.
+
+#### Scoring orientation
+
+Every Activity declares one of:
+
+```text
+evidence_only
+standards_based
+mixed
+local_criteria_only
+```
+
+##### `evidence_only`
+
+The Activity collects, organizes, reviews, or moderates evidence without producing Concord Score Records.
+
+It does not require:
+
+* a standards profile;
+* Focus Standards;
+* Criteria;
+* or a Scoring Scale.
+
+##### `standards_based`
+
+The Activity’s scored judgments are direct judgments against selected Focus Standards.
+
+It requires:
+
+* one Core `standards_profile_id`;
+* one or more ordered `focus_standard_ids`;
+* one or more standard-backed Criteria;
+* and applicable Scoring Scale revisions.
+
+Scored Criteria should ordinarily be standard-backed.
+
+##### `mixed`
+
+The Activity uses both:
+
+* standard-backed Criteria;
+* and local Concord Criteria.
+
+It requires one standards profile and one or more ordered Focus Standards.
+
+##### `local_criteria_only`
+
+The Activity produces Scores, but those Scores are not direct standards judgments.
+
+It does not require a standards profile or Focus Standards.
+
+Local Criteria may carry optional non-governing standards-alignment metadata.
+
+That metadata must not cause a local Score to enter a direct standards-result handoff.
+
+#### Focus Standards
+
+For `standards_based` and `mixed` Activities:
+
+* `standards_profile_id` identifies the Core-owned profile used for selection;
+* `focus_standard_ids` is nonempty;
+* duplicate Focus Standard IDs are invalid;
+* order is meaningful for teacher-facing scoring and future handoff;
+* each Focus Standard should belong to the selected profile;
+* and missing, inactive, or deprecated references must be reported without silently mutating the Activity.
+
+Selecting a Focus Standard does not create a Score.
 
 #### Cardinality
 
-* One Core class may contain zero or many Concord activities.
+* One Core class may contain zero or many Concord Activities.
 * One Activity belongs to exactly one Core class in the initial model.
 * One Activity contains one or more Sessions.
 * One Activity may contain zero or more Groups.
+* One Activity may select zero or more Criterion Sets.
 * One Activity may generate zero or more Packet Instances.
+* One Activity may contain zero or more Artifact Instances.
+* One Activity may produce zero or more Score Records.
+* One `standards_based` or `mixed` Activity selects exactly one standards profile and one or more Focus Standards.
+* One `evidence_only` or `local_criteria_only` Activity may omit standards configuration.
 
-Cross-class collaborative activities are outside the initial model.
+Cross-class collaborative Activities are outside the initial model.
+
+#### Invariants
+
+* `activity_id` is Concord’s Core `work_id`.
+* An Activity is not automatically a graded assignment.
+* An evidence-only Activity must not produce Score Records.
+* A standard-backed Criterion used by an Activity must govern one of that Activity’s Focus Standards.
+* A local Criterion remains local even when it contains optional alignment references.
+* Cancellation does not delete generated evidence.
+* Activity-specific structures remain optional unless selected records require them.
+
 
 ### 6.2 Session
 
@@ -325,6 +610,7 @@ A Session should contain:
 * One Session may contextualize zero or more memberships, roles, responsibilities, artifacts, events, and scores.
 
 Even a single-period activity should have one Session. This avoids special cases in group membership, role assignment, artifact routing, and provenance.
+
 
 ### 6.3 Group
 
@@ -360,6 +646,7 @@ A separate Subteam entity is not required in the initial model.
 * One Group may have zero or many child Groups.
 * One Group has zero or many Group Membership records.
 
+
 ### 6.4 Group Membership
 
 A **Group Membership** associates one human participant with one Group for a defined context.
@@ -388,6 +675,7 @@ The participant will normally be a Core student reference. The model should also
 * One membership is effective for one or more identified Sessions.
 
 A participant may belong to different Groups in different Sessions without rewriting earlier records.
+
 
 ### 6.5 Role Assignment
 
@@ -423,6 +711,7 @@ A Role Assignment should contain:
 * A role assignment may be limited to one Session, several Sessions, one Group, or one stage within a Session.
 
 Roles are contextual assignments, not personality labels or permanent classifications.
+
 
 ### 6.6 Responsibility Assignment
 
@@ -464,7 +753,6 @@ It does not prove:
 * or role fulfillment.
 
 Evidence of fulfillment must come from an artifact, observation, contribution claim, teacher judgment, or other reviewed source.
-
 ## 7. Reusable Definitions and Generated Instances
 
 ### 7.1 Template Definition
@@ -476,7 +764,7 @@ Examples include:
 * peer observation form;
 * discussion map;
 * responsibility record;
-* group retrospective;
+* Group retrospective;
 * teacher observation tracker;
 * or scoring rubric.
 
@@ -484,13 +772,14 @@ A Template Definition should contain:
 
 * durable `template_id`;
 * name;
-* general artifact category;
+* general Artifact category;
 * purpose;
 * owner or source;
 * lifecycle status;
-* and zero or more Template Versions.
+* creation provenance;
+* and one or more Template Versions.
 
-A Template Definition does not contain a specific class, group, student, or activity assignment.
+A Template Definition does not contain a specific class, Group, student, or Activity assignment.
 
 ### 7.2 Template Version
 
@@ -502,76 +791,126 @@ It should contain:
 * parent `template_id`;
 * version label or sequence;
 * layout or rendering specification reference;
-* artifact category;
-* page structure;
+* Artifact category;
+* expected page structure;
 * expected-return behavior;
-* default privacy classification;
-* default authorship and subject expectations;
-* optional supported criteria;
-* QR-placement requirements;
+* default privacy policy;
+* default authorship and Subject expectations;
+* optional supported Criteria;
+* page-level PDS2 route requirements;
 * creation provenance;
-* and retirement status.
+* lifecycle status;
+* and optional superseded Template Version.
 
 Once a Template Version has generated an Artifact Instance, it must not be silently modified.
 
-A change to wording, layout, QR placement, scoring criteria, or page structure requires a new Template Version.
+A change to:
+
+* wording;
+* layout;
+* page structure;
+* QR placement;
+* authorship expectations;
+* Subject expectations;
+* supported Criteria;
+* or return behavior
+
+requires a new Template Version.
 
 ### 7.3 Packet Definition
 
-A **Packet Definition** is a reusable, ordered composition of Template Versions.
+A **Packet Definition** represents the stable identity and lineage of one reusable packet design.
 
 It should contain:
 
 * durable `packet_definition_id`;
 * name;
-* version or revision;
 * purpose;
+* lifecycle status;
+* creation provenance;
+* and one or more Packet Versions.
+
+A Packet Definition does not directly contain mutable component composition after use.
+
+Composition belongs to Packet Version.
+
+### 7.4 Packet Version
+
+A **Packet Version** is one immutable ordered composition of Template Versions and optional external components.
+
+It should contain:
+
+* durable `packet_version_id`;
+* parent `packet_definition_id`;
+* version label or sequence;
 * ordered Packet Components;
 * optional generation rules;
 * lifecycle status;
-* and creation provenance.
+* creation provenance;
+* and optional superseded Packet Version.
 
-Each Packet Component should identify:
+A Packet Version must contain at least one Packet Component.
 
-* exact Template Version;
+Once a Packet Version has generated a Packet Instance, changes to composition or order require a new Packet Version.
+
+### 7.5 Packet Component
+
+A **Packet Component** is one ordered element of a Packet Version.
+
+It should identify:
+
+* durable `packet_component_id`;
+* parent `packet_version_id`;
+* sequence;
+* component kind;
+* exact Concord Template Version or external component reference;
 * quantity or repetition rule;
 * intended audience or context;
-* whether it is required, recommended, or conditional;
-* and its order within the packet.
+* requirement level;
+* optional generation condition;
+* and optional display label.
 
-A Packet Definition should be immutable after it has generated Packet Instances. Changes to its composition require a new revision.
+Exactly one Concord Template Version or external component is identified according to component kind.
 
-### 7.4 Packet Instance
+Physical assembly into one packet does not transfer record ownership.
+
+### 7.6 Packet Instance
 
 A **Packet Instance** is a generated packet tied to a specific classroom context.
 
 It should contain:
 
 * durable `packet_instance_id`;
-* exact Packet Definition revision;
+* exact `packet_version_id`;
 * `activity_id`;
 * optional `session_id`;
 * optional Group or participant context;
+* optional long-running series identity;
+* optional previous Packet Instance;
 * generation timestamp;
 * generator or teacher reference;
 * generation status;
-* and one or more Artifact Instances.
+* creation provenance;
+* and one or more Concord Artifact Instances.
 
 #### Cardinality
 
-* One Packet Definition may generate zero or many Packet Instances.
-* One Packet Instance uses exactly one Packet Definition revision.
+* One Packet Definition has one or more Packet Versions.
+* One Packet Version may generate zero or many Packet Instances.
+* One Packet Instance uses exactly one Packet Version.
 * One Activity may have zero or many Packet Instances.
-* One Packet Instance contains one or more Artifact Instances.
+* One Packet Instance contains one or more Concord Artifact Instances.
 
 A long-running Activity may use:
 
-* one Packet Instance containing artifacts that continue across Sessions; or
-* several linked Packet Instances generated at different checkpoints.
+* one continuing Packet Instance whose Artifacts span several Sessions; or
+* several linked Packet Instances within one series.
 
-The exact long-lived-packet policy remains a contract question.
+The Activity or packet-generation configuration must choose deliberately.
 
-### 7.5 Artifact Instance
+Regeneration does not silently replace an already distributed Packet Instance.
+
+### 7.7 Artifact Instance
 
 An **Artifact Instance** is one generated copy of one Template Version.
 
@@ -588,13 +927,14 @@ An Artifact Instance should contain:
 * exact `template_version_id`;
 * parent `activity_id`;
 * optional `packet_instance_id`;
-* optional Session, Group, or activity-marker context;
-* artifact category;
+* optional Session, Group, Activity Marker, or Work Item context;
+* Artifact category;
 * generation provenance;
 * expected-return status;
-* artifact lifecycle status;
-* default or effective privacy classification;
-* and one or more Artifact Pages.
+* Artifact lifecycle status;
+* effective privacy policy;
+* one or more Artifact Pages;
+* and optional superseded Artifact Instance.
 
 An Artifact Instance may exist independently of a Packet Instance when the teacher generates a single form.
 
@@ -608,34 +948,69 @@ An Artifact Instance may exist independently of a Packet Instance when the teach
 * One Artifact Instance may have zero or many Authors.
 * One Artifact Instance may have zero or many Subjects.
 
-### 7.6 Artifact Page
+### 7.8 Artifact Page
 
-An **Artifact Page** represents one expected page within an Artifact Instance.
+An **Artifact Page** represents one expected physical page within an Artifact Instance.
 
 It should contain:
 
 * durable `artifact_page_id`;
 * parent `artifact_instance_id`;
-* page number;
+* logical page number;
 * total expected pages where known;
 * page kind;
-* stable human-readable fallback identifier;
-* shared QR payload or QR reference where required;
 * expected-return status;
+* whether a PDS2 route is required;
+* one immutable `route_id` when routing is required;
+* stable human-readable fallback identifier when routing is required;
 * optional continuation-page relationship;
-* and page lifecycle status.
+* page lifecycle status;
+* and creation provenance.
 
-Every scannable page expected to return to Concord should have stable page identity.
+Every returned scannable page should have stable page identity before rendering.
 
-Non-returned instructional scaffolds may omit QR data when the Template Version declares that the page is not evidence-bearing.
+#### PDS2 route semantics
+
+The generated locator is exactly:
+
+```text
+PDS2|m=concord|c=<class_id>|w=<activity_id>|r=<route_id>
+```
+
+The Core Route Registration targets:
+
+```text
+module_id: concord
+record_kind: artifact_page
+record_id: <artifact_page_id>
+```
+
+The Artifact Page must exist before its Route Registration and QR code are generated.
+
+The locator does not contain:
+
+* student identity;
+* Artifact Author;
+* Artifact Subject;
+* Group identity;
+* Session identity;
+* logical page semantics;
+* Criterion identity;
+* standard identity;
+* scorer identity;
+* or Score target identity.
+
+Those meanings resolve through the Artifact Page and linked Concord records.
 
 #### Cardinality
 
 * One Artifact Instance contains one or more Artifact Pages.
 * One Artifact Page belongs to exactly one Artifact Instance.
 * One Artifact Page may have zero or many Scan References.
-* One Scan Reference should identify one source page associated with one Artifact Page.
+* One route-required Artifact Page has exactly one immutable Core route registration.
+* One Scan Reference identifies one source page or defined region associated with one Artifact Page.
 
+Non-returned instructional scaffolds may omit a route when the Template Version declares that the page is not evidence-bearing.
 ## 8. Authorship and Subject Relationships
 
 ### 8.1 Artifact Author
@@ -731,7 +1106,6 @@ The initial model does not require handwriting-region extraction. A Score Eviden
 * student label;
 * criterion column;
 * or teacher-entered note.
-
 ## 9. Evidence, Scans, Review, and Moderation
 
 ### 9.1 Evidence as a domain role
@@ -744,26 +1118,34 @@ The following may function as evidence:
 * one Artifact Page;
 * a teacher observation;
 * a moderated peer observation;
-* a reviewed attachment;
-* a contribution claim;
+* a reviewed Attachment;
+* a Contribution Claim;
+* an Activity Event;
 * a teacher-entered rationale;
 * a ScoreForm result;
-* or a Quillan response.
+* a Quillan result;
+* or another authorized external record.
 
-The domain should therefore use a typed **Evidence Reference** rather than requiring every evidence source to be transformed into one universal evidence entity.
+The domain therefore uses a typed **Evidence Reference** rather than requiring every source to become one universal Evidence entity.
 
 An Evidence Reference should identify:
 
-* evidence source type;
+* evidence source kind;
+* owning system;
 * durable source identifier;
-* optional page or location;
-* optional subject context;
+* optional public contract version;
+* optional page or source location;
+* optional Subject context;
 * optional relevance note;
-* and optional moderation requirement.
+* and optional Moderation requirement.
+
+Evidence ownership remains with the source record’s owner.
+
+A reference to evidence does not create a Score.
 
 ### 9.2 Scan Reference
 
-A **Scan Reference** is a Concord-owned routed reference to a source scan retained by Core.
+A **Scan Reference** is a Concord-owned routed association between one Artifact Page and one page or defined region of a Core-retained source scan.
 
 It should contain:
 
@@ -771,22 +1153,45 @@ It should contain:
 * `artifact_page_id`;
 * Core source-scan reference;
 * source page index;
-* routed representation reference where applicable;
+* routed derivative reference where applicable;
 * routing status;
 * readability status;
 * filing status;
-* provenance metadata required by Core;
+* review status;
+* whether the source is currently preferred for use;
+* provenance;
+* optional Status Reason;
 * and optional superseded Scan Reference.
 
 Concord does not own or replace the original source scan.
+
+#### PDS2 relationship
+
+The normal resolution chain is:
+
+```text
+PDS2 locator
+    -> Core Route Registration
+    -> Artifact Page
+    -> Artifact Instance
+    -> optional Packet Instance
+    -> Activity
+    -> optional Session and Group context
+    -> Artifact Authors
+    -> Artifact Subjects
+```
+
+Core retains the original source before module-specific processing.
+
+Concord creates the Scan Reference after dispatch and semantic validation.
 
 #### Cardinality
 
 * One Artifact Page may have zero or many Scan References.
 * One Core source scan may yield references for many Artifact Pages.
-* One Scan Reference links one source page or page region to one Artifact Page.
+* One Scan Reference links one source page or defined region to one Artifact Page.
 * One active routed source page should normally resolve to one Artifact Page after review.
-* Duplicate, conflicting, or corrected routing states must remain representable.
+* Duplicate, conflicting, rescanned, misrouted, and corrected states remain representable.
 
 ### 9.3 Artifact Review
 
@@ -801,16 +1206,24 @@ It should contain:
 * scan-readability judgment;
 * page-completeness judgment;
 * filing confirmation;
-* author confirmation or correction;
-* subject confirmation or correction;
+* Author confirmation or correction;
+* Subject confirmation or correction;
 * privacy confirmation or override;
 * relevance judgment;
-* moderation requirement;
+* Moderation requirement;
 * scoring-readiness status;
+* review outcome;
 * notes;
-* and optional superseded Review reference.
+* privacy policy;
+* and optional superseded Review.
 
 A Review may confirm or correct metadata, but it must not modify the source scan.
+
+Review determines administrative and evidentiary readiness.
+
+It does not determine performance.
+
+It does not create a Score.
 
 #### Cardinality
 
@@ -821,26 +1234,29 @@ A Review may confirm or correct metadata, but it must not modify the source scan
 
 ### 9.4 Moderation Record
 
-A **Moderation Record** documents a teacher’s judgment about the reliability, fairness, relevance, or permissible use of evidence.
+A **Moderation Record** documents an authorized judgment about the reliability, fairness, relevance, credibility, or permissible use of evidence.
 
 Moderation is especially important for:
 
 * peer observations;
 * student-created claims about other students;
 * disputed contribution records;
-* conflicting group accounts;
-* and incomplete or questionable evidence.
+* conflicting Group accounts;
+* incomplete or questionable evidence;
+* and evidence proposed for consequential individual scoring.
 
 A Moderation Record should contain:
 
 * durable `moderation_record_id`;
 * moderator reference;
-* target evidence reference;
-* optional target subject;
-* moderation status;
-* qualification or rationale;
-* permitted scoring use;
+* target Evidence Reference;
+* optional target Subjects;
+* Moderation status;
+* qualification where required;
+* permitted use;
+* rationale;
 * timestamp;
+* privacy policy;
 * and optional superseded Moderation Record.
 
 Possible statuses include:
@@ -856,12 +1272,23 @@ Possible statuses include:
 
 * One evidence source may have zero or many Moderation Records.
 * One Moderation Record evaluates exactly one primary evidence source or claim.
-* One Moderation Record may apply to one or several Subjects if explicitly identified.
-* Evidence requiring moderation must not support a consequential score until an applicable moderation decision exists.
+* One Moderation Record may apply to one or several Subjects when explicitly identified.
+* Evidence requiring Moderation must not support a consequential Score until an applicable permitted-use decision exists.
+
+#### Invariants
+
+* Moderation evaluates evidence use, not performance.
+* Accepted evidence is not a high Score.
+* Rejected evidence is not negative evidence against a Subject.
+* Moderation does not select the Criterion, Score target, standard, scale value, or final Score.
+* Superseded decisions remain available.
 
 ### 9.5 Correction and Supersession
 
-The initial model should support a general **Correction Record** or equivalent append-only correction relationship.
+Concord uses a hybrid correction model:
+
+1. same-type replacement records use explicit supersession relationships; and
+2. a general **Correction Record** explains the correction, actor, reason, and old-to-new relationship.
 
 A Correction Record should identify:
 
@@ -869,78 +1296,209 @@ A Correction Record should identify:
 * target record type and identifier;
 * correction type;
 * reason;
-* correcting actor;
+* correcting Actor;
 * timestamp;
 * replacement or superseding record where applicable;
+* optional supporting source;
+* privacy policy;
 * and optional note.
 
 Corrections may apply to:
 
 * filing metadata;
-* author attribution;
-* subject attribution;
-* Group membership;
-* role or responsibility assignment;
+* Author attribution;
+* Subject attribution;
+* Group Membership;
+* Role or Responsibility Assignment;
 * Scan Reference;
 * Review;
 * Moderation Record;
+* Criterion revision;
 * Score Record;
-* or optional activity-context records.
+* or optional Activity-context records.
 
 The original record remains available for provenance.
 
+A current-record designation is a retrieval aid, not deletion of history.
 ## 10. Criteria and Scoring
 
-### 10.1 Criterion Set
+Concord’s primary academic scoring model is standards-based.
 
-A **Criterion Set** is a reusable or activity-specific collection of related Criteria.
+The model also preserves local Criteria and local Scores where direct standards judgment is not intended.
 
-It should contain:
+### 10.1 Core standards context
 
-* durable `criterion_set_id`;
+Core owns:
+
+* shared standard definitions;
+* standards profiles;
+* durable `standard_id` values;
+* durable `profile_id` values;
+* display metadata;
+* profile membership;
+* active, inactive, and deprecated status;
+* browsing and selection;
+* and module-neutral validation.
+
+Concord stores durable Core references and owns their Activity-, Criterion-, Score-, and workflow-specific meaning.
+
+The principal standards references are:
+
+* `standards_profile_id` on a `standards_based` or `mixed` Activity;
+* ordered `focus_standard_ids` on that Activity;
+* exactly one governing `standard_id` on a standard-backed Criterion;
+* optional non-governing `alignment_standard_ids` on a local Criterion;
+* and the governing `standard_id` on a standard-backed Score Record.
+
+Display codes, short names, titles, and descriptions are not durable identities.
+
+### 10.2 Criterion Set
+
+A **Criterion Set** is one immutable revision of an ordered collection of related Criteria.
+
+Each revision should contain:
+
+* durable immutable `criterion_set_id`;
+* stable `lineage_id`;
 * name;
 * purpose;
-* version or revision;
-* scope;
+* revision label or sequence;
+* reusable or Activity-specific scope;
+* required classification as `standard_backed`, `local`, or `mixed`;
+* optional Core standards-profile context;
 * ordered Criterion references;
-* optional Core standards references;
 * lifecycle status;
-* and creation provenance.
+* creation provenance;
+* and optional superseded Criterion Set revision.
 
-An Activity may select one or more Criterion Sets.
+#### Classification
 
-A Criterion Set should be immutable after scores reference it. Changes require a new revision.
+```text
+standard_backed
+local
+mixed
+```
 
-### 10.2 Criterion
+A `standard_backed` Criterion Set contains only standard-backed Criteria.
+
+A `local` Criterion Set contains only local Criteria.
+
+A `mixed` Criterion Set may contain both.
+
+#### Cardinality and invariants
+
+* One Criterion Set contains one or more Criteria.
+* One Activity may select zero or many Criterion Sets.
+* One Criterion Set revision may be selected by zero or many Activities.
+* A Criterion Set becomes immutable once selected by an Activity that produces Scores.
+* Changes to Criterion membership, order, definition, governing standards, target applicability, classification, or scoring meaning require a new revision.
+* Historical Scores retain the exact referenced Criterion and Set revision.
+* Selecting a Criterion Set does not create Scores.
+
+### 10.3 Criterion
 
 A **Criterion** defines one aspect of performance, process, contribution, or product quality.
 
-Examples include:
+Every Criterion used for scoring is classified as:
 
-* responds to peers’ ideas;
-* uses evidence in decisions;
-* fulfills responsibilities;
-* contributes to testing;
-* supports Group coordination;
-* or improves the shared product.
+```text
+standard_backed
+local
+```
 
 A Criterion should contain:
 
-* durable `criterion_id`;
-* parent Criterion Set;
+* durable immutable `criterion_id`;
+* parent Criterion Set revision;
 * stable key;
 * teacher-facing label;
 * definition;
-* supported score-target types;
-* optional default Scoring Scale;
-* optional standards references;
-* and lifecycle status.
+* required Criterion classification;
+* exactly one governing `standard_id` when standard-backed;
+* optional non-governing `alignment_standard_ids` when local;
+* supported Score-target types;
+* optional default Scoring Scale revision;
+* lifecycle status;
+* and creation provenance.
 
-Criteria should describe performance rather than personality.
+#### Standard-backed Criterion
 
-### 10.3 Scoring Scale
+A standard-backed Criterion defines how one selected Focus Standard will be judged in an Activity context.
 
-A **Scoring Scale** defines the permitted values and meanings used by Score Records.
+Conceptually:
+
+```text
+criterion_kind: standard_backed
+standard_id: <one durable Core standard_id>
+```
+
+Example:
+
+```text
+Standard:
+njsls-ela:SL.PE.9-10.1
+
+Activity-specific Criterion:
+Builds on peers' ideas and responds substantively during collaborative discussion
+```
+
+The Activity-specific definition may clarify what the shared standard looks like in:
+
+* a seminar;
+* a laboratory;
+* a programming project;
+* an engineering challenge;
+* or another collaborative context.
+
+It does not redefine the Core-owned standard.
+
+A standard-backed Criterion used by an Activity must govern exactly one standard in that Activity’s ordered Focus Standards.
+
+#### Local Criterion
+
+A local Criterion evaluates an Activity-specific, procedural, organizational, or collaborative expectation that is not a direct standards rating.
+
+Conceptually:
+
+```text
+criterion_kind: local
+standard_id: absent
+```
+
+Examples include:
+
+* returns shared materials;
+* performs an assigned observer rotation;
+* records a component handoff;
+* follows a local discussion protocol;
+* or maintains an Activity-specific version log.
+
+A local Criterion may include optional `alignment_standard_ids`.
+
+Those references document instructional relevance only.
+
+A Score against the local Criterion must not become a direct rating for any aligned standard.
+
+#### Multi-standard or holistic Criteria
+
+One direct Score must not govern several standards.
+
+When one classroom behavior reflects several standards, Concord should ordinarily use:
+
+* several standard-backed Criteria;
+* and several separate Score Records.
+
+A holistic Criterion spanning several standards must be modeled as:
+
+* a local Criterion with non-governing alignment references;
+* several separate standard-backed Criteria;
+* or a future explicitly defined composite contract.
+
+A future reporting module must not split one holistic Score across several standards automatically.
+
+### 10.4 Scoring Scale
+
+A **Scoring Scale** defines one immutable revision of the values and meanings used by Score Records.
 
 It may be:
 
@@ -952,75 +1510,186 @@ It may be:
 
 A Scoring Scale should contain:
 
-* durable `scoring_scale_id`;
+* durable immutable `scoring_scale_id`;
+* stable `lineage_id`;
 * name;
-* version or revision;
+* revision label or sequence;
 * scale type;
 * permitted values or levels;
 * level labels and descriptions;
-* optional aggregation guidance;
+* ordering where applicable;
+* optional non-binding aggregation guidance;
 * lifecycle status;
-* and creation provenance.
+* creation provenance;
+* and optional superseded Scoring Scale revision.
 
-A scale used by an existing Score Record must remain reproducible. Changes require a new revision.
+A scale used by an existing Score Record must remain reproducible.
 
-### 10.4 Score Record
+Changes require a new Scoring Scale revision.
+
+A future grading and reporting module must not assume that similarly numbered scales are semantically equivalent.
+
+### 10.5 Score Record
 
 A **Score Record** is one teacher-approved judgment about one Criterion for one target.
 
-It should contain:
+Every Score is classified as:
+
+```text
+standard_backed
+local
+```
+
+The classification must match the referenced Criterion.
+
+A Score Record should contain:
 
 * durable `score_record_id`;
 * `activity_id`;
 * optional `session_id`;
-* typed score-target reference;
-* `criterion_id`;
+* exactly one typed Score-target reference;
+* exact immutable `criterion_id`;
+* required Score classification;
+* governing `standard_id` when standard-backed;
 * exact Scoring Scale revision;
-* score disposition;
-* score value when applicable;
+* Score disposition;
+* Score value when applicable;
+* basis;
 * scorer reference;
 * scoring timestamp;
-* optional rationale;
-* optional moderation-complete status;
+* rationale where required;
+* optional Status Reason;
+* whether required Moderation is complete;
+* privacy policy;
 * and optional superseded Score Record.
 
-Score-target types may include:
+#### Standard-backed Score
 
-* student;
-* Group;
-* subteam represented as Group;
+A standard-backed Score is a direct contextual Concord judgment about one standard.
+
+It must reference:
+
+* one standard-backed Criterion;
+* the same one governing `standard_id`;
+* one target;
+* one exact Scoring Scale revision;
+* one scorer;
+* and one decision time.
+
+Conceptually:
+
+```text
+one Score Record
+    -> one standard-backed Criterion
+    -> one standard_id
+    -> one Score target
+    -> one Scoring Scale revision
+```
+
+The direct `standard_id` on the Score Record is a historical and interoperability field.
+
+It must match the immutable referenced Criterion.
+
+A standard-backed Score is not automatically:
+
+* mastery;
+* a final standards rating;
+* a marking-period result;
+* or a course Grade.
+
+#### Local Score
+
+A local Score evaluates one local Criterion.
+
+It must reference:
+
+* one local Criterion;
+* no governing `standard_id`;
+* one target;
+* and one exact Scoring Scale revision.
+
+Optional Criterion alignment does not convert the Score into a direct standards result.
+
+#### Score-target types
+
+Initial target kinds may include:
+
+* Core student;
+* Concord Group;
 * Session;
 * Artifact Instance;
-* activity component;
+* Work Item;
+* Activity component;
 * or Activity.
+
+A Group target does not imply individual Scores for Group members.
 
 #### Score disposition
 
-A Score Record should distinguish:
+A Score Record distinguishes:
 
-* scored;
-* insufficient evidence;
-* absent;
-* excused;
-* not observed;
-* not applicable;
-* or deferred.
+* `scored`;
+* `insufficient_evidence`;
+* `absent`;
+* `excused`;
+* `not_observed`;
+* `not_applicable`;
+* or `deferred`.
 
-When the disposition is `scored`, a valid scale value is required.
+When `disposition = scored`:
 
-When the disposition is not `scored`, a low or zero score must not be inferred automatically.
+* a valid value from the exact Scoring Scale revision is required;
+* the scorer and decision time are required;
+* and required Moderation must be complete.
 
-#### Cardinality
+When the disposition is not `scored`:
 
-* One Criterion may be used by zero or many Score Records.
-* One target may have zero or many Score Records.
-* One Score Record evaluates exactly one Criterion for exactly one target.
-* One Score Record may have zero or many Score Evidence Links.
-* One Score Record may supersede zero or one earlier Score Record.
+* a value is forbidden;
+* zero or the lowest scale level must not be inferred;
+* and a Status Reason may be required by workflow policy.
 
-A teacher may enter a Score using professional judgment without one controlling Artifact, but the Score should retain a rationale and scorer provenance.
+#### Score basis
 
-### 10.5 Score Evidence Link
+Initial basis values are:
+
+```text
+linked_evidence
+professional_judgment
+mixed_basis
+```
+
+A teacher may enter a Score through professional judgment without one controlling Artifact.
+
+When no formal Score Evidence Link exists:
+
+* rationale is required;
+* scorer provenance is required;
+* and the Activity context must be explicit.
+
+#### Individual Scores and Group evidence
+
+An individual Score does not require an exclusively individual evidence source.
+
+A teacher may use Group or multi-subject evidence when:
+
+* the evidence is relevant to the individual target;
+* any required Moderation permits that use;
+* the Score is an explicit teacher judgment;
+* and the rationale or evidence-link description explains the individual relevance.
+
+Group evidence must never generate individual Scores automatically.
+
+#### Group standards Scores
+
+A standard-backed Score may target a Group when:
+
+* the governing standard validly supports Group-level judgment;
+* the Criterion supports Group targets;
+* and the teacher deliberately selects the Group target.
+
+A Group standards Score does not become an individual standards Score for each Group member.
+
+### 10.6 Score Evidence Link
 
 A **Score Evidence Link** associates one Score Record with one evidence source.
 
@@ -1029,57 +1698,157 @@ It should contain:
 * durable `score_evidence_link_id`;
 * `score_record_id`;
 * typed Evidence Reference;
-* optional evidence locator;
-* relevance or use description;
-* optional weight or significance note;
-* moderation status where applicable;
-* and creation provenance.
+* optional Evidence Locator;
+* optional Subject context;
+* required relevance description;
+* optional significance;
+* applicable Moderation Record where required;
+* lifecycle status;
+* creation provenance;
+* and optional superseded Score Evidence Link.
+
+Possible significance values include:
+
+* primary;
+* corroborating;
+* contextual;
+* qualifying;
+* counterevidence;
+* and background.
 
 #### Cardinality
 
 * One Score Record may link to zero or many evidence sources.
 * One evidence source may support zero or many Score Records.
-* Individual, Group, and subteam Scores may cite overlapping evidence.
-* Overlapping evidence does not make those Scores equivalent.
+* Individual and Group Scores may cite overlapping evidence.
+* One source may support several standard-backed Scores.
+* One standard-backed Score may use several sources.
 
-#### Invariant
+#### Invariants
 
-Group evidence or a Group score must not automatically generate or populate an individual Score Record.
+* Overlapping evidence does not make Scores equivalent.
+* Link count does not determine Score value.
+* Numeric evidence weighting is not required.
+* Rejected evidence must not remain an active supporting link for a consequential Score.
+* Historical links remain associated with historical Scores.
+* Group evidence does not automatically create individual Scores.
 
-An individual score requires an explicit teacher judgment.
+### 10.7 Standards Result Handoff Projection
 
+A **Standards Result Handoff Projection** is a future derived interoperability view of canonical standard-backed Score Records.
+
+It is not a replacement for:
+
+* the Score Record;
+* Criterion;
+* Activity;
+* Score Evidence Links;
+* Moderation Records;
+* or source evidence.
+
+The projection exists so a future grading and reporting module does not need to infer standards meaning from generic Criteria.
+
+A future handoff must expose at least:
+
+* `module_id = concord`;
+* Core class identity;
+* `activity_id`;
+* optional `session_id`;
+* `score_record_id`;
+* typed Score target;
+* governing `standard_id`;
+* exact `criterion_id`;
+* exact `scoring_scale_id`;
+* disposition;
+* value when scored;
+* scorer;
+* scoring timestamp;
+* evidence-link references;
+* Moderation-complete state;
+* supersession relationship;
+* and whether the Score is current or superseded.
+
+#### Invariants
+
+* Only standard-backed Scores enter the direct standards-result projection.
+* Local Scores are excluded from direct standards-result handoff.
+* Non-score dispositions remain explicit and are not converted to zero.
+* Group and individual targets remain distinguishable.
+* External evidence remains distinguishable from Concord-owned judgment.
+* The projection does not calculate mastery, Grades, weights, averages, growth, or cross-scale normalization.
 ## 11. External References
 
-An **External Reference** represents a relationship to a record owned by another module or system.
+An **External Reference** represents a relationship to a record owned by another PDS module or external system.
 
 It should contain:
 
 * durable `external_reference_id`;
 * owning module or system;
-* external record type;
+* external record kind;
 * external record identifier;
+* optional public contract version;
 * relationship purpose;
-* related Concord Activity, Session, Artifact, Criterion, or Score;
+* related Concord Activity;
+* optional Session, Group, Activity Marker, Work Item, Artifact, Criterion, Score, or Subject context;
 * availability status;
+* optional provider-neutral locator;
 * optional descriptive label;
-* and creation provenance.
+* last-confirmed timestamp where available;
+* creation provenance;
+* and optional superseded External Reference.
 
 Possible external references include:
 
 * ScoreForm assignment;
 * ScoreForm result;
 * Quillan assignment;
-* Quillan response;
+* Quillan response or standards result;
 * Core standards profile;
 * Core standard;
 * future lesson-plan record;
-* future gradebook record;
-* or authorized external artifact location.
+* future grading and reporting record;
+* source-control record;
+* or authorized external Artifact location.
 
-Concord should not copy the external record’s full content when a stable reference is sufficient.
+Possible relationship purposes include:
+
+* related assignment;
+* packet instruction;
+* individual accountability check;
+* supporting evidence;
+* complementary written response;
+* prerequisite check;
+* follow-up reflection;
+* Score evidence;
+* contextual result;
+* or downstream export relationship.
+
+Concord should not copy an external record’s full content when a stable reference is sufficient.
 
 An unavailable external record should remain an explicit unavailable reference rather than being treated as missing student performance.
 
+### Standards-related external evidence
+
+A ScoreForm or Quillan result may support a Concord standard-backed Score through:
+
+```text
+external result
+    -> Concord External Reference
+    -> Evidence Reference
+    -> Score Evidence Link
+    -> explicit Concord Score Record
+```
+
+The external module remains authoritative for its own result.
+
+The Concord Score remains authoritative for the Concord Activity judgment.
+
+Concord must not:
+
+* infer a Concord Score merely because an external record cites the same standard;
+* convert ScoreForm percent correct automatically into a Concord rating;
+* import Quillan review-unit workflow;
+* or create a direct runtime package dependency on ScoreForm or Quillan.
 ## 12. Optional Context and Extension Concepts
 
 The following concepts belong in the Concord domain but should not be required for every Activity.
@@ -1228,40 +1997,47 @@ An Attachment is distinct from a Scan Reference:
 
 * a Scan Reference links a Core-retained source scan to an Artifact Page;
 * an Attachment identifies related work that may have its own file, photograph, cover sheet, or external location.
-
 ## 13. Cardinality Summary
 
-| Relationship                                  | Cardinality         |
-| --------------------------------------------- | ------------------- |
-| Core Class → Activity                         | One to zero-or-many |
-| Activity → Session                            | One to one-or-many  |
-| Activity → Group                              | One to zero-or-many |
-| Group → child Group                           | One to zero-or-many |
-| Group → Group Membership                      | One to zero-or-many |
-| Participant → Group Membership                | One to zero-or-many |
-| Membership/participant → Role Assignment      | One to zero-or-many |
+| Relationship | Cardinality |
+| --- | --- |
+| Core Class → Activity | One to zero-or-many |
+| Core Standards Profile → standards-based or mixed Activity | One to zero-or-many |
+| Activity → Focus Standard | One to one-or-many when standards configuration is required |
+| Activity → Session | One to one-or-many |
+| Activity → Group | One to zero-or-many |
+| Group → child Group | One to zero-or-many |
+| Group → Group Membership | One to zero-or-many |
+| Participant → Group Membership | One to zero-or-many |
+| Membership/participant → Role Assignment | One to zero-or-many |
 | Participant/Group → Responsibility Assignment | One to zero-or-many |
-| Template Definition → Template Version        | One to one-or-many  |
-| Packet Definition → Packet Component          | One to one-or-many  |
-| Template Version → Packet Component           | One to zero-or-many |
-| Packet Definition → Packet Instance           | One to zero-or-many |
-| Activity → Packet Instance                    | One to zero-or-many |
-| Packet Instance → Artifact Instance           | One to one-or-many  |
-| Template Version → Artifact Instance          | One to zero-or-many |
-| Artifact Instance → Artifact Page             | One to one-or-many  |
-| Artifact Instance → Artifact Author           | One to zero-or-many |
-| Artifact Instance → Artifact Subject          | One to zero-or-many |
-| Artifact Page → Scan Reference                | One to zero-or-many |
-| Artifact Instance → Artifact Review           | One to zero-or-many |
-| Evidence source → Moderation Record           | One to zero-or-many |
-| Criterion Set → Criterion                     | One to one-or-many  |
-| Activity → Criterion Set                      | Many-to-many        |
-| Criterion → Score Record                      | One to zero-or-many |
-| Score target → Score Record                   | One to zero-or-many |
-| Score Record → Score Evidence Link            | One to zero-or-many |
-| Evidence source → Score Evidence Link         | One to zero-or-many |
-| Concord record → External Reference           | One to zero-or-many |
-
+| Template Definition → Template Version | One to one-or-many |
+| Packet Definition → Packet Version | One to one-or-many |
+| Packet Version → Packet Component | One to one-or-many |
+| Template Version → Packet Component | One to zero-or-many |
+| Packet Version → Packet Instance | One to zero-or-many |
+| Activity → Packet Instance | One to zero-or-many |
+| Packet Instance → Artifact Instance | One to one-or-many |
+| Template Version → Artifact Instance | One to zero-or-many |
+| Artifact Instance → Artifact Page | One to one-or-many |
+| Core Route Registration → route-required Artifact Page | One to one |
+| Artifact Instance → Artifact Author | One to zero-or-many |
+| Artifact Instance → Artifact Subject | One to zero-or-many |
+| Artifact Page → Scan Reference | One to zero-or-many |
+| Core Source Scan → Scan Reference | One to zero-or-many |
+| Artifact Instance → Artifact Review | One to zero-or-many |
+| Evidence source → Moderation Record | One to zero-or-many |
+| Criterion Set → Criterion | One to one-or-many |
+| Activity → Criterion Set | Many-to-many |
+| Core Standard → standard-backed Criterion | One to zero-or-many |
+| Core Standard → local Criterion alignment | Many-to-many, non-governing |
+| Criterion → Score Record | One to zero-or-many |
+| Score target → Score Record | One to zero-or-many |
+| Standard-backed Score Record → Core Standard | Many-to-one |
+| Score Record → Score Evidence Link | One to zero-or-many |
+| Evidence source → Score Evidence Link | One to zero-or-many |
+| Standard-backed Score Record → Standards Result Handoff Projection | One to zero-or-one derived current view |
+| Concord record → External Reference | One to zero-or-many |
 ## 14. Lifecycle Relationships
 
 ### 14.1 Activity lifecycle
@@ -1274,53 +2050,105 @@ draft
   -> archived
 ```
 
-An Activity may also be cancelled. Cancellation must not remove already generated evidence.
+An Activity may also be cancelled.
 
-### 14.2 Packet and artifact lifecycle
+Cancellation must not remove already generated evidence.
+
+Configuration includes:
+
+* class and Activity identity;
+* scoring orientation;
+* standards profile and Focus Standards when required;
+* selected Criterion Sets;
+* optional Groups, Roles, Responsibilities, and packet choices;
+* and applicable privacy defaults.
+
+An Activity must not enter standards-based or mixed scoring workflows until its standards references and standard-backed Criteria validate.
+
+### 14.2 Packet and Artifact lifecycle
 
 ```text
 definition selected
-  -> packet instance generated
-  -> artifact instances generated
+  -> immutable version selected
+  -> Packet Instance generated
+  -> Artifact Instances generated
+  -> Artifact Pages and routes created
   -> pages printed/distributed
   -> evidence expected
   -> pages returned
-  -> scans retained by Core
-  -> pages identified and filed by Concord
-  -> artifacts reviewed
-  -> moderation completed where required
-  -> evidence ready for scoring
-  -> scores recorded
+  -> source scans retained by Core
+  -> PDS2 routes resolved
+  -> Scan References created by Concord
+  -> Artifacts reviewed
+  -> Moderation completed where required
+  -> evidence ready for possible scoring
+  -> Scores recorded
   -> records retained or archived
 ```
 
-Not every Artifact will pass through every step.
+Not every Artifact passes through every step.
 
 Examples:
 
 * a non-returned scaffold stops after distribution;
 * a missing Artifact never reaches scan review;
-* a peer observation requires moderation;
-* a teacher tracker may move directly from review to scoring use.
+* a peer observation requires Moderation;
+* a teacher tracker may move directly from Review to scoring use;
+* and an evidence-only Activity may never create Scores.
 
-### 14.3 Independent status dimensions
+### 14.3 Standard-backed Score lifecycle
 
-The initial contracts should avoid one overly broad status field when several independent facts exist.
+```text
+Focus Standard selected
+  -> standard-backed Criterion selected
+  -> evidence collected and reviewed
+  -> Moderation completed where required
+  -> teacher records standard-backed Score or non-score disposition
+  -> Score becomes available to standards-result handoff
+  -> later Score may supersede it
+  -> historical Score remains available
+```
+
+The following do not create a standards Score:
+
+* selecting a Focus Standard;
+* attaching a standard to a Criterion Set;
+* printing a standards-aligned form;
+* receiving an Artifact;
+* completing Review;
+* accepting evidence through Moderation;
+* or linking an external standards-related result.
+
+The explicit teacher-approved standard-backed Score Record is the direct Concord standards result.
+
+### 14.4 Independent status dimensions
+
+The contracts should avoid one overly broad status field when several independent facts exist.
 
 An Artifact may separately have:
 
 * generation status;
 * expected-return status;
+* page status;
 * scan status;
 * filing status;
-* review status;
-* moderation status;
+* Review status;
+* Moderation status;
 * scoring-readiness status;
 * and supersession status.
 
+A Score separately has:
+
+* standard-backed or local classification;
+* disposition;
+* value state;
+* basis;
+* Moderation-complete state;
+* and current or superseded state.
+
 This prevents ambiguous states such as treating “reviewed” as meaning “complete, accepted, moderated, and scored.”
 
-### 14.4 Correction lifecycle
+### 14.5 Correction lifecycle
 
 ```text
 original record
@@ -1330,9 +2158,10 @@ original record
   -> original remains available for provenance
 ```
 
+Changes to governing standard, Criterion classification, Criterion meaning, Scoring Scale meaning, or consequential Score create new immutable revisions or superseding records.
 ## 15. Durable Identifier Requirements
 
-The following should have durable identifiers:
+The following should have durable Concord identifiers:
 
 * Activity;
 * Session;
@@ -1343,6 +2172,8 @@ The following should have durable identifiers:
 * Template Definition;
 * Template Version;
 * Packet Definition;
+* Packet Version;
+* Packet Component;
 * Packet Instance;
 * Artifact Instance;
 * Artifact Page;
@@ -1351,9 +2182,9 @@ The following should have durable identifiers:
 * Scan Reference;
 * Artifact Review;
 * Moderation Record;
-* Criterion Set;
+* Criterion Set revision;
 * Criterion;
-* Scoring Scale;
+* Scoring Scale revision;
 * Score Record;
 * Score Evidence Link;
 * External Reference;
@@ -1365,28 +2196,52 @@ The following should have durable identifiers:
 * Contribution Claim;
 * and Attachment.
 
-Identifier formats are owned by shared Core conventions.
+`activity_id` is also Concord’s Core `work_id`.
+
+Core owns the identifiers for:
+
+* class;
+* student;
+* standards profile;
+* standard;
+* Route Registration;
+* source scan;
+* and other Core records.
+
+Concord stores those as typed references rather than issuing replacement identities.
+
+Identifier formats are governed by shared Core conventions and later Concord contracts.
 
 Identifiers must:
 
 * be stable;
+* be opaque;
 * avoid student names or other direct PII;
 * remain safe for local paths when used in paths;
-* and remain usable after display names, Group labels, or titles change.
+* remain usable after display names, Group labels, standard display metadata, or titles change;
+* and never be reused for a different record.
+
+Stable lineages and immutable revisions are distinct:
+
+* Template Definition uses `template_id`; each revision uses `template_version_id`.
+* Packet Definition uses `packet_definition_id`; each revision uses `packet_version_id`.
+* Criterion Set revisions use immutable `criterion_set_id` plus stable `lineage_id`.
+* Scoring Scale revisions use immutable `scoring_scale_id` plus stable `lineage_id`.
 
 The following are normally value objects rather than independently identified records:
 
 * privacy classification;
 * role key;
 * authorship mode;
-* subject type;
-* evidence locator;
-* score disposition;
-* status reason;
+* Subject type;
+* Evidence Locator;
+* Score disposition;
+* Status Reason;
 * event type;
 * contribution type;
-* and page position.
-
+* page position;
+* Activity scoring orientation;
+* and Criterion classification.
 ## 16. Privacy Model
 
 Privacy should be attached to evidence-bearing and judgment-bearing records.
@@ -1399,194 +2254,313 @@ At minimum, privacy must be supported on:
 * Contribution Claim;
 * Attachment;
 * Score Record;
+* Correction Record;
+* Activity Event where sensitive;
 * and teacher-entered notes.
 
-The effective privacy level may be inherited from a Template Version and overridden by the generated record.
+The effective privacy policy may be inherited from a Template Version and overridden by the generated record.
 
 A child or derived record may become more restrictive than its parent.
+
+A child must not become less restrictive automatically.
 
 For example:
 
 * a Group process sheet may be Group-and-teacher;
+* a peer observation may be teacher-restricted;
 * a teacher note about a dispute may be teacher-restricted;
-* a Score Record may be visible only to the teacher and scored subject.
+* a standard-backed Score may be visible to the teacher and scored Subject;
+* and a Moderation rationale may remain more restricted than the resulting Score.
 
-A less restrictive child privacy setting must not be inferred automatically from a parent record.
+Access to a Score does not imply access to every supporting evidence source.
 
-The exact shared privacy vocabulary remains to be coordinated with Core.
+Author, Subject, Group Membership, Score target, and audience are separate concepts.
 
+The initial minimum privacy vocabulary may include:
+
+* `teacher_restricted`;
+* `teacher_and_subjects`;
+* `group_and_teacher`;
+* `classroom_shared`;
+* `inherited`;
+* and `external_policy`.
+
+Final suite-wide ownership of the privacy vocabulary remains to be coordinated with Core.
+
+Sensitive medical, disability, counseling, or disciplinary details must not be copied into Concord merely to explain a restriction or exception.
 ## 17. Domain Invariants
 
 The following rules must be preserved by all later contracts and implementations.
 
-1. **The retained source scan is canonical evidence.**
-   Routed files, metadata, notes, reviews, and scores do not replace it.
+1. **The retained source scan is canonical evidence.**  
+   Routed derivatives, metadata, notes, Reviews, Moderation decisions, and Scores do not replace it.
 
-2. **Author and subject are separate relationships.**
-   They must never be inferred to be the same merely because only one student is named.
+2. **PDS2 identifies a physical route, not full semantic context.**  
+   The QR contains module, class, work, and route identity. Artifact Page and linked Concord records provide Authors, Subjects, Group, Session, Criterion, standard, and Score meaning.
 
-3. **Authorship is not inferred from physical or digital possession.**
-   Handwriting, recorder status, account ownership, and file ownership do not establish sole authorship.
+3. **The route target is an existing Artifact Page.**  
+   The Artifact Page exists before its Route Registration and QR are created.
 
-4. **Roles, responsibilities, tasks, and contributions are distinct.**
-   One may inform another, but none proves the others automatically.
+4. **`activity_id` is Concord’s Core `work_id`.**  
+   The effective work identity is `module_id + class_id + activity_id`.
 
-5. **Assignment is not performance.**
-   Being assigned a role or responsibility does not prove fulfillment.
+5. **Author and Subject are separate relationships.**  
+   They must never be inferred to be the same merely because only one participant is named.
 
-6. **Missing evidence is not negative evidence.**
+6. **Authorship is not inferred from physical or digital possession.**  
+   Handwriting, recorder status, account ownership, file ownership, scanning, and upload identity do not establish sole authorship.
+
+7. **Roles, Responsibilities, Work Items, and Contributions are distinct.**  
+   One may contextualize another, but none proves the others automatically.
+
+8. **Assignment is not performance.**  
+   Being assigned a Role or Responsibility does not prove fulfillment.
+
+9. **Missing evidence is not negative evidence.**  
    Missing, unreadable, misrouted, absent, excused, not observed, and insufficient-evidence states remain distinct.
 
-7. **External failure is not poor performance.**
-   Equipment failure, interruption, blocked work, dependency failure, or unavailable external files must be represented separately from neglect or low-quality work.
+10. **External failure is not poor performance.**  
+    Equipment failure, interruption, blocked work, dependency failure, or unavailable external records remain separate from neglect or low-quality work.
 
-8. **Moderation precedes consequential use when required.**
-   Peer evidence and disputed student-generated claims must receive human review before affecting a score.
+11. **Moderation precedes consequential use when required.**  
+    Peer evidence and disputed student-generated claims must receive authorized human review before affecting a consequential Score.
 
-9. **Group evidence does not automatically produce individual scores.**
-   An individual Score requires explicit teacher judgment.
+12. **Group evidence does not automatically produce individual Scores.**  
+    An individual Score requires an explicit teacher judgment.
 
-10. **Evidence and scores have a many-to-many relationship.**
-    One score may use several evidence sources, and one source may support several scores.
+13. **A Group Score does not become member Scores.**  
+    Target identity remains explicit.
 
-11. **Review, moderation, and scoring remain separate.**
-    Reviewing a scan does not imply accepting its claims or assigning a score.
+14. **Evidence and Scores have a many-to-many relationship.**  
+    One Score may use several sources, and one source may support several Scores.
 
-12. **A score is not a course grade.**
-    Concord records judgments about criteria or components. Grade calculation belongs elsewhere.
+15. **Review, Moderation, and Scoring remain separate.**  
+    Reviewing a scan does not accept its claims, and accepting evidence does not assign a Score.
 
-13. **History is preserved.**
-    Corrections, rescans, reassignments, revised decisions, and revised scores must not erase earlier records.
+16. **Concord’s primary academic scoring model is standards-based.**  
+    Standards-based and mixed Activities explicitly select a Core standards profile and ordered Focus Standards.
 
-14. **Definitions used by evidence are reproducible.**
-    Template Versions, Packet Definition revisions, Criterion Sets, Criteria, and Scoring Scales must remain identifiable after use.
+17. **Concord is not standards-exclusive.**  
+    Evidence-only, local-criteria-only, and mixed Activities remain valid.
 
-15. **Activity-specific vocabulary remains optional.**
+18. **A standard-backed Criterion governs exactly one standard.**  
+    A direct Score must not be split across several standards automatically.
+
+19. **A local Criterion has no governing standard.**  
+    Optional alignment references are non-governing.
+
+20. **Alignment is not a direct standards result.**  
+    A local Score does not enter the standards-result handoff merely because the local Criterion cites standards.
+
+21. **Focus Standard selection is not a Score.**  
+    Selection alone does not prove teaching, practice, assessment, demonstration, mastery, or Grade impact.
+
+22. **A standard-backed Score is explicit and teacher-approved.**  
+    It identifies one standard-backed Criterion, one governing `standard_id`, one target, one exact Scoring Scale revision, one scorer, and one decision time.
+
+23. **A Score is not mastery or a course Grade.**  
+    Concord records contextual judgments. Cross-Activity aggregation, weighting, normalization, mastery, and grading belong elsewhere.
+
+24. **Non-score dispositions are not low Scores.**  
+    Insufficient evidence, absence, excusal, not observed, not applicable, and deferred states must not become zero or the lowest scale value.
+
+25. **Zero is valid only when deliberately permitted and selected from the exact scale.**
+
+26. **External standards-related results do not automatically become Concord Scores.**  
+    ScoreForm and Quillan records may support a Concord judgment through explicit evidence relationships.
+
+27. **Core remains authoritative for standards identity and profiles.**  
+    Concord must not duplicate shared standard definitions or use display codes as durable keys.
+
+28. **Missing, inactive, or deprecated standards references preserve history.**  
+    Validation reports the problem without silently deleting or substituting Concord records.
+
+29. **Definitions used by evidence and Scores are reproducible.**  
+    Template Versions, Packet Versions, Criterion Set revisions, Criteria, and Scoring Scale revisions remain identifiable after use.
+
+30. **History is preserved.**  
+    Corrections, rescans, reassignments, revised decisions, revised Criteria, and revised Scores must not erase earlier records.
+
+31. **Activity-specific vocabulary remains optional.**  
     Seminar rotations, laboratory trials, project milestones, software builds, and similar terms must not become required fields in every Concord record.
 
-16. **External systems remain authoritative for their own records.**
-    Concord may reference ScoreForm, Quillan, Core, source-control, cloud-document, or institutional records but does not silently copy or replace their authority.
+32. **External systems remain authoritative for their own records.**  
+    Concord may reference Core, ScoreForm, Quillan, source-control, cloud-document, or institutional records but does not silently copy or replace their authority.
 
+33. **Privacy is record-specific.**  
+    Access to a Score does not imply access to all supporting evidence, and a child record must not become less restrictive automatically.
 ## 18. Domain Decisions Reached
 
-The initial domain model adopts the following decisions:
+The revised initial domain model adopts the following decisions.
 
-1. Concord uses its own `activity_id` while retaining a reference to Core’s assignment-routing context.
-2. Every Activity contains at least one Session.
-3. Groups are Activity-specific and Concord-owned.
-4. Temporary subteams are represented as Groups with a parent Group and bounded context.
-5. Group Membership is contextual and preserves historical changes.
-6. Role Assignment is a universal first-class relationship.
-7. Responsibility Assignment is a first-class but optional relationship.
-8. Packet Definitions and Template Versions are reusable definitions; Packet and Artifact Instances are generated records.
-9. Artifact Authors and Artifact Subjects are separate association records with flexible cardinality.
-10. Multi-subject teacher trackers remain single source Artifacts with several Subject relationships.
-11. Evidence is represented through typed references rather than one universal evidence entity.
-12. Scan References point to Core-retained source scans rather than duplicating source-scan ownership.
-13. Review and Moderation are separate concepts.
-14. Score Records evaluate one Criterion for one target.
-15. Score Evidence Links provide the many-to-many relationship between scores and evidence.
-16. Activity-specific decisions, tests, troubleshooting episodes, revisions, and handoffs initially share a typed Activity Event envelope.
-17. Milestones, phases, checkpoints, and iterations may share an optional Activity Marker concept.
-18. Tasks and components may share an optional Work Item concept.
-19. Attachments are distinct from normal Artifact Pages and Scan References.
-20. Corrections and superseding records preserve history rather than overwriting evidence.
+1. Concord uses `activity_id` as its Core `work_id`.
+2. The effective PDS2 work identity is `module_id + class_id + activity_id`.
+3. The canonical Concord work root is module-qualified.
+4. Every returnable scannable page is represented by an Artifact Page before route creation.
+5. The PDS2 Route Registration targets `record_kind = artifact_page`.
+6. The PDS2 locator carries route identity only; semantic context resolves through Concord records.
+7. Every Activity contains at least one Session.
+8. Every Activity declares one scoring orientation: evidence-only, standards-based, mixed, or local-criteria-only.
+9. Concord’s primary academic scoring model is standards-based.
+10. Concord remains capable of evidence-only and local-criterion workflows.
+11. Standards-based and mixed Activities select one Core standards profile and one or more ordered Focus Standards.
+12. Core owns standards identity, definitions, profiles, display metadata, and module-neutral validation.
+13. Criteria are classified as standard-backed or local.
+14. A standard-backed Criterion governs exactly one Focus Standard.
+15. A local Criterion has no governing standard but may carry non-governing alignment references.
+16. One direct Score must not be interpreted as several standards ratings.
+17. Score Records are classified as standard-backed or local and must match their Criteria.
+18. A standard-backed Score preserves the governing `standard_id` explicitly.
+19. Only standard-backed Scores enter the direct standards-result handoff projection.
+20. Local Scores and alignment-only records remain outside direct standards-result handoff.
+21. Standards-result handoff preserves Group versus individual targets and does not calculate mastery or Grades.
+22. Groups are Activity-specific and Concord-owned.
+23. Temporary subteams are represented as Groups with a parent Group and bounded context.
+24. Group Membership is contextual and preserves historical changes.
+25. Role Assignment is a universal first-class relationship.
+26. Responsibility Assignment is a first-class but optional relationship.
+27. Template Definition and Template Version are separate.
+28. Packet Definition and Packet Version are separate.
+29. Packet Components preserve ordered composition and external ownership.
+30. Packet and Artifact Instances are generated records tied to exact immutable versions.
+31. Artifact Authors and Artifact Subjects are separate association records with flexible cardinality.
+32. Multi-subject teacher trackers remain one source Artifact with several Subject relationships.
+33. Evidence is represented through typed references rather than one universal Evidence entity.
+34. Scan References point to Core-retained source scans rather than duplicating source ownership.
+35. Review and Moderation are separate.
+36. Score Records evaluate one Criterion for one target.
+37. Score Evidence Links provide a many-to-many relationship between Scores and evidence.
+38. Group evidence may support an individual Score only through explicit teacher judgment and relevance.
+39. Activity-specific decisions, tests, troubleshooting episodes, revisions, and handoffs initially share a typed Activity Event envelope.
+40. Milestones, phases, checkpoints, and iterations may share an optional Activity Marker.
+41. Tasks and components may share an optional Work Item.
+42. Attachments are distinct from normal Artifact Pages and Scan References.
+43. Both continuing and linked-series Packet Instance models are permitted for long-running Activities.
+44. Session identity is the primary effective-time unit for Memberships, Roles, and Responsibilities; Markers and sequence may refine it.
+45. Teachers and other authorized adults use typed Actor References; a mandatory Concord-local actor registry is not required by the foundation.
+46. Criterion Sets and Scoring Scales use immutable revision records with stable lineages.
+47. Concord uses same-type supersession plus a general Correction Record.
+48. Corrections and superseding records preserve history rather than overwriting evidence.
+49. External ScoreForm and Quillan records remain source-module-owned and may support, but do not determine, Concord Scores.
+50. Course-grade calculation, cross-module reporting, mastery, weighting, and scale conversion remain outside Concord.
+## 19. Deferred Implementation Questions
 
-## 19. Unresolved Questions
+The foundational domain decisions are sufficiently settled for representative contract examples and implementation planning.
 
-The following questions remain for architecture decisions or conceptual contract work:
+The following questions remain implementation-level or belong to later modules.
 
-1. What exact relationship should exist between Concord `activity_id` and Core `assignment_id`?
-2. Which Activity and Artifact context fields belong in the shared QR payload rather than the linked Artifact record?
-3. How will the shared QR contract represent Group, Session, Activity, Event, Artifact, and multi-subject scope without a required `student_id`?
-4. Does Core provide a durable teacher or authorized-adult identity, or must Concord define a local actor reference?
-5. What temporal precision should Group Membership, Role Assignment, and Responsibility Assignment use:
+1. What exact serialized schema versions will govern each record?
+2. What exact filesystem layout will be used beneath:
 
-   * Session;
-   * Session range;
-   * sequence within Session;
-   * named stage;
-   * or timestamp?
-6. Should Packet Definition versioning use a separate Packet Version entity or an immutable revision field on Packet Definition?
-7. Should a long-running project use one continuing Packet Instance or several linked Packet Instances?
-8. Which privacy classifications should be shared across PDS modules?
-9. Should Correction Record be one generic contract or should each record type use type-specific supersession fields?
-10. How much typed structure should Activity Event provide before specialized event contracts become necessary?
-11. Should an individual Score require at least one individual-specific evidence source?
-12. Should Criterion and Scoring Scale revisions be separate entities or immutable version fields?
-13. How should teacher-entered professional judgment be represented when no Artifact or external evidence record controls the Score?
-14. How should external digital locations be stored without assuming Git, Google Drive, or another provider?
-15. Which role, criterion, contribution, and event vocabularies should ship as starter data rather than domain requirements?
+   ```text
+   classes/<class_id>/modules/concord/work/<activity_id>/
+   ```
 
-## 20. Recommendations for Conceptual Contract Work
+3. What persistence service will create Scan References after successful Core dispatch?
+4. How will authorized-adult Actor References resolve when a broader suite identity capability becomes available?
+5. Which privacy classifications will ultimately move into a shared Core contract?
+6. What exact teacher workflow will present multiple standard-backed Criteria efficiently when one classroom behavior supplies evidence for several standards?
+7. What exact exported file, event, or API contract will carry the Standards Result Handoff Projection to the future grading and reporting module?
+8. Which ScoreForm and Quillan public record kinds and contract versions will Concord support first?
+9. Which role, Criterion, contribution, and Activity Event vocabularies should ship as starter data rather than domain requirements?
+10. When do repeated Activity Event extension fields justify specialized event contracts?
+11. What user-interface safeguards will make the distinction between:
 
-The initial conceptual contracts should be drafted in the following order.
+    * direct standard-backed Score;
+    * local Score;
+    * standards alignment;
+    * non-score disposition;
+    * and evidence-only status
+
+    unmistakable to teachers?
+12. What current-record indexing strategy will make supersession traversal efficient without weakening append-only history?
+13. Which cross-scale conversion, weighting, attempt-selection, and mastery policies will the future grading and reporting module adopt?
+
+Question 13 is explicitly outside Concord’s authority.
+
+No foundational question remains about whether Concord’s primary academic scoring model is standards-based.
+## 20. Recommendations for Representative Contract Work
+
+The next contract work should validate the domain in the following order.
 
 ### Phase 1: Shared reference primitives
 
-Define:
+Validate:
 
 * Concord identifier conventions;
 * Core class reference;
 * Core student reference;
-* actor reference;
-* subject reference;
-* score-target reference;
-* evidence reference;
-* privacy classification;
-* provenance fields;
+* Actor Reference;
+* Subject Reference;
+* Score-Target Reference;
+* Evidence Reference;
+* Core standards profile and standard references;
+* privacy policy;
+* provenance;
+* Effective Context;
 * and supersession references.
 
-### Phase 2: Activity context
+### Phase 2: Activity and scoring context
 
-Draft examples for:
+Draft complete examples for:
 
-* `activity`;
-* `session`;
-* `group`;
-* `group_membership`;
-* `role_assignment`;
-* and optional `responsibility_assignment`.
+* evidence-only Activity;
+* standards-based Activity;
+* mixed Activity;
+* local-criteria-only Activity;
+* Session;
+* Group;
+* Group Membership;
+* Role Assignment;
+* and optional Responsibility Assignment.
 
 Test them against:
 
 * seminar role rotation;
 * laboratory reassignment;
-* project membership changes;
+* project Membership changes;
 * absence;
 * late arrival;
-* and temporary subteams.
+* temporary subteams;
+* standards profile selection;
+* ordered Focus Standards;
+* and invalid or inactive standard references.
 
-### Phase 3: Definitions and generated artifacts
+### Phase 3: Definitions and generated Artifacts
 
-Draft examples for:
+Draft complete examples for:
 
-* `template_definition`;
-* `template_version`;
-* `packet_definition`;
-* `packet_instance`;
-* `artifact_instance`;
-* `artifact_page`;
-* `artifact_author`;
-* and `artifact_subject`.
+* Template Definition;
+* Template Version;
+* Packet Definition;
+* Packet Version;
+* Packet Component;
+* Packet Instance;
+* Artifact Instance;
+* Artifact Page;
+* Artifact Author;
+* and Artifact Subject.
 
 Test them against:
 
-* one student author and a different student subject;
-* one Group author;
+* one student Author and a different student Subject;
+* one Group Author;
 * one recorder acting for a Group;
 * one Artifact with several Subjects;
 * one Group Artifact with no individual student Subject;
-* and one teacher tracker spanning several Groups.
+* one teacher tracker spanning several Groups;
+* one Packet containing external module instructions;
+* and one PDS2 route per returnable Artifact Page.
 
-### Phase 4: Scan, review, and moderation
+### Phase 4: Scan, Review, Moderation, and correction
 
-Draft examples for:
+Draft complete examples for:
 
-* `scan_reference`;
-* `artifact_review`;
-* `moderation_record`;
-* and correction or supersession behavior.
+* Scan Reference;
+* Artifact Review;
+* Moderation Record;
+* Correction Record;
+* and same-type supersession.
 
 Test them against:
 
@@ -1596,65 +2570,96 @@ Test them against:
 * damaged QR codes;
 * incorrect Subjects;
 * peer evidence;
-* disputed contribution claims;
-* and rescans.
+* disputed Contribution Claims;
+* rescans;
+* and a source whose permitted use differs by Subject.
 
 ### Phase 5: Criteria and scoring
 
-Draft examples for:
+Draft complete examples for:
 
-* `criterion_set`;
-* `criterion`;
-* `scoring_scale`;
-* `score_record`;
-* and `score_evidence_link`.
+* standard-backed Criterion Set;
+* local Criterion Set;
+* mixed Criterion Set;
+* standard-backed Criterion;
+* local Criterion with alignment metadata;
+* Scoring Scale revision;
+* standard-backed Score Record;
+* local Score Record;
+* non-score disposition;
+* and Score Evidence Link.
 
 Test them against:
 
-* one score using several Artifacts;
-* one Artifact supporting several Scores;
-* individual and Group Scores using overlapping evidence;
+* one standard-backed Score using several Artifacts;
+* one Artifact supporting several standards Scores;
+* separate Criteria when one behavior relates to several standards;
+* one Group standards Score;
+* one individual standards Score supported by Group evidence;
+* local alignment that does not become a standards result;
 * insufficient evidence;
 * absence;
 * deferred scoring;
 * revised Scores;
-* and external ScoreForm or Quillan evidence.
+* and professional judgment without one controlling Artifact.
 
-### Phase 6: Optional extension concepts
+### Phase 6: External evidence and standards handoff
+
+Draft examples for:
+
+* ScoreForm result used as supporting evidence;
+* Quillan standards result used as supporting evidence;
+* External Reference unavailability;
+* Standards Result Handoff Projection;
+* current versus superseded standard-backed Scores;
+* Group versus individual standards targets;
+* and explicit non-score dispositions in the handoff.
+
+The examples must demonstrate that the future grading and reporting module can consume direct standards results without reverse-engineering generic Criteria.
+
+### Phase 7: Optional extension concepts
 
 Draft examples only after the foundation succeeds for:
 
-* `activity_marker`;
-* `work_item`;
-* `work_item_dependency`;
-* `activity_event`;
-* `contribution_claim`;
-* and `attachment`.
+* Activity Marker;
+* Work Item;
+* Work-Item Dependency;
+* Activity Event;
+* Contribution Claim;
+* and Attachment.
 
-These concepts should be added only where representative records demonstrate that generic context fields are insufficient.
-
+These concepts should be instantiated only where representative records demonstrate that generic context fields are insufficient.
 ## 21. Completion Assessment
 
-The minimum shared Concord domain has been identified.
+The minimum shared Concord domain has been identified and aligned with the current PDS2 and standards-based architecture.
 
 The model now distinguishes:
 
-* reusable definitions from generated instances;
+* reusable Definitions from immutable Versions and generated Instances;
 * Core identities from Concord-owned context;
-* roles from responsibilities;
-* assignments from contributions;
+* Core `work_id` from module semantics while establishing `activity_id = work_id`;
+* PDS2 route identity from Artifact semantics;
+* Roles from Responsibilities;
+* assignments from Contributions;
 * Artifact Authors from Artifact Subjects;
-* source scans from routed evidence references;
-* review from moderation;
-* evidence from scores;
+* source scans from routed Scan References;
+* Review from Moderation;
+* evidence from Scores;
+* standard-backed Criteria from local Criteria;
+* direct standards Scores from alignment-only metadata;
 * individual Scores from Group Scores;
-* and Concord scores from course grades.
+* non-score dispositions from low Scores;
+* Concord Scores from mastery and course Grades;
+* and Concord-owned judgments from ScoreForm- or Quillan-owned evidence.
 
 Universal concepts have been separated from optional seminar-, laboratory-, and project-oriented extensions.
 
-This document provides the foundation for:
+The foundation now supports Concord’s declared role as a predominantly standards-based collaborative-evidence module without forcing every Activity or Criterion into standards scoring.
 
-* recording formal architecture decisions;
-* identifying required Core integration changes;
-* drafting conceptual data contracts;
-* and testing representative contract examples.
+This document provides the basis for:
+
+* maintaining consistent architecture documentation;
+* testing representative contract examples;
+* validating the initial conceptual data contracts;
+* preparing the v0.1.0 foundation review;
+* and later implementing Concord without forcing the future grading and reporting module to infer standards meaning from generic records.

--- a/docs/design/pds-core-integration-requirements.md
+++ b/docs/design/pds-core-integration-requirements.md
@@ -1,56 +1,42 @@
 # PDS Core Integration Requirements
 
-**Status:** Proposed integration specification
+**Status:** Accepted architecture record; implemented by the released `pds-core` 0.5/PDS2 foundation
 **Project:** Paper Data Suite
 **Module:** `pds-concord`
 **Issue:** `Paper-Data-Suite/pds-concord#10`
-**Date:** July 13, 2026
+**Original date:** July 13, 2026
+**Reconciled:** July 24, 2026
+**Current Core baseline:** `pds-core` 0.5.0, Python 3.11+, PDS2
 
 ## 1. Purpose
 
-This document specifies the changes required in `pds-core` to make `pds-concord` a first-class Paper Data Suite module while establishing a QR, routing, identity, workspace, scan-provenance, and package contract suitable for all Paper Data Suite modules that generate and receive paper pages.
+This document records the integration requirements that led to the released `pds-core` 0.5/PDS2 architecture and defines the continuing boundary between Core routing infrastructure and Concord-owned semantics.
 
-This specification addresses the current Core assumptions that:
+The document was originally written prospectively, before PDS2 and the module-qualified work architecture were implemented. It is retained because it explains:
 
-* every routed page belongs to one student;
-* every routed page belongs to one assignment identified by an unqualified `assignment_id`;
-* every QR payload must contain `student_id`;
-* every successful route terminates in a student submission directory;
-* and every module can safely share one assignment directory and one `assignment.json`.
+* why the earlier student-oriented PDS1 model could not represent Concord;
+* why page routing must remain separate from Artifact Authors, Artifact Subjects, students, Groups, and Score targets;
+* why module work identity must be qualified by module, class, and work;
+* how retained source scans and module-owned evidence remain connected;
+* and which Concord implementation obligations remain after Core supplies the shared infrastructure.
 
-Those assumptions describe the initial ScoreForm and Quillan workflows but cannot represent Concord accurately.
+The released Core 0.5 contracts now govern the shared implementation. Where this document uses historical language such as “current PDS1 contract,” “replace,” or “must introduce,” that language describes the pre-PDS2 state and the requirement that produced the current Core design. It must not be read as an instruction to re-open settled PDS2 decisions.
 
-Concord must support pages associated with:
+For current Concord domain and scoring semantics, the governing documents are:
 
-* one student;
-* several students;
-* one Group;
-* several Groups;
-* one Session;
-* one Activity;
-* one Artifact Instance;
-* one Artifact Page;
-* one Activity Event;
-* a teacher-authored multi-subject tracker;
-* an unresolved Author or Subject;
-* or another Concord-owned contextual record.
+* `docs/concord-conceptual-design-revised.md`;
+* `docs/design/cross-case-requirements.md`;
+* `docs/design/initial-concord-domain-model.md`;
+* `docs/design/conceptual-data-contracts.md`;
+* and the accepted Concord ADRs, including ADR 0014.
 
-The new Core contract must support these cases without:
-
-* creating synthetic students;
-* placing Group, Session, Activity, Artifact, or other identifiers into `student_id`;
-* treating a route target as an Artifact Author or Artifact Subject;
-* encoding an Artifact’s complete Author or Subject graph in its QR code;
-* duplicating Concord’s domain model in Core;
-* or requiring direct dependencies among sibling modules.
-
-This is an integration-requirements document. It defines the required architecture and contract semantics. It does not prescribe every internal class name, storage implementation, command-line interface, or graphical workflow.
+This remains an integration-architecture document. It does not define every Concord record, serialized schema, persistence service, command-line workflow, graphical workflow, grading policy, or reporting contract.
 
 ---
 
 ## 2. Governing Design Sources
 
-This specification must remain consistent with the accepted Concord Architecture Decision Records and the Concord conceptual domain model.
+This specification must remain consistent with the accepted Concord Architecture Decision Records and the current Concord conceptual documents.
 
 The most directly relevant decisions are:
 
@@ -62,28 +48,38 @@ The most directly relevant decisions are:
 * `docs/decisions/0009-many-to-many-evidence-to-score-relationships.md`;
 * `docs/decisions/0010-exceptional-evidence-states-are-not-low-scores.md`;
 * `docs/decisions/0012-link-scoreform-and-quillan-without-duplication.md`;
-* and `docs/decisions/0013-keep-activity-specific-structures-optional.md`.
+* `docs/decisions/0013-keep-activity-specific-structures-optional.md`;
+* and `docs/decisions/0014-make-standards-based-scoring-the-primary-concord-scoring-model.md`.
 
-The relevant existing Core contracts and implementations include:
+The current Concord conceptual authorities are:
 
-* `pds-core/docs/qr_payload_and_routing_contract.md`;
-* `pds-core/docs/active_scan_contract.md`;
-* `pds_core.qr_payload`;
-* `pds_core.pds1`;
-* `pds_core.routes`;
-* `pds_core.scan_routes`;
-* `pds_core.scan_failure_metadata`;
-* and `pds_core.scan_resolution_metadata`.
+* `docs/concord-conceptual-design-revised.md`;
+* `docs/design/cross-case-requirements.md`;
+* `docs/design/initial-concord-domain-model.md`;
+* and `docs/design/conceptual-data-contracts.md`.
 
-When this specification conflicts with the current pre-production Core QR or route implementation, this specification describes the required replacement. When it conflicts with an accepted Concord ADR, the ADR governs unless a later ADR explicitly supersedes it.
+The relevant released Core authorities include:
+
+* `pds-core` 0.5.0;
+* the PDS2 QR and routing contracts;
+* the route-registration contract;
+* module-qualified work-path contracts;
+* active source-scan retention and provenance contracts;
+* generic routing failure and resolution schema version 2;
+* module-profile registration and dispatch;
+* and `pds-core/docs/module_standards_integration.md`.
+
+The released Core contracts govern shared QR, route, path, scan, profile, and standards-reference behavior. Concord ADRs and conceptual contracts govern Concord-owned Activity, Artifact, Author, Subject, Review, Moderation, Criterion, Score, and standards-scoring semantics.
+
+When this historical document conflicts with the released Core 0.5 contracts, Core 0.5 governs shared infrastructure. When it conflicts with an accepted Concord ADR, the ADR governs unless a later ADR explicitly supersedes it.
 
 ---
 
 ## 3. Decision Summary
 
-The integration should adopt the following architecture:
+The integration adopts the following architecture:
 
-1. Replace the current student-oriented `PDS1` contract with a new `PDS2` page-locator contract.
+1. Use the released `PDS2` page-locator contract in place of the historical student-oriented `PDS1` contract.
 2. Give every scannable returned page a durable, module-owned route identity before the page is generated.
 3. Encode only a compact route locator in the QR code.
 4. Resolve student, Group, Author, Subject, document, template, attempt, and other semantic context from a persisted route registration and module-owned records.
@@ -95,10 +91,10 @@ The integration should adopt the following architecture:
 6. Store module work beneath module-qualified class paths.
 7. Persist route registrations at deterministic Core-defined locations so routing does not require recursive directory discovery.
 8. Use a Core module-profile registry for module recognition and dispatch without hard-coding sibling-module imports into Core.
-9. Replace student-specific normalized route and failure models with generic route-locator and typed-target models.
+9. Use generic route-locator and typed-target models rather than student-specific normalized route and failure models.
 10. Preserve the existing Core source-scan retention, immutability, provenance, and append-only resolution principles.
-11. Migrate ScoreForm and Quillan deliberately to the new contract rather than preserving the student-oriented route as the universal model.
-12. Use explicit, compatible package versions across Core, ScoreForm, Quillan, and Concord.
+11. Keep ScoreForm and Quillan aligned with the shared PDS2 contract rather than treating their student-oriented workflows as the universal model.
+12. Use explicit, compatible package and contract-version ranges across Core, ScoreForm, Quillan, and Concord.
 
 The core principle is:
 
@@ -106,11 +102,14 @@ The core principle is:
 
 ---
 
-## 4. Current Contract Defects
+## 4. Historical Pre-PDS2 Contract Defects
+
+This section describes the defects in the earlier PDS1-era contracts that motivated PDS2. The defects are retained as architectural rationale; they are not descriptions of the released Core 0.5 design.
+
 
 ### 4.1 Student identity is universally required
 
-The current normalized `QrPayload` requires:
+The earlier normalized `QrPayload` required:
 
 * `schema`;
 * `module`;
@@ -120,7 +119,7 @@ The current normalized `QrPayload` requires:
 * `page`;
 * and optional metadata.
 
-The current `PDS1` parser similarly requires:
+The earlier `PDS1` parser similarly required:
 
 ```text
 module
@@ -143,7 +142,7 @@ Making `student_id` nullable would not solve the deeper problem. It would preser
 
 ### 4.2 Assignment identity is not module-qualified
 
-The current route layout uses:
+The earlier route layout used:
 
 ```text
 classes/<class_id>/assignments/<assignment_id>/
@@ -162,11 +161,11 @@ A bare `assignment_id` does not distinguish:
 * Concord Activity `project_check`;
 * or a similarly named record in a future module.
 
-The current shared `assignment.json` also creates an ownership collision because each module has a different assignment or activity schema.
+The earlier shared `assignment.json` also created an ownership collision because each module has a different assignment or activity schema.
 
 ### 4.3 The route destination is student-specific
 
-The current universal route terminates in:
+The earlier universal route terminated in:
 
 ```text
 submissions/<student_id>/
@@ -187,7 +186,7 @@ A Concord Artifact Page may belong operationally beneath an Artifact Instance wh
 
 ### 4.4 QR metadata duplicates mutable semantic data
 
-The current payload can carry student, page number, document type, template, form, attempt, and similar values.
+The earlier payload could carry student, page number, document type, template, form, attempt, and similar values.
 
 Encoding semantic context in the QR creates several risks:
 
@@ -201,13 +200,13 @@ The QR should contain a stable locator. The authoritative semantic record should
 
 ### 4.5 Failure metadata assumes assignment and student resolution
 
-The current shared failure schema contains top-level:
+The earlier shared failure schema contained top-level:
 
 * `class_id`;
 * `assignment_id`;
 * and `student_id`.
 
-The shared categories include:
+The earlier shared categories included:
 
 * `assignment_unknown`;
 * and `student_unknown`.
@@ -216,9 +215,9 @@ These fields and categories cannot serve as the universal route model for non-st
 
 ### 4.6 Package relationships are implicit
 
-ScoreForm and Quillan import Core code but do not declare a released, versioned `pds-core` runtime dependency.
+At the time of the original specification, ScoreForm and Quillan imported Core code without declaring a released, versioned `pds-core` runtime dependency.
 
-Quillan additionally relies on a sibling-repository `mypy_path`.
+At that time, Quillan also relied on a sibling-repository `mypy_path`.
 
 A coordinated breaking contract requires explicit dependency declarations and compatible supported Python versions.
 
@@ -228,7 +227,7 @@ A coordinated breaking contract requires explicit dependency declarations and co
 
 ### 5.1 Core ownership
 
-`pds-core` must own:
+`pds-core` owns:
 
 * workspace-root resolution;
 * canonical class identity;
@@ -265,7 +264,7 @@ Each module must own:
 
 ### 5.3 Core must not own Concord semantics
 
-Core must not define or interpret:
+Core does not define or interpret:
 
 * Activity;
 * Session;
@@ -340,7 +339,7 @@ Module identifiers should be lowercase and must satisfy the Core safe-identifier
 
 ### 6.2 Module work reference
 
-Core must introduce a neutral module work reference.
+Core provides a neutral module work reference.
 
 Conceptually:
 
@@ -391,7 +390,7 @@ A `route_id` must be:
 * unique within its `ModuleWorkRef`;
 * and never reused for a different target.
 
-Core should provide a shared route-ID generator.
+Core provides shared route-ID generation under its public contract.
 
 The generated identifier should not contain:
 
@@ -407,7 +406,7 @@ A short prefix such as `rt_` may be used for diagnostics, but the identifier’s
 
 ### 6.4 Module record reference
 
-Core must define a generic typed reference for module-owned records.
+Core provides a generic typed reference for module-owned records.
 
 Conceptually:
 
@@ -464,7 +463,7 @@ They may sometimes refer to related records, but none may be inferred universall
 
 ### 7.1 New schema identifier
 
-The revised QR contract must use a new schema identifier:
+The released QR contract uses the schema identifier:
 
 ```text
 PDS2
@@ -508,7 +507,7 @@ PDS2|m=concord|c=english10_p3|w=socratic_seminar_1|r=rt_01j2m8h8x5z2
 
 ### 7.3 Required fields
 
-Every `PDS2` payload contains exactly these four fields:
+Every valid `PDS2` payload contains exactly these four fields:
 
 | QR key | Internal name | Meaning                                  |
 | ------ | ------------- | ---------------------------------------- |
@@ -611,7 +610,7 @@ The absence of `student_id` from the QR does not prevent student workflows. It p
 
 ### 7.8 Strict grammar
 
-The parser must enforce:
+The parser enforces:
 
 * the first segment is exactly `PDS2`;
 * subsequent segments use `key=value`;
@@ -625,7 +624,7 @@ The parser must enforce:
 
 Field order must not affect parsing.
 
-The canonical serializer must emit:
+The canonical serializer emits:
 
 ```text
 PDS2|m=...|c=...|w=...|r=...
@@ -648,15 +647,15 @@ A future universally required routing field should be introduced through an expl
 
 ### 7.10 Payload size
 
-Core must enforce an absolute serialized payload limit.
+Core enforces an absolute serialized payload limit under the released contract.
 
-The initial maximum should be no more than:
+The architectural maximum is:
 
 ```text
 256 ASCII bytes
 ```
 
-Generators should warn or fail earlier when identifiers produce a payload above a recommended operational target of:
+Generators should warn or fail earlier when identifiers produce a payload above the recommended operational target of:
 
 ```text
 160 ASCII bytes
@@ -792,7 +791,7 @@ A future assignment registry will index module work references and academic orga
 
 ### 9.1 Required module-qualified root
 
-Core must replace the unqualified shared assignment root with a module-qualified work root.
+Core uses a module-qualified work root rather than the former unqualified shared assignment root.
 
 The preferred layout is:
 
@@ -816,7 +815,7 @@ classes/<class_id>/modules/<module_id>/work/<work_id>/
 
 ### 9.2 Route registration location
 
-Core must define a deterministic helper for locating a route registration from a `RouteLocator`.
+Core defines deterministic route-registration lookup from a `RouteLocator`.
 
 A conceptual layout is:
 
@@ -887,7 +886,7 @@ These examples do not establish the final module-specific layouts. They demonstr
 
 ### 9.4 Core path APIs
 
-Core should provide helpers conceptually equivalent to:
+Core provides public path helpers equivalent in responsibility to:
 
 ```python
 classes_dir(root)
@@ -923,7 +922,7 @@ assignment_submissions_dir(...)
 student_submission_dir(...)
 ```
 
-must no longer define the universal Core route model.
+do not define the universal Core route model.
 
 Migration options include:
 
@@ -937,7 +936,7 @@ No retained compatibility helper may cause Concord or future modules to adopt st
 
 ## 10. Normalized Core Models
 
-Core should replace the current student-required `QrPayload` with explicit models separating locator, registration, target, and resolution.
+Core separates locator, registration, target, and resolution through explicit public models.
 
 Representative conceptual models follow.
 
@@ -1003,9 +1002,9 @@ A module may derive those values after it receives the resolution.
 
 ### 11.1 Requirement
 
-Core must recognize installed PDS modules without importing their private implementations or maintaining a permanently closed module allow-list.
+Core recognizes installed PDS modules without importing their private implementations or treating a closed allow-list as the public extension model.
 
-Core should define a public module-profile interface.
+Core defines a public module-profile interface.
 
 A profile should provide at least:
 
@@ -1200,7 +1199,7 @@ Corrections belong in:
 
 ### 14.1 Generalized identity
 
-The shared failure schema must replace top-level assignment/student identity with route-oriented structures.
+The shared failure schema version 2 uses route-oriented structures rather than top-level assignment/student identity.
 
 A representative shape is:
 
@@ -1552,62 +1551,100 @@ A successful Concord route must create or support creation of a Concord Scan Ref
 * filing state;
 * and supersession history.
 
+
+### 17.6 Standards integration boundary
+
+Core owns shared standards infrastructure:
+
+* standards libraries;
+* standards profiles;
+* durable `standard_id` and `profile_id` values;
+* module-neutral reference validation;
+* and shared display metadata.
+
+Concord owns the meaning and use of those references within Concord:
+
+* Activity `standards_profile_id`;
+* ordered Activity `focus_standard_ids`;
+* Activity scoring orientation;
+* standard-backed and local Criterion classification;
+* the rule that one standard-backed Criterion has exactly one governing `standard_id`;
+* teacher-approved standard-backed Scores;
+* evidence links supporting those Scores;
+* and Concord-specific standards-result handoff data.
+
+Standards identity does not belong in the PDS2 QR, Route Locator, or generic Route Registration. Routing resolves an expected physical Artifact Page. Concord then resolves the Activity, Criterion, Score target, and governing standard from Concord-owned records.
+
+Core must not infer that:
+
+* selecting a standard is a Score;
+* aligning evidence to a standard establishes mastery;
+* one Score applies to several standards;
+* a local Criterion is a direct standards result;
+* or a Concord standards Score is a course Grade.
+
+The future grading and reporting module may consume Concord standards results through explicit module-owned exports or public contracts. It must not reconstruct standards meaning from QR payloads or generic routing metadata.
+
+
 ---
 
 ## 18. Versioning and Package Requirements
 
-### 18.1 Core release
+### 18.1 Current Core baseline
 
-The PDS2 and module-qualified route redesign is a breaking Core contract.
-
-Because `pds-core` is currently pre-1.0, the coordinated release should use at least:
+The architecture described by this document is implemented by:
 
 ```text
-pds-core 0.2.0
+pds-core 0.5.0
+Python >= 3.11
+QR schema: PDS2
+route-registration contract: 1
+routing failure/resolution contract: 2
 ```
 
-### 18.2 Explicit dependencies
+The earlier recommendation to publish `pds-core 0.2.0` was a pre-implementation planning target and is historical. It is not the current compatibility baseline.
 
-Each consuming module must declare a compatible Core dependency.
+### 18.2 Concord dependency range
 
-For the initial coordinated release:
+The initial Concord implementation should declare:
 
 ```toml
 dependencies = [
-    "pds-core>=0.2,<0.3"
+    "pds-core>=0.5,<0.6"
 ]
 ```
 
-The exact installation source may be a local package, private index, or released distribution, but dependency compatibility must be machine-verifiable.
+The dependency must be machine-verifiable. Concord must not depend on an undeclared sibling checkout or local type-checking path.
 
-### 18.3 Python version alignment
+### 18.3 Sibling-module independence
 
-All four repositories should align on:
+The supported dependency direction remains:
 
 ```text
-Python >= 3.11
+pds-scoreform -> pds-core
+pds-quillan   -> pds-core
+pds-concord   -> pds-core
 ```
 
-ScoreForm must update its declared minimum from Python 3.10 if it depends on a Core release requiring Python 3.11.
+Concord must not require ScoreForm or Quillan as runtime dependencies merely to resolve shared identities, standards, paths, QRs, retained scans, or routes.
 
-### 18.4 No sibling-checkout type path
+Cross-module relationships use public serialized contracts, module-qualified references, module-owned exports, or optional adapters.
 
-Quillan must remove:
+### 18.4 Python alignment
 
-```toml
-mypy_path = "../pds-core"
-```
+PDS Core 0.5 requires Python 3.11 or newer.
 
-Type checking and runtime imports must resolve through the declared package dependency.
+A consuming module must declare a Python range compatible with its selected Core range and must verify that runtime imports and type checking resolve through installed dependencies rather than sibling paths.
 
 ### 18.5 Contract compatibility
 
-Module profiles must declare the supported ranges of:
+Module profiles and public adapters must declare compatible ranges for:
 
 * Core package version;
 * QR schema;
 * route-registration schema;
-* and any public module-record contract used by optional adapters.
+* routing failure and resolution schemas;
+* and any public module-record contract they consume.
 
 Incompatibility must fail explicitly rather than being ignored.
 
@@ -1730,6 +1767,9 @@ QR error correction already addresses ordinary scan corruption, while route-regi
 ---
 
 ## 21. Testing Requirements
+
+This section preserves the required behavioral coverage identified by the original integration specification. Core 0.5 supplies the shared PDS2 foundation; each repository must verify its own current test coverage. Concord-specific cases remain acceptance requirements for later Concord implementation and are not satisfied merely because Core can parse or dispatch PDS2 routes.
+
 
 ### 21.1 Core parser tests
 
@@ -1869,81 +1909,81 @@ This integration does not:
 
 ---
 
-## 23. Required Implementation Issues
+## 23. Implementation Status and Remaining Work
 
-Acceptance of this document should produce separate implementation issues.
+The original version of this section listed implementation issues that were required to produce PDS2. The shared Core architecture has since been released. The list below distinguishes settled Core capability from remaining module-owned work.
 
-### 23.1 `pds-core`
+### 23.1 Implemented Core foundation
 
-1. Record an ADR for PDS2 page-locator routing.
-2. Add `ModuleWorkRef`, `RouteLocator`, `ModuleRecordRef`, `RouteRegistration`, and `RouteResolution`.
-3. Implement strict PDS2 parsing and serialization.
-4. Add route-ID generation.
-5. Add module-qualified class/work path helpers.
-6. Add deterministic route-registration storage and validation.
-7. Add module-profile registration and dispatch.
-8. Replace routing-failure metadata with schema version 2.
-9. Update scan-resolution metadata for corrected generic routes.
-10. Update the active-scan contract.
-11. Remove or deprecate universal student-assignment route helpers.
-12. Publish `pds-core 0.2.0`.
+The released Core 0.5 baseline provides the architectural capabilities required by this document:
 
-### 23.2 `pds-scoreform`
+1. PDS2 page-locator parsing and serialization.
+2. `ModuleWorkRef`, `RouteLocator`, `ModuleRecordRef`, `RouteRegistration`, and route-resolution contracts.
+3. route-ID generation and validation.
+4. module-qualified class/work path helpers.
+5. deterministic route-registration storage and validation.
+6. module-profile registration and generic dispatch.
+7. generic routing failure and resolution schema version 2.
+8. source-scan retention and provenance.
+9. package and contract-version boundaries suitable for independent modules.
+10. shared standards libraries, profiles, durable standards IDs, and module-neutral validation.
 
-1. Declare the compatible Core dependency.
-2. Align Python support.
-3. Move assignment storage beneath the ScoreForm module work root.
-4. Add durable answer-sheet page records.
-5. Create route registrations before PDF rendering.
-6. Generate PDS2 QR codes.
-7. Resolve student identity from page records.
-8. Migrate scanner and scoring routes.
-9. Add provenance and duplicate-page tests.
-10. Remove active generation of OMR1 and PDS1.
+The earlier requirement to publish `pds-core 0.2.0` is superseded by the released `pds-core` 0.5.0 baseline.
 
-### 23.3 `pds-quillan`
+### 23.2 ScoreForm and Quillan
 
-1. Declare the compatible Core dependency.
-2. Remove sibling `mypy_path`.
-3. Move assignment storage beneath the Quillan module work root.
-4. Add durable response-page records.
-5. Create route registrations before document rendering.
-6. Generate PDS2 QR codes.
-7. Resolve student submissions from page records.
-8. Migrate scan assembly and review routes.
-9. Add continuation-page and provenance tests.
-10. Remove active generation of PDS1.
+ScoreForm and Quillan remain responsible for their own current PDS2 page records, route registrations, scanning workflows, package dependencies, and result contracts.
 
-### 23.4 `pds-concord`
+This Concord document does not serve as the current implementation tracker for those repositories. Their repositories and issues govern any remaining migration or maintenance work.
 
-1. Declare the compatible Core dependency.
-2. Register the Concord module profile.
-3. Use `activity_id` as the Concord routing `work_id`.
-4. Create Artifact Page records before rendering.
-5. Create route registrations for returned Artifact Pages.
-6. Generate PDS2 QR codes.
-7. Resolve routes to Artifact Pages.
-8. Create Concord Scan References from Core source-page references.
-9. Implement routing-review integration.
-10. Test all representative student, Group, Session, Activity, Event, and multi-subject cases.
+### 23.3 Remaining Concord implementation work
 
-### 23.5 Future Core design issue
+Later Concord implementation issues must:
 
-Open a separate issue for the suite assignment registry, including:
+1. declare `pds-core>=0.5,<0.6`;
+2. register the Concord module profile;
+3. use `activity_id` as the Concord routing `work_id`;
+4. create Artifact Page records before rendering;
+5. create route registrations for returned Artifact Pages;
+6. generate PDS2 QR codes through Core;
+7. resolve routes to Artifact Pages through a side-effect-free route handler;
+8. create Concord Scan References through a separate persistence service after successful dispatch;
+9. integrate routing results with filing and Review;
+10. preserve Core source-page provenance;
+11. test student, Group, Session, Activity, Event, unresolved-attribution, and multi-subject cases;
+12. implement Activity standards configuration and standard-backed/local Criterion semantics under ADR 0014;
+13. preserve direct standards-result meaning without placing standards data in QRs or generic route records;
+14. and expose future reporting handoff data through Concord-owned contracts rather than Core routing metadata.
 
-* module work discovery;
+### 23.4 Future suite assignment and reporting work
+
+A separate future design effort remains responsible for:
+
+* module-work discovery;
 * academic-period hierarchy;
 * assessment classification;
-* lifecycle and status;
+* reporting eligibility;
 * rebuildable indexes;
 * stale-entry detection;
-* and grading/reporting consumption.
+* standards-result aggregation;
+* grading policy;
+* and reporting consumption.
+
+That future work must reference module work through:
+
+```text
+module_id + class_id + work_id
+```
+
+It must not change the PDS2 QR grammar to carry grading, standards, academic-period, or reporting metadata.
 
 ---
 
-## 24. Acceptance Criteria
+## 24. Architectural Acceptance Criteria
 
-This integration specification is satisfied when:
+The shared architecture represented by this document is satisfied when the following conditions hold. Core-level conditions are governed by the released Core contracts; module-level readiness must be verified in each consuming repository.
+
+
 
 1. Core no longer requires `student_id` in its universal QR or normalized route model.
 2. Core no longer treats student submission directories as the universal route destination.
@@ -1959,12 +1999,15 @@ This integration specification is satisfied when:
 12. generic failure metadata supports student and non-student routes.
 13. retained source scans remain canonical and immutable.
 14. all routed evidence remains traceable to its source scan and source page.
-15. ScoreForm and Quillan declare compatible Core package dependencies.
-16. all modules run under a compatible Python version.
+15. every consuming module declares a compatible Core package dependency.
+16. every consuming module declares and tests a Python version compatible with its selected Core range.
 17. Concord routes valid pages with no student Subject.
 18. one teacher tracker can route as one Artifact while retaining several Subjects.
 19. unresolved Author or Subject status does not prevent correct page routing.
 20. the resulting identity model can be indexed later by a suite assignment registry without changing the QR contract.
+21. Core standards libraries and profiles remain separate from Concord-owned standards-scoring semantics.
+22. no standard, Criterion, Score target, rating, mastery state, Grade, or reporting category is encoded in PDS2 or generic Route Registration.
+23. a future reporting module can consume Concord standards results from Concord-owned records without reverse-engineering generic routing metadata.
 
 ---
 
@@ -1990,3 +2033,23 @@ QR
 ```
 
 This distinction is required for Concord and provides the cleaner long-term contract for ScoreForm, Quillan, and future paper-processing modules.
+
+The corresponding standards boundary is:
+
+```text
+Core standard/profile identity
+    -> Concord Activity Focus Standards
+    -> Concord standard-backed Criterion
+    -> teacher-approved Concord Score
+    -> future Concord-owned standards-result handoff
+```
+
+It is not:
+
+```text
+PDS2 QR or Route Registration
+    -> inferred standard
+    -> inferred mastery or Grade
+```
+
+Routing identifies the physical page. Concord-owned records identify the evidence, target, Criterion, governing standard, and teacher judgment.


### PR DESCRIPTION
## Summary

Completes issue #11 by defining Concord’s initial implementation-neutral conceptual data contracts and reconciling the surrounding architecture documentation with:

* the released `pds-core` 0.5/PDS2 contracts;
* ADR 0014, which establishes standards-based scoring as Concord’s primary academic scoring model;
* the revised Concord domain model;
* and the established boundaries among Concord, Core, ScoreForm, Quillan, and future grading/reporting functionality.

This PR contains documentation and architectural contracts only. It does not add production models, persistence, routing handlers, packet rendering, or user-interface code.

## Major changes

### Added the initial conceptual data contracts

Updated `docs/design/conceptual-data-contracts.md` to define the purpose, ownership, identity, fields, references, cardinalities, lifecycle, provenance, privacy, mutability, and invariants for Concord’s foundational records.

The contracts cover:

* Activities and Sessions;
* Groups, Memberships, Roles, and Responsibilities;
* Template Definitions and immutable Template Versions;
* Packet Definitions, immutable Packet Versions, Components, and Instances;
* Artifact Instances and Artifact Pages;
* Artifact Authors and Artifact Subjects;
* Scan References, Reviews, Moderation Records, and Corrections;
* Criterion Sets, Criteria, Scoring Scales, Scores, and Score Evidence Links;
* Attachments and External References;
* and optional Activity Markers, Work Items, Dependencies, Events, and Contribution Claims.

### Established the standards-based scoring architecture

The documentation now consistently establishes that Concord is predominantly standards-based but not standards-exclusive.

Supported Activity orientations are:

* `evidence_only`
* `standards_based`
* `mixed`
* `local_criteria_only`

The revised contracts distinguish:

* Core-owned standards profiles and durable standard identities;
* ordered Activity Focus Standards;
* standard-backed Criteria with exactly one governing `standard_id`;
* local Criteria with no governing standard;
* optional non-governing alignment metadata for local Criteria;
* standard-backed Scores;
* local Scores;
* explicit non-score dispositions;
* and a future Standards Result Handoff Projection.

The contracts explicitly prevent:

* treating standards selection or alignment as a standards result;
* assigning one direct Score to several governing standards;
* automatically propagating Group Scores or Group evidence into individual Scores;
* treating missing evidence as a low Score;
* and interpreting one Concord Score as mastery, a course Grade, or a longitudinal proficiency determination.

### Reconciled Concord with PDS2

The active architecture now consistently uses:

```text
work_id = activity_id
```

with module-qualified work identity:

```text
module_id + class_id + work_id
```

and the conceptual Concord work root:

```text
classes/<class_id>/modules/concord/work/<activity_id>/
```

The standard Concord route target is an existing Artifact Page:

```text
module_id: concord
record_kind: artifact_page
record_id: <artifact_page_id>
```

The documentation also confirms that a PDS2 QR identifies a physical page route only. Authors, Subjects, students, Groups, Criteria, standards, scorers, and Score targets resolve through Concord-owned records rather than QR metadata.

### Reconciled related design documents

Updated:

* `docs/concord-conceptual-design-revised.md`
* `docs/design/cross-case-requirements.md`
* `docs/design/initial-concord-domain-model.md`
* `docs/design/pds-core-integration-requirements.md`
* `docs/design/conceptual-data-contracts.md`
* `docs/decisions/0014-make-standards-based-scoring-the-primary-concord-scoring-model.md`

The revisions remove or clearly mark historical assumptions involving:

* PDS1;
* universal student routes;
* required Core `assignment_id` relationships;
* unqualified assignment directories;
* mutable Packet Definitions;
* generic standards references with ambiguous scoring meaning;
* points-based rubrics as the presumed primary model;
* and conflation of Artifact Subjects with Score targets.

## Architectural decisions preserved

This PR preserves the following boundaries:

* Core owns shared identity, paths, standards libraries and profiles, PDS2 parsing, Route Registrations, retained source scans, provenance, and generic dispatch.
* Concord owns collaborative Activity semantics, Artifacts, Authors, Subjects, Review, Moderation, Criteria, Scores, evidence relationships, and standards-result handoff semantics.
* ScoreForm owns OMR and selected-response workflows.
* Quillan owns focused and extended written-response review workflows.
* A future grading and reporting module will own aggregation, weighting, mastery policy, Grade calculation, scale conversion, and longitudinal reporting.

## Acceptance audit

The six governing documents were reviewed together for contradictions involving:

* active PDS1 assumptions;
* `activity_id` versus `assignment_id`;
* universal student routing;
* unqualified assignment paths;
* Packet Definition mutability;
* ambiguous standards references;
* multiple governing standards per Criterion;
* points-based scoring as the presumed primary architecture;
* Artifact Subject versus Score target terminology;
* and standards alignment being treated as a standards result.

No blocking architectural contradictions were found.

ADR 0014 is referenced by each active document whose scoring language it governs.

## Out of scope

This PR does not include:

* production Python models;
* JSON Schema publication;
* filesystem or persistence implementation;
* packet rendering;
* QR generation;
* route-handler implementation;
* scan-intake workflows;
* CLI or graphical interfaces;
* complete representative seminar, laboratory, and project record sets;
* grading or mastery calculation;
* or final approval of the Concord v0.1.0 foundation.

Representative end-to-end contract examples remain in issue #12. Final skeptical architecture review and foundation approval remain in issue #13.

Closes #11.
