### PR TITLE
feat: implement canonical guarded persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,12 @@ All notable changes to this project will be documented in this file.
 - Side-effect-free help and version CLI.
 - Authenticated released-Core integration, packaging, documentation, and CI
   validation tooling.
+- Concord-owned canonical storage with immutable record revisions and work
+  snapshots, atomic current-pointer publication, optimistic concurrency, strict
+  graph reconstruction, and stable storage errors.
+- Disposable per-Activity SQLite catalog, deterministic storage diagnostics,
+  lock inspection, and conservative recovery documentation.
+- Persistence durability hardening for complete orphan-free history checks,
+  full snapshot-chain proof, structured post-publication and retained-lock
+  outcomes, minimized catalog metadata, and native graph diagnostic codes.
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 Concord is the Paper Data Suite module for paper-first, human-reviewed evidence
 created during collaborative classroom Activities. The repository has moved from
 architecture into v0.2.0 implementation. The installable Core 0.6 package
-baseline and the immutable native record, exact conversion, and pure validation
-layer are complete.
+baseline, immutable native records, exact conversion, pure validation, and
+canonical guarded persistence layers are complete.
 
-The available models do not make the complete Activity workflow operational.
-Storage and teacher workflows remain pending. Concord does not yet handle
+These layers do not make the complete teacher-local Activity workflow
+operational. Teacher workflows remain pending. Concord does not yet handle
 returned Artifact Pages, calculate Grades, publish result manifests, or expose
 either a routing profile or a publication-producer profile.
 
@@ -51,6 +51,12 @@ Native model imports are documented in
 [the implementation guide](docs/implementation/native-record-models.md).
 Record bodies can be converted without filesystem access, and relationship
 validation is deterministic and side-effect free.
+
+Canonical record history, atomic work snapshots, guarded batch commits, strict
+reads, the disposable SQLite catalog, and conservative recovery rules are
+documented in the
+[canonical storage guide](docs/implementation/canonical-storage.md). The catalog
+is derived state and is never required to reconstruct the current graph.
 
 Core exposes routing through `paper_data_suite.modules` and publication through
 `paper_data_suite.publication_producers`. These are independent surfaces: a

--- a/concord/model_conversion.py
+++ b/concord/model_conversion.py
@@ -28,6 +28,7 @@ from concord.models import (
     ScoringScale,
     Session,
 )
+from concord.record_registry import CONVERSION_KIND_ALIASES, RECORD_DESCRIPTORS
 
 Record = (
     Activity
@@ -51,26 +52,15 @@ Record = (
 )
 
 RECORD_KIND_REGISTRY: dict[str, type[Record]] = {
-    "activity": Activity,
-    "session": Session,
-    "group": Group,
-    "group_membership": GroupMembership,
-    "role_assignment": RoleAssignment,
-    "responsibility_assignment": ResponsibilityAssignment,
-    "artifact_instance": ArtifactInstance,
-    "artifact_page": ArtifactPage,
-    "artifact_author": ArtifactAuthor,
-    "artifact_subject": ArtifactSubject,
-    "artifact_review": ArtifactReview,
-    "moderation_record": ModerationRecord,
-    "criterion_set": CriterionSet,
-    "criterion": Criterion,
-    "scoring_scale": ScoringScale,
-    "score_record": ScoreRecord,
-    "score_evidence_link": ScoreEvidenceLink,
-    "correction": CorrectionRecord,
-    "correction_record": CorrectionRecord,
+    descriptor.kind: cast(type[Record], descriptor.model_type)
+    for descriptor in RECORD_DESCRIPTORS
 }
+RECORD_KIND_REGISTRY.update(
+    {
+        alias: RECORD_KIND_REGISTRY[canonical]
+        for alias, canonical in CONVERSION_KIND_ALIASES.items()
+    }
+)
 
 
 def record_to_dict(record: Record) -> dict[str, Any]:

--- a/concord/model_validation.py
+++ b/concord/model_validation.py
@@ -33,6 +33,7 @@ from concord.models import (
     ScoringScale,
     Session,
 )
+from concord.record_registry import RECORD_DESCRIPTORS
 from concord.validation_diagnostics import ConcordRecordGraphError, ValidationIssue
 
 Record = (
@@ -57,45 +58,14 @@ Record = (
 )
 T = TypeVar("T")
 
-_COLLECTIONS: tuple[tuple[str, type[Any], str, str], ...] = (
-    ("activities", Activity, "activity", "activity_id"),
-    ("sessions", Session, "session", "session_id"),
-    ("groups", Group, "group", "group_id"),
-    ("memberships", GroupMembership, "group_membership", "membership_id"),
-    ("role_assignments", RoleAssignment, "role_assignment", "role_assignment_id"),
+_COLLECTIONS: tuple[tuple[str, type[Any], str, str], ...] = tuple(
     (
-        "responsibility_assignments",
-        ResponsibilityAssignment,
-        "responsibility_assignment",
-        "responsibility_assignment_id",
-    ),
-    (
-        "artifact_instances",
-        ArtifactInstance,
-        "artifact_instance",
-        "artifact_instance_id",
-    ),
-    ("artifact_pages", ArtifactPage, "artifact_page", "artifact_page_id"),
-    ("artifact_authors", ArtifactAuthor, "artifact_author", "artifact_author_id"),
-    ("artifact_subjects", ArtifactSubject, "artifact_subject", "artifact_subject_id"),
-    ("artifact_reviews", ArtifactReview, "artifact_review", "artifact_review_id"),
-    (
-        "moderation_records",
-        ModerationRecord,
-        "moderation_record",
-        "moderation_record_id",
-    ),
-    ("criterion_sets", CriterionSet, "criterion_set", "criterion_set_id"),
-    ("criteria", Criterion, "criterion", "criterion_id"),
-    ("scoring_scales", ScoringScale, "scoring_scale", "scoring_scale_id"),
-    ("score_records", ScoreRecord, "score_record", "score_record_id"),
-    (
-        "score_evidence_links",
-        ScoreEvidenceLink,
-        "score_evidence_link",
-        "score_evidence_link_id",
-    ),
-    ("correction_records", CorrectionRecord, "correction", "correction_id"),
+        descriptor.graph_collection,
+        descriptor.model_type,
+        descriptor.kind,
+        descriptor.identity_field,
+    )
+    for descriptor in RECORD_DESCRIPTORS
 )
 
 

--- a/concord/record_registry.py
+++ b/concord/record_registry.py
@@ -1,0 +1,125 @@
+"""One authoritative descriptor registry for Concord native records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from concord.models import (
+    Activity,
+    ArtifactAuthor,
+    ArtifactInstance,
+    ArtifactPage,
+    ArtifactReview,
+    ArtifactSubject,
+    CorrectionRecord,
+    Criterion,
+    CriterionSet,
+    Group,
+    GroupMembership,
+    ModerationRecord,
+    ResponsibilityAssignment,
+    RoleAssignment,
+    ScoreEvidenceLink,
+    ScoreRecord,
+    ScoringScale,
+    Session,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RecordDescriptor:
+    kind: str
+    model_type: type[Any]
+    identity_field: str
+    graph_collection: str
+
+
+RECORD_DESCRIPTORS: tuple[RecordDescriptor, ...] = (
+    RecordDescriptor("activity", Activity, "activity_id", "activities"),
+    RecordDescriptor("session", Session, "session_id", "sessions"),
+    RecordDescriptor("group", Group, "group_id", "groups"),
+    RecordDescriptor(
+        "group_membership", GroupMembership, "membership_id", "memberships"
+    ),
+    RecordDescriptor(
+        "role_assignment", RoleAssignment, "role_assignment_id", "role_assignments"
+    ),
+    RecordDescriptor(
+        "responsibility_assignment",
+        ResponsibilityAssignment,
+        "responsibility_assignment_id",
+        "responsibility_assignments",
+    ),
+    RecordDescriptor(
+        "artifact_instance",
+        ArtifactInstance,
+        "artifact_instance_id",
+        "artifact_instances",
+    ),
+    RecordDescriptor(
+        "artifact_page", ArtifactPage, "artifact_page_id", "artifact_pages"
+    ),
+    RecordDescriptor(
+        "artifact_author", ArtifactAuthor, "artifact_author_id", "artifact_authors"
+    ),
+    RecordDescriptor(
+        "artifact_subject", ArtifactSubject, "artifact_subject_id", "artifact_subjects"
+    ),
+    RecordDescriptor(
+        "artifact_review", ArtifactReview, "artifact_review_id", "artifact_reviews"
+    ),
+    RecordDescriptor(
+        "moderation_record",
+        ModerationRecord,
+        "moderation_record_id",
+        "moderation_records",
+    ),
+    RecordDescriptor(
+        "criterion_set", CriterionSet, "criterion_set_id", "criterion_sets"
+    ),
+    RecordDescriptor("criterion", Criterion, "criterion_id", "criteria"),
+    RecordDescriptor(
+        "scoring_scale", ScoringScale, "scoring_scale_id", "scoring_scales"
+    ),
+    RecordDescriptor("score_record", ScoreRecord, "score_record_id", "score_records"),
+    RecordDescriptor(
+        "score_evidence_link",
+        ScoreEvidenceLink,
+        "score_evidence_link_id",
+        "score_evidence_links",
+    ),
+    RecordDescriptor(
+        "correction", CorrectionRecord, "correction_id", "correction_records"
+    ),
+)
+
+DESCRIPTOR_BY_KIND = {item.kind: item for item in RECORD_DESCRIPTORS}
+DESCRIPTOR_BY_TYPE = {item.model_type: item for item in RECORD_DESCRIPTORS}
+CONVERSION_KIND_ALIASES = {"correction_record": "correction"}
+
+
+def descriptor_for_kind(kind: str, *, allow_alias: bool = False) -> RecordDescriptor:
+    canonical = CONVERSION_KIND_ALIASES.get(kind, kind) if allow_alias else kind
+    try:
+        return DESCRIPTOR_BY_KIND[canonical]
+    except (KeyError, TypeError) as error:
+        raise ValueError(f"unsupported record_kind {kind!r}.") from error
+
+
+def descriptor_for_record(record: object) -> RecordDescriptor:
+    try:
+        return DESCRIPTOR_BY_TYPE[type(record)]
+    except KeyError as error:
+        raise ValueError(f"unsupported record type {type(record).__name__}.") from error
+
+
+__all__ = [
+    "CONVERSION_KIND_ALIASES",
+    "DESCRIPTOR_BY_KIND",
+    "DESCRIPTOR_BY_TYPE",
+    "RECORD_DESCRIPTORS",
+    "RecordDescriptor",
+    "descriptor_for_kind",
+    "descriptor_for_record",
+]

--- a/concord/storage.py
+++ b/concord/storage.py
@@ -1,0 +1,989 @@
+"""Strict reads and guarded batch commits for canonical Concord state."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Iterable, TypeVar, cast
+
+from pds_core.class_metadata import load_class_metadata_for_class
+from pds_core.routes import module_work_collection_dir
+from pds_core.routing_models import ModuleWorkRef, module_work_ref_to_dict
+from pds_core.workspace import inspect_workspace_root, resolve_workspace_root
+
+from concord.model_conversion import Record, record_from_dict, record_to_dict
+from concord.model_validation import (
+    ConcordRecordGraph,
+    validate_core_standards,
+    validate_record_graph,
+)
+from concord.record_registry import (
+    RECORD_DESCRIPTORS,
+    descriptor_for_kind,
+    descriptor_for_record,
+)
+from concord.storage_errors import (
+    ConcordStorageConflictError,
+    ConcordStorageError,
+    ConcordStorageGraphIntegrityError,
+    ConcordStorageIntegrityError,
+    ConcordStorageNotFoundError,
+    ConcordStoragePartialSuccessError,
+    ConcordStorageReadError,
+    ConcordStorageValidationError,
+    ConcordStorageWriteError,
+)
+from concord.storage_models import (
+    CONCORD_NATIVE_RECORD_CONTRACT_VERSION,
+    CONCORD_STORAGE_SCHEMA_VERSION,
+    ConcordCurrentSnapshot,
+    ConcordLoadedRecordGraph,
+    ConcordRecordRevision,
+    ConcordRecordRevisionRef,
+    ConcordStorageCommitResult,
+    ConcordWorkMarker,
+    ConcordWorkSnapshot,
+)
+from concord.storage_paths import (
+    current_snapshot_path,
+    locks_path,
+    record_revision_path,
+    record_revisions_path,
+    records_path,
+    snapshot_path,
+    snapshots_path,
+    state_path,
+    work_marker_path,
+    work_root,
+    write_lock_path,
+)
+from concord.storage_serialization import (
+    canonical_json_bytes,
+    current_from_dict,
+    marker_from_dict,
+    revision_from_dict,
+    serialize,
+    snapshot_from_dict,
+    strict_json_loads,
+)
+from concord.validation_diagnostics import ConcordRecordGraphError
+
+T = TypeVar("T")
+
+
+def _sha(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _require_no_symlink_ancestors(path: Path) -> None:
+    for ancestor in (path, *path.parents):
+        try:
+            if ancestor.is_symlink():
+                raise ConcordStorageIntegrityError(
+                    f"canonical path traverses a symlink: {ancestor}"
+                )
+        except OSError as error:
+            raise ConcordStorageReadError(
+                f"could not inspect canonical path {ancestor}: {error}"
+            ) from error
+
+
+def require_regular_nonsymlink_file(
+    path: Path,
+    *,
+    missing: bool = False,
+) -> None:
+    _require_no_symlink_ancestors(path)
+    try:
+        if path.is_symlink() or not path.is_file():
+            if not path.exists() and not path.is_symlink() and missing:
+                raise ConcordStorageNotFoundError(f"canonical object not found: {path}")
+            raise ConcordStorageIntegrityError(
+                f"canonical path is not a regular non-symlink file: {path}"
+            )
+    except ConcordStorageNotFoundError:
+        raise
+    except OSError as error:
+        raise ConcordStorageReadError(
+            f"could not inspect canonical path {path}: {error}"
+        ) from error
+
+
+def read_canonical_bytes(path: Path, *, missing: bool = False) -> bytes:
+    require_regular_nonsymlink_file(path, missing=missing)
+    try:
+        return path.read_bytes()
+    except FileNotFoundError as error:
+        raise ConcordStorageNotFoundError(
+            f"canonical object not found: {path}"
+        ) from error
+    except OSError as error:
+        raise ConcordStorageReadError(f"could not read {path}: {error}") from error
+
+
+def _parse(
+    path: Path, parser: Callable[[object], T], *, missing: bool = False
+) -> tuple[T, bytes]:
+    data = read_canonical_bytes(path, missing=missing)
+    try:
+        return parser(strict_json_loads(data)), data
+    except (
+        ConcordStorageReadError,
+        ConcordStorageValidationError,
+        ValueError,
+    ) as error:
+        raise ConcordStorageReadError(
+            f"invalid canonical object at {path}: {error}"
+        ) from error
+
+
+def load_work_marker(
+    workspace_root: str | Path, work: ModuleWorkRef
+) -> ConcordWorkMarker:
+    value, _ = _parse(
+        work_marker_path(workspace_root, work), marker_from_dict, missing=True
+    )
+    if value.work != work:
+        raise ConcordStorageIntegrityError(
+            "work marker identity disagrees with its canonical path."
+        )
+    return value
+
+
+def load_record_revision(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+    record_kind: str,
+    record_id: str,
+    record_revision: int,
+) -> tuple[Record, ConcordRecordRevision]:
+    descriptor = descriptor_for_kind(record_kind)
+    path = record_revision_path(
+        workspace_root, work, record_kind, record_id, record_revision
+    )
+    envelope, _ = _parse(path, revision_from_dict, missing=True)
+    if (
+        envelope.work != work
+        or envelope.record_kind != record_kind
+        or envelope.record_id != record_id
+        or envelope.record_revision != record_revision
+    ):
+        raise ConcordStorageIntegrityError(
+            "record envelope identity disagrees with its canonical path."
+        )
+    record = record_from_dict(record_kind, envelope.body)
+    if (
+        getattr(record, descriptor.identity_field) != record_id
+        or record_to_dict(record) != envelope.body
+    ):
+        raise ConcordStorageIntegrityError(
+            "record body identity or round trip disagrees with its envelope."
+        )
+    return record, envelope
+
+
+def _visible(path: Path, description: str) -> tuple[Path, ...]:
+    try:
+        _require_no_symlink_ancestors(path)
+        entries = tuple(path.iterdir())
+    except FileNotFoundError:
+        return ()
+    except OSError as error:
+        raise ConcordStorageReadError(
+            f"could not enumerate {description} {path}: {error}"
+        ) from error
+    return tuple(
+        sorted((p for p in entries if not p.name.startswith(".")), key=lambda p: p.name)
+    )
+
+
+def list_record_revisions(
+    workspace_root: str | Path, work: ModuleWorkRef, record_kind: str, record_id: str
+) -> tuple[int, ...]:
+    descriptor_for_kind(record_kind)
+    result: list[int] = []
+    for path in _visible(
+        record_revisions_path(workspace_root, work, record_kind, record_id),
+        "record revisions",
+    ):
+        if (
+            path.is_symlink()
+            or not path.is_file()
+            or not path.name.endswith(".json")
+            or not path.stem.isdigit()
+            or path.stem.startswith("0")
+        ):
+            raise ConcordStorageIntegrityError(
+                f"unexpected record revision entry: {path}"
+            )
+        revision = int(path.stem)
+        load_record_revision(workspace_root, work, record_kind, record_id, revision)
+        result.append(revision)
+    return tuple(sorted(result))
+
+
+def list_record_identities(
+    workspace_root: str | Path, work: ModuleWorkRef
+) -> tuple[tuple[str, str], ...]:
+    result: list[tuple[str, str]] = []
+    for kind_path in _visible(records_path(workspace_root, work), "record kinds"):
+        descriptor_for_kind(kind_path.name)
+        if kind_path.is_symlink() or not kind_path.is_dir():
+            raise ConcordStorageIntegrityError(
+                f"unexpected record kind entry: {kind_path}"
+            )
+        for identity_path in _visible(kind_path, "record identities"):
+            if identity_path.is_symlink() or not identity_path.is_dir():
+                raise ConcordStorageIntegrityError(
+                    f"unexpected record identity entry: {identity_path}"
+                )
+            children = _visible(identity_path, "record identity")
+            if tuple(p.name for p in children) != ("revisions",):
+                raise ConcordStorageIntegrityError(
+                    f"unexpected record identity contents: {identity_path}"
+                )
+            list_record_revisions(
+                workspace_root, work, kind_path.name, identity_path.name
+            )
+            result.append((kind_path.name, identity_path.name))
+    return tuple(sorted(result))
+
+
+def _load_snapshot_chain(
+    workspace_root: str | Path, work: ModuleWorkRef, snapshot_revision: int
+) -> tuple[ConcordWorkSnapshot, bytes]:
+    target, target_bytes = _parse(
+        snapshot_path(workspace_root, work, snapshot_revision),
+        snapshot_from_dict,
+        missing=True,
+    )
+    if target.work != work or target.snapshot_revision != snapshot_revision:
+        raise ConcordStorageIntegrityError(
+            "snapshot identity disagrees with its canonical path."
+        )
+
+    child = target
+    for expected_revision in range(snapshot_revision - 1, 0, -1):
+        predecessor, predecessor_bytes = _parse(
+            snapshot_path(workspace_root, work, expected_revision),
+            snapshot_from_dict,
+            missing=True,
+        )
+        if (
+            predecessor.work != work
+            or predecessor.snapshot_revision != expected_revision
+        ):
+            raise ConcordStorageIntegrityError(
+                "snapshot predecessor identity disagrees with its canonical path."
+            )
+        if child.previous_snapshot_revision != expected_revision:
+            raise ConcordStorageIntegrityError(
+                "snapshot predecessor revision mismatch."
+            )
+        if child.previous_snapshot_sha256 != _sha(predecessor_bytes):
+            raise ConcordStorageIntegrityError("snapshot predecessor digest mismatch.")
+        child = predecessor
+
+    return target, target_bytes
+
+
+def load_work_snapshot(
+    workspace_root: str | Path, work: ModuleWorkRef, snapshot_revision: int
+) -> tuple[ConcordWorkSnapshot, str]:
+    value, data = _load_snapshot_chain(workspace_root, work, snapshot_revision)
+    selected_records: list[Record] = []
+    for ref in value.records:
+        record_path = record_revision_path(
+            workspace_root, work, ref.record_kind, ref.record_id, ref.record_revision
+        )
+        if _sha(read_canonical_bytes(record_path, missing=True)) != ref.sha256:
+            raise ConcordStorageIntegrityError(
+                f"record digest mismatch for {ref.record_kind}:{ref.record_id}."
+            )
+        record, _ = load_record_revision(
+            workspace_root, work, ref.record_kind, ref.record_id, ref.record_revision
+        )
+        selected_records.append(record)
+    try:
+        graph = _graph_from_records(selected_records)
+        if len(graph.activities) != 1 or graph.activities[0].work_reference != work:
+            raise ConcordStorageIntegrityError(
+                "snapshot must contain exactly one matching Activity."
+            )
+        validate_record_graph(graph)
+    except ConcordStorageIntegrityError:
+        raise
+    except ConcordRecordGraphError as error:
+        raise ConcordStorageGraphIntegrityError(
+            "snapshot graph is invalid.", issues=error.issues
+        ) from error
+    except ValueError as error:
+        raise ConcordStorageIntegrityError(
+            f"snapshot graph is invalid: {error}"
+        ) from error
+    return value, _sha(data)
+
+
+def list_work_snapshots(
+    workspace_root: str | Path, work: ModuleWorkRef
+) -> tuple[int, ...]:
+    result: list[int] = []
+    for path in _visible(snapshots_path(workspace_root, work), "snapshots"):
+        if (
+            path.is_symlink()
+            or not path.is_file()
+            or not path.name.endswith(".json")
+            or not path.stem.isdigit()
+            or path.stem.startswith("0")
+        ):
+            raise ConcordStorageIntegrityError(f"unexpected snapshot entry: {path}")
+        revision = int(path.stem)
+        load_work_snapshot(workspace_root, work, revision)
+        result.append(revision)
+    return tuple(sorted(result))
+
+
+def load_current_snapshot(
+    workspace_root: str | Path, work: ModuleWorkRef
+) -> ConcordCurrentSnapshot:
+    value, _ = _parse(
+        current_snapshot_path(workspace_root, work), current_from_dict, missing=True
+    )
+    if value.work != work:
+        raise ConcordStorageIntegrityError(
+            "current pointer work disagrees with canonical path."
+        )
+    _, digest = load_work_snapshot(workspace_root, work, value.snapshot_revision)
+    if digest != value.snapshot_sha256:
+        raise ConcordStorageIntegrityError("current pointer snapshot digest mismatch.")
+    return value
+
+
+def load_current_record_graph(
+    workspace_root: str | Path, work: ModuleWorkRef, *, standards_library: Any = None
+) -> ConcordLoadedRecordGraph:
+    load_work_marker(workspace_root, work)
+    current = load_current_snapshot(workspace_root, work)
+    snapshot, _ = load_work_snapshot(workspace_root, work, current.snapshot_revision)
+    collections: dict[str, list[Record]] = {
+        d.graph_collection: [] for d in RECORD_DESCRIPTORS
+    }
+    for ref in snapshot.records:
+        record, _ = load_record_revision(
+            workspace_root, work, ref.record_kind, ref.record_id, ref.record_revision
+        )
+        collections[descriptor_for_kind(ref.record_kind).graph_collection].append(
+            record
+        )
+    graph = ConcordRecordGraph(
+        **cast(Any, {key: tuple(values) for key, values in collections.items()})
+    )
+    if len(graph.activities) != 1 or graph.activities[0].work_reference != work:
+        raise ConcordStorageIntegrityError(
+            "snapshot must contain exactly one matching Activity."
+        )
+    try:
+        validate_record_graph(graph)
+        requires_standards = (
+            graph.activities[0].scoring_orientation in {"standards_based", "mixed"}
+            or any(item.criterion_kind == "standard_backed" for item in graph.criteria)
+            or any(item.score_kind == "standard_backed" for item in graph.score_records)
+        )
+        if requires_standards:
+            if standards_library is None:
+                raise ConcordStorageValidationError(
+                    "standards_library is required for this Activity."
+                )
+            validate_core_standards(graph, standards_library)
+    except ConcordStorageValidationError:
+        raise
+    except ConcordRecordGraphError as error:
+        raise ConcordStorageGraphIntegrityError(
+            "current graph is invalid.", issues=error.issues
+        ) from error
+    except ValueError as error:
+        raise ConcordStorageIntegrityError(
+            f"current graph is invalid: {error}"
+        ) from error
+    return ConcordLoadedRecordGraph(
+        graph, current.snapshot_revision, current.snapshot_sha256
+    )
+
+
+def load_current_record(
+    workspace_root: str | Path, work: ModuleWorkRef, record_kind: str, record_id: str
+) -> tuple[Record, ConcordRecordRevision]:
+    current = load_current_snapshot(workspace_root, work)
+    snapshot, _ = load_work_snapshot(workspace_root, work, current.snapshot_revision)
+    ref = next(
+        (
+            r
+            for r in snapshot.records
+            if (r.record_kind, r.record_id) == (record_kind, record_id)
+        ),
+        None,
+    )
+    if ref is None:
+        raise ConcordStorageNotFoundError(
+            f"record is not selected by current snapshot: {record_kind}:{record_id}"
+        )
+    return load_record_revision(
+        workspace_root, work, record_kind, record_id, ref.record_revision
+    )
+
+
+def list_activity_work_refs(
+    workspace_root: str | Path, class_id: str
+) -> tuple[ModuleWorkRef, ...]:
+    root = module_work_collection_dir(
+        resolve_workspace_root(workspace_root), class_id, "concord"
+    )
+    result: list[ModuleWorkRef] = []
+    for entry in _visible(root, "Concord work collection"):
+        if entry.is_symlink() or not entry.is_dir():
+            raise ConcordStorageIntegrityError(f"unexpected work entry: {entry}")
+        work = ModuleWorkRef(module_id="concord", class_id=class_id, work_id=entry.name)
+        marker = load_work_marker(workspace_root, work)
+        if marker.work != work:
+            raise ConcordStorageIntegrityError("discovered marker identity mismatch.")
+        result.append(work)
+    return tuple(sorted(result, key=lambda w: w.work_id))
+
+
+def _validate_canonical_write_history(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+    current_snapshot: ConcordWorkSnapshot | None,
+) -> None:
+    try:
+        snapshot_revisions = list_work_snapshots(workspace_root, work)
+        record_identities = list_record_identities(workspace_root, work)
+    except ConcordStorageIntegrityError:
+        raise
+    except ConcordStorageError as error:
+        raise ConcordStorageIntegrityError(
+            "canonical history cannot be proven safe for writing."
+        ) from error
+
+    if current_snapshot is None:
+        if snapshot_revisions or record_identities:
+            raise ConcordStorageIntegrityError(
+                "orphan canonical history blocks initial creation."
+            )
+        return
+
+    expected_snapshots = tuple(range(1, current_snapshot.snapshot_revision + 1))
+    if snapshot_revisions != expected_snapshots:
+        raise ConcordStorageIntegrityError(
+            "snapshot history is noncontiguous or contains orphan revisions."
+        )
+
+    selected = {
+        (reference.record_kind, reference.record_id): reference
+        for reference in current_snapshot.records
+    }
+    if record_identities != tuple(sorted(selected)):
+        raise ConcordStorageIntegrityError(
+            "canonical record identities disagree with the current snapshot."
+        )
+
+    for identity, reference in sorted(selected.items()):
+        revisions = list_record_revisions(
+            workspace_root,
+            work,
+            identity[0],
+            identity[1],
+        )
+        expected_revisions = tuple(range(1, reference.record_revision + 1))
+        if revisions != expected_revisions:
+            raise ConcordStorageIntegrityError(
+                "record history is noncontiguous or contains an orphan "
+                f"revision for {identity[0]}:{identity[1]}."
+            )
+
+
+def _write_exclusive(path: Path, data: bytes) -> None:
+    created = False
+    file_synced = False
+    try:
+        _require_no_symlink_ancestors(path)
+        with path.open("xb") as target:
+            created = True
+            target.write(data)
+            target.flush()
+            os.fsync(target.fileno())
+            file_synced = True
+        _fsync_directory_if_supported(path.parent)
+    except FileExistsError as error:
+        raise ConcordStorageConflictError(
+            f"immutable canonical file already exists: {path}"
+        ) from error
+    except OSError as error:
+        if created and not file_synced:
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError as cleanup_error:
+                raise ConcordStoragePartialSuccessError(
+                    "exclusive write failed and the partially written file "
+                    "could not be removed.",
+                    durable_paths=(str(path),),
+                    pointer_published=False,
+                    snapshot_revision=None,
+                    snapshot_sha256=None,
+                ) from cleanup_error
+        if created and file_synced:
+            raise ConcordStoragePartialSuccessError(
+                "canonical file bytes were written and synchronized, but "
+                "directory durability could not be confirmed.",
+                durable_paths=(str(path),),
+                pointer_published=False,
+                snapshot_revision=None,
+                snapshot_sha256=None,
+            ) from error
+        raise ConcordStorageWriteError(f"could not write {path}: {error}") from error
+
+
+def _require_safe_storage_directories(
+    workspace_root: str | Path, work: ModuleWorkRef
+) -> None:
+    root = resolve_workspace_root(workspace_root)
+    canonical_work = work_root(root, work)
+    try:
+        canonical_work.relative_to(root)
+    except ValueError as error:
+        raise ConcordStorageIntegrityError(
+            "Core work root is outside the resolved workspace root."
+        ) from error
+    state = state_path(root, work)
+    for path in (
+        canonical_work,
+        state,
+        records_path(root, work),
+        snapshots_path(root, work),
+        locks_path(root, work),
+    ):
+        if path.exists() and (path.is_symlink() or not path.is_dir()):
+            raise ConcordStorageIntegrityError(
+                f"canonical storage directory is unsafe: {path}"
+            )
+
+
+def _lock_bytes(work: ModuleWorkRef, purpose: str) -> bytes:
+    return canonical_json_bytes(
+        {
+            "schema_version": "1",
+            "record_type": "concord_storage_lock",
+            "work": module_work_ref_to_dict(work),
+            "purpose": purpose,
+        }
+    )
+
+
+def _publish(path: Path, data: bytes) -> None:
+    temp: Path | None = None
+    try:
+        _require_no_symlink_ancestors(path)
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            delete=False,
+            dir=path.parent,
+            prefix=".current.json.",
+            suffix=".tmp",
+        ) as target:
+            temp = Path(target.name)
+            target.write(data)
+            target.flush()
+            os.fsync(target.fileno())
+        os.replace(temp, path)
+        temp = None
+    except OSError as error:
+        raise ConcordStorageWriteError(
+            f"could not atomically publish {path}: {error}"
+        ) from error
+    finally:
+        if temp is not None:
+            try:
+                temp.unlink()
+            except OSError:
+                pass
+
+
+def _fsync_directory_if_supported(path: Path) -> None:
+    if os.name == "nt":
+        return
+
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _graph_from_records(records: Iterable[Record]) -> ConcordRecordGraph:
+    collections: dict[str, list[Record]] = {
+        d.graph_collection: [] for d in RECORD_DESCRIPTORS
+    }
+    for record in records:
+        collections[descriptor_for_record(record).graph_collection].append(record)
+    return ConcordRecordGraph(
+        **cast(Any, {key: tuple(value) for key, value in collections.items()})
+    )
+
+
+def _records_by_identity(
+    graph: ConcordRecordGraph,
+) -> dict[tuple[str, str], Record]:
+    return {
+        (descriptor.kind, str(getattr(record, descriptor.identity_field))): record
+        for descriptor in RECORD_DESCRIPTORS
+        for record in getattr(graph, descriptor.graph_collection)
+    }
+
+
+def _validate_candidate(
+    work: ModuleWorkRef, graph: ConcordRecordGraph, standards_library: Any
+) -> None:
+    if len(graph.activities) != 1 or graph.activities[0].work_reference != work:
+        raise ConcordStorageValidationError(
+            "candidate graph must contain exactly one Activity matching work."
+        )
+    try:
+        validate_record_graph(graph)
+    except ValueError as error:
+        raise ConcordStorageValidationError(
+            f"candidate graph is invalid: {error}"
+        ) from error
+    activity = graph.activities[0]
+    requires_standards = (
+        activity.scoring_orientation in {"standards_based", "mixed"}
+        or any(item.criterion_kind == "standard_backed" for item in graph.criteria)
+        or any(item.score_kind == "standard_backed" for item in graph.score_records)
+    )
+    if requires_standards:
+        if standards_library is None:
+            raise ConcordStorageValidationError(
+                "standards_library is required for this Activity."
+            )
+        try:
+            validate_core_standards(graph, standards_library)
+        except ValueError as error:
+            raise ConcordStorageValidationError(
+                f"candidate standards selection is invalid: {error}"
+            ) from error
+
+
+def commit_record_batch(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+    records: Iterable[Record],
+    *,
+    expected_snapshot_revision: int | None,
+    standards_library: Any = None,
+) -> ConcordStorageCommitResult:
+    if not isinstance(work, ModuleWorkRef) or work.module_id != "concord":
+        raise ConcordStorageValidationError("work must be a Concord ModuleWorkRef.")
+    candidates = tuple(records)
+    if not candidates:
+        raise ConcordStorageValidationError(
+            "records must contain one or more native records."
+        )
+    candidate_map: dict[tuple[str, str], Record] = {}
+    for record in candidates:
+        try:
+            descriptor = descriptor_for_record(record)
+        except ValueError as error:
+            raise ConcordStorageValidationError(str(error)) from error
+        identity = (descriptor.kind, str(getattr(record, descriptor.identity_field)))
+        if identity in candidate_map:
+            raise ConcordStorageValidationError(
+                f"duplicate candidate identity {identity[0]}:{identity[1]}."
+            )
+        candidate_map[identity] = record
+    if expected_snapshot_revision is not None and (
+        type(expected_snapshot_revision) is not int or expected_snapshot_revision < 1
+    ):
+        raise ConcordStorageValidationError(
+            "expected_snapshot_revision must be a positive integer or None."
+        )
+    status = inspect_workspace_root(workspace_root)
+    if not status.exists or not status.is_dir or not status.is_writable:
+        raise ConcordStorageWriteError(
+            "an existing writable Core workspace is required."
+        )
+    try:
+        metadata = load_class_metadata_for_class(status.root, work.class_id)
+    except ValueError as error:
+        raise ConcordStorageWriteError(
+            "an existing matching Core class is required."
+        ) from error
+    if metadata.class_id != work.class_id:
+        raise ConcordStorageValidationError("Core class identity mismatch.")
+    _require_safe_storage_directories(status.root, work)
+    lock_dir = locks_path(status.root, work)
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    _require_safe_storage_directories(status.root, work)
+    lock = write_lock_path(status.root, work)
+    acquired = False
+    pointer_published = False
+    published_snapshot_revision: int | None = None
+    published_snapshot_sha256: str | None = None
+    durable: list[str] = []
+    result: ConcordStorageCommitResult | None = None
+    operation_error: Exception | None = None
+    lock_cleanup_error: OSError | None = None
+
+    class _CommitComplete(Exception):
+        pass
+
+    try:
+        try:
+            with lock.open("xb") as target:
+                acquired = True
+                target.write(_lock_bytes(work, "canonical_commit"))
+                target.flush()
+                os.fsync(target.fileno())
+
+            _fsync_directory_if_supported(lock.parent)
+        except FileExistsError as error:
+            raise ConcordStorageConflictError(
+                f"Concord write lock already exists: {lock}"
+            ) from error
+        except OSError as error:
+            raise ConcordStorageWriteError(
+                f"could not durably acquire Concord write lock {lock}: {error}"
+            ) from error
+        marker_exists = work_marker_path(status.root, work).exists()
+        current_exists = current_snapshot_path(status.root, work).exists()
+        if marker_exists != current_exists:
+            raise ConcordStorageIntegrityError(
+                "marker/current presence is contradictory."
+            )
+        if current_exists:
+            loaded = load_current_record_graph(
+                status.root, work, standards_library=standards_library
+            )
+            current_revision = loaded.snapshot_revision
+            current_snapshot, _ = load_work_snapshot(
+                status.root, work, current_revision
+            )
+            _validate_canonical_write_history(
+                status.root,
+                work,
+                current_snapshot,
+            )
+            if expected_snapshot_revision is None:
+                existing = _records_by_identity(loaded.graph)
+                if existing == candidate_map:
+                    result = ConcordStorageCommitResult(
+                        work, current_revision, loaded.snapshot_sha256, (), True
+                    )
+                    raise _CommitComplete
+                raise ConcordStorageConflictError(
+                    "initial commit requested for existing work."
+                )
+            if current_revision != expected_snapshot_revision:
+                raise ConcordStorageConflictError(
+                    f"expected snapshot {expected_snapshot_revision}, "
+                    f"found {current_revision}."
+                )
+            selected = {
+                (r.record_kind, r.record_id): r for r in current_snapshot.records
+            }
+            all_records = _records_by_identity(loaded.graph)
+        else:
+            if expected_snapshot_revision is not None:
+                raise ConcordStorageConflictError(
+                    "no current snapshot exists for expected revision."
+                )
+            _validate_canonical_write_history(status.root, work, None)
+            current_revision = 0
+            selected = {}
+            all_records = {}
+        all_records.update(candidate_map)
+        graph = _graph_from_records(all_records.values())
+        _validate_candidate(work, graph, standards_library)
+        changed: list[tuple[tuple[str, str], Record, int]] = []
+        for identity, record in sorted(candidate_map.items()):
+            ref = selected.get(identity)
+            if ref is not None:
+                old, _ = load_record_revision(
+                    status.root, work, *identity, ref.record_revision
+                )
+                if record_to_dict(old) == record_to_dict(record):
+                    continue
+                revision = ref.record_revision + 1
+            else:
+                revision = 1
+            if record_revision_path(status.root, work, *identity, revision).exists():
+                raise ConcordStorageIntegrityError(
+                    "orphan/colliding record revision blocks commit: "
+                    f"{identity[0]}:{identity[1]}:{revision}"
+                )
+            changed.append((identity, record, revision))
+        if not changed and current_revision:
+            current = load_current_snapshot(status.root, work)
+            result = ConcordStorageCommitResult(
+                work, current.snapshot_revision, current.snapshot_sha256, (), True
+            )
+            raise _CommitComplete
+        state_path(status.root, work).mkdir(parents=True, exist_ok=True)
+        if not marker_exists:
+            marker = ConcordWorkMarker(
+                CONCORD_STORAGE_SCHEMA_VERSION,
+                "concord_work",
+                work,
+                work.work_id,
+                CONCORD_NATIVE_RECORD_CONTRACT_VERSION,
+            )
+            path = work_marker_path(status.root, work)
+            _write_exclusive(path, serialize(marker))
+            durable.append(str(path))
+        new_refs = dict(selected)
+        created: list[ConcordRecordRevisionRef] = []
+        for identity, record, revision in changed:
+            path = record_revision_path(status.root, work, *identity, revision)
+            _require_no_symlink_ancestors(path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            envelope = ConcordRecordRevision(
+                CONCORD_STORAGE_SCHEMA_VERSION,
+                "concord_record_revision",
+                work,
+                identity[0],
+                identity[1],
+                revision,
+                CONCORD_NATIVE_RECORD_CONTRACT_VERSION,
+                cast(Any, record_to_dict(record)),
+            )
+            data = serialize(envelope)
+            _write_exclusive(path, data)
+            durable.append(str(path))
+            persisted, persisted_envelope = load_record_revision(
+                status.root, work, identity[0], identity[1], revision
+            )
+            if persisted != record or persisted_envelope != envelope:
+                raise ConcordStorageIntegrityError(
+                    "newly written record revision failed exact verification."
+                )
+            ref = ConcordRecordRevisionRef(
+                identity[0], identity[1], revision, _sha(data)
+            )
+            new_refs[identity] = ref
+            created.append(ref)
+        next_revision = current_revision + 1
+        if snapshot_path(status.root, work, next_revision).exists():
+            raise ConcordStorageIntegrityError(
+                "orphan/colliding snapshot blocks commit."
+            )
+        previous_digest = None
+        if current_revision:
+            _, previous_digest = load_work_snapshot(status.root, work, current_revision)
+        snapshot = ConcordWorkSnapshot(
+            CONCORD_STORAGE_SCHEMA_VERSION,
+            "concord_work_snapshot",
+            work,
+            next_revision,
+            current_revision or None,
+            previous_digest,
+            tuple(
+                sorted(new_refs.values(), key=lambda r: (r.record_kind, r.record_id))
+            ),
+        )
+        snapshot_data = serialize(snapshot)
+        _require_no_symlink_ancestors(snapshot_path(status.root, work, next_revision))
+        snapshot_path(status.root, work, next_revision).parent.mkdir(
+            parents=True, exist_ok=True
+        )
+        _write_exclusive(snapshot_path(status.root, work, next_revision), snapshot_data)
+        durable.append(str(snapshot_path(status.root, work, next_revision)))
+        verified_snapshot, verified_digest = load_work_snapshot(
+            status.root, work, next_revision
+        )
+        if verified_snapshot != snapshot or verified_digest != _sha(snapshot_data):
+            raise ConcordStorageIntegrityError(
+                "newly written snapshot failed exact verification."
+            )
+        pointer = ConcordCurrentSnapshot(
+            CONCORD_STORAGE_SCHEMA_VERSION,
+            "concord_current_snapshot",
+            work,
+            next_revision,
+            _sha(snapshot_data),
+        )
+        current_path = current_snapshot_path(status.root, work)
+        _publish(current_path, serialize(pointer))
+        pointer_published = True
+        published_snapshot_revision = next_revision
+        published_snapshot_sha256 = pointer.snapshot_sha256
+        durable.append(str(current_path))
+        _fsync_directory_if_supported(current_path.parent)
+        verified = load_current_record_graph(
+            status.root, work, standards_library=standards_library
+        )
+        if _records_by_identity(verified.graph) != _records_by_identity(graph):
+            raise ConcordStorageIntegrityError(
+                "published graph differs from validated candidate."
+            )
+        result = ConcordStorageCommitResult(
+            work, next_revision, pointer.snapshot_sha256, tuple(created)
+        )
+    except _CommitComplete:
+        pass
+    except Exception as error:
+        operation_error = error
+
+    if acquired:
+        try:
+            lock.unlink()
+            _fsync_directory_if_supported(lock.parent)
+        except OSError as error:
+            lock_cleanup_error = error
+
+    reported_paths = list(durable)
+    if isinstance(operation_error, ConcordStoragePartialSuccessError):
+        reported_paths.extend(operation_error.durable_paths)
+    if lock_cleanup_error is not None:
+        reported_paths.append(str(lock))
+    unique_paths = tuple(dict.fromkeys(reported_paths))
+
+    if operation_error is not None:
+        if pointer_published:
+            raise ConcordStoragePartialSuccessError(
+                "canonical current state was published, but final verification failed.",
+                durable_paths=unique_paths,
+                pointer_published=True,
+                snapshot_revision=published_snapshot_revision,
+                snapshot_sha256=published_snapshot_sha256,
+            ) from operation_error
+        if unique_paths:
+            message = (
+                str(operation_error)
+                if isinstance(operation_error, ConcordStoragePartialSuccessError)
+                else "commit stopped after canonical files may have become durable; "
+                "current pointer was not advanced."
+            )
+            raise ConcordStoragePartialSuccessError(
+                message,
+                durable_paths=unique_paths,
+                pointer_published=False,
+                snapshot_revision=None,
+                snapshot_sha256=None,
+            ) from operation_error
+        raise operation_error
+
+    if lock_cleanup_error is not None:
+        raise ConcordStoragePartialSuccessError(
+            "storage operation succeeded, but write.lock could not be removed.",
+            durable_paths=unique_paths,
+            pointer_published=pointer_published,
+            snapshot_revision=published_snapshot_revision,
+            snapshot_sha256=published_snapshot_sha256,
+        ) from lock_cleanup_error
+
+    if result is None:
+        raise ConcordStorageWriteError("storage operation produced no result.")
+    return result

--- a/concord/storage_catalog.py
+++ b/concord/storage_catalog.py
@@ -1,0 +1,391 @@
+"""Disposable per-Activity SQLite catalog rebuilt from canonical JSON."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import sqlite3
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pds_core.routing_models import ModuleWorkRef, module_work_ref_to_dict
+
+from concord.storage import (
+    _fsync_directory_if_supported,
+    list_record_identities,
+    list_record_revisions,
+    list_work_snapshots,
+    load_current_snapshot,
+    load_record_revision,
+    load_work_marker,
+    load_work_snapshot,
+    read_canonical_bytes,
+    require_regular_nonsymlink_file,
+)
+from concord.storage_errors import (
+    ConcordCatalogBuildError,
+    ConcordCatalogCompatibilityError,
+    ConcordCatalogConflictError,
+    ConcordCatalogIntegrityError,
+    ConcordCatalogNotFoundError,
+    ConcordCatalogSourceError,
+    ConcordStorageError,
+    ConcordStorageNotFoundError,
+)
+from concord.storage_models import CONCORD_CATALOG_SCHEMA_VERSION
+from concord.storage_paths import catalog_lock_path, catalog_path
+from concord.storage_serialization import canonical_json_bytes
+
+CATALOG_APPLICATION_ID = 0x434F4E43
+
+
+@dataclass(frozen=True, slots=True)
+class CatalogRecordRow:
+    record_kind: str
+    record_id: str
+    record_revision: int
+    sha256: str
+    selected_snapshot_revision: int | None
+    is_current: bool
+
+
+def canonical_source_inventory(
+    workspace_root: str | Path, work: ModuleWorkRef
+) -> tuple[tuple[str, int, str], ...]:
+    load_work_marker(workspace_root, work)
+    load_current_snapshot(workspace_root, work)
+    paths: list[Path] = []
+    from concord.storage_paths import (
+        current_snapshot_path,
+        record_revision_path,
+        snapshot_path,
+        state_path,
+        work_marker_path,
+    )
+
+    paths.append(work_marker_path(workspace_root, work))
+    for kind, record_id in list_record_identities(workspace_root, work):
+        for revision in list_record_revisions(workspace_root, work, kind, record_id):
+            paths.append(
+                record_revision_path(workspace_root, work, kind, record_id, revision)
+            )
+    for revision in list_work_snapshots(workspace_root, work):
+        paths.append(snapshot_path(workspace_root, work, revision))
+    paths.append(current_snapshot_path(workspace_root, work))
+    base = state_path(workspace_root, work)
+    result = []
+    for path in paths:
+        data = read_canonical_bytes(path, missing=True)
+        result.append(
+            (
+                path.relative_to(base).as_posix(),
+                len(data),
+                hashlib.sha256(data).hexdigest(),
+            )
+        )
+    return tuple(sorted(result))
+
+
+def source_inventory_digest(inventory: tuple[tuple[str, int, str], ...]) -> str:
+    digest = hashlib.sha256()
+    for relative, size, sha in inventory:
+        encoded = relative.encode("utf-8")
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+        digest.update(size.to_bytes(8, "big"))
+        digest.update(bytes.fromhex(sha))
+    return digest.hexdigest()
+
+
+def rebuild_catalog(workspace_root: str | Path, work: ModuleWorkRef) -> Path:
+    target = catalog_path(workspace_root, work)
+    for ancestor in (target, *target.parents):
+        if ancestor.is_symlink():
+            raise ConcordCatalogSourceError(
+                f"catalog path traverses a symlink: {ancestor}"
+            )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    lock = catalog_lock_path(workspace_root, work)
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    acquired = False
+    installed = False
+    temporary: Path | None = None
+    result: Path | None = None
+    operation_error: Exception | None = None
+    lock_cleanup_error: OSError | None = None
+    try:
+        try:
+            with lock.open("xb") as output:
+                acquired = True
+                output.write(
+                    canonical_json_bytes(
+                        {
+                            "schema_version": "1",
+                            "record_type": "concord_storage_lock",
+                            "work": module_work_ref_to_dict(work),
+                            "purpose": "catalog_rebuild",
+                        }
+                    )
+                )
+                output.flush()
+                os.fsync(output.fileno())
+
+            _fsync_directory_if_supported(lock.parent)
+        except FileExistsError as error:
+            raise ConcordCatalogConflictError(
+                f"catalog lock already exists: {lock}"
+            ) from error
+        before = canonical_source_inventory(workspace_root, work)
+        source_digest = source_inventory_digest(before)
+        current = load_current_snapshot(workspace_root, work)
+        selected: dict[tuple[str, str, int], list[int]] = {}
+        digests: dict[tuple[str, str, int], str] = {}
+        for snapshot_revision in list_work_snapshots(workspace_root, work):
+            snapshot, _ = load_work_snapshot(workspace_root, work, snapshot_revision)
+            for ref in snapshot.records:
+                key = (ref.record_kind, ref.record_id, ref.record_revision)
+                selected.setdefault(key, []).append(snapshot_revision)
+                digests[key] = ref.sha256
+        fd, name = tempfile.mkstemp(
+            prefix=".catalog.sqlite.", suffix=".tmp", dir=target.parent
+        )
+        os.close(fd)
+        temporary = Path(name)
+        connection = sqlite3.connect(temporary)
+        try:
+            connection.executescript("""
+                PRAGMA journal_mode=DELETE;
+                PRAGMA application_id=1129270851;
+                CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+                CREATE TABLE record_revisions (
+                    record_kind TEXT NOT NULL, record_id TEXT NOT NULL,
+                    record_revision INTEGER NOT NULL, sha256 TEXT NOT NULL,
+                    relative_path TEXT NOT NULL,
+                    PRIMARY KEY(record_kind, record_id, record_revision));
+                CREATE TABLE snapshot_records (
+                    snapshot_revision INTEGER NOT NULL, record_kind TEXT NOT NULL,
+                    record_id TEXT NOT NULL, record_revision INTEGER NOT NULL,
+                    is_current INTEGER NOT NULL,
+                    PRIMARY KEY(snapshot_revision, record_kind, record_id));
+                CREATE INDEX snapshot_records_identity
+                    ON snapshot_records(record_kind, record_id, record_revision);
+            """)
+            identity_count = len(list_record_identities(workspace_root, work))
+            revision_count = sum(
+                len(list_record_revisions(workspace_root, work, kind, record_id))
+                for kind, record_id in list_record_identities(workspace_root, work)
+            )
+            connection.executemany(
+                "INSERT INTO metadata VALUES (?, ?)",
+                (
+                    ("schema_version", str(CONCORD_CATALOG_SCHEMA_VERSION)),
+                    ("application_id", str(CATALOG_APPLICATION_ID)),
+                    ("built_at_utc", datetime.now(timezone.utc).isoformat()),
+                    ("work_module_id", work.module_id),
+                    ("work_class_id", work.class_id),
+                    ("work_id", work.work_id),
+                    ("source_digest", source_digest),
+                    ("source_file_count", str(len(before))),
+                    ("current_snapshot_revision", str(current.snapshot_revision)),
+                    ("current_snapshot_sha256", current.snapshot_sha256),
+                    ("record_identity_count", str(identity_count)),
+                    ("record_revision_count", str(revision_count)),
+                    (
+                        "snapshot_count",
+                        str(len(list_work_snapshots(workspace_root, work))),
+                    ),
+                ),
+            )
+            for kind, record_id in list_record_identities(workspace_root, work):
+                for revision in list_record_revisions(
+                    workspace_root, work, kind, record_id
+                ):
+                    _, envelope = load_record_revision(
+                        workspace_root, work, kind, record_id, revision
+                    )
+                    sha = digests.get((kind, record_id, revision))
+                    if sha is None:
+                        from concord.storage_serialization import serialize
+
+                        sha = hashlib.sha256(serialize(envelope)).hexdigest()
+                    connection.execute(
+                        "INSERT INTO record_revisions VALUES (?, ?, ?, ?, ?)",
+                        (
+                            kind,
+                            record_id,
+                            revision,
+                            sha,
+                            (f"records/{kind}/{record_id}/revisions/{revision}.json"),
+                        ),
+                    )
+            for key, snapshots in selected.items():
+                for snapshot_revision in snapshots:
+                    connection.execute(
+                        "INSERT INTO snapshot_records VALUES (?, ?, ?, ?, ?)",
+                        (
+                            snapshot_revision,
+                            *key,
+                            int(snapshot_revision == current.snapshot_revision),
+                        ),
+                    )
+            connection.commit()
+            if connection.execute("PRAGMA integrity_check").fetchone() != ("ok",):
+                raise ConcordCatalogIntegrityError(
+                    "replacement catalog failed integrity_check."
+                )
+        finally:
+            connection.close()
+        after = canonical_source_inventory(workspace_root, work)
+        if after != before:
+            raise ConcordCatalogConflictError(
+                "canonical source changed during catalog rebuild."
+            )
+        os.replace(temporary, target)
+        installed = True
+        temporary = None
+        _open_verified(workspace_root, work).close()
+        result = target
+    except (ConcordCatalogConflictError, ConcordCatalogIntegrityError) as error:
+        operation_error = error
+    except Exception as error:
+        operation_error = ConcordCatalogBuildError(f"catalog rebuild failed: {error}")
+
+    if temporary is not None:
+        try:
+            temporary.unlink()
+        except OSError as error:
+            if operation_error is None:
+                operation_error = ConcordCatalogBuildError(
+                    "catalog rebuild failed and its temporary file remains."
+                )
+                operation_error.__cause__ = error
+
+    if acquired:
+        try:
+            lock.unlink()
+            _fsync_directory_if_supported(lock.parent)
+        except OSError as error:
+            lock_cleanup_error = error
+
+    if lock_cleanup_error is not None:
+        if installed:
+            raise ConcordCatalogBuildError(
+                "catalog was installed successfully, but catalog.lock could not "
+                "be removed."
+            ) from lock_cleanup_error
+        raise ConcordCatalogBuildError(
+            "catalog rebuild failed and catalog.lock could not be removed; the "
+            "lock may remain."
+        ) from lock_cleanup_error
+
+    if operation_error is not None:
+        raise operation_error
+    if result is None:
+        raise ConcordCatalogBuildError("catalog rebuild produced no result.")
+    return result
+
+
+def _open_verified(
+    workspace_root: str | Path, work: ModuleWorkRef
+) -> sqlite3.Connection:
+    path = catalog_path(workspace_root, work)
+    try:
+        require_regular_nonsymlink_file(path, missing=True)
+    except ConcordStorageNotFoundError as error:
+        raise ConcordCatalogNotFoundError(f"catalog not found: {path}") from error
+    except ConcordStorageError as error:
+        raise ConcordCatalogIntegrityError(f"catalog path is unsafe: {path}") from error
+    try:
+        connection = sqlite3.connect(f"file:{path.as_posix()}?mode=ro", uri=True)
+        metadata = dict(connection.execute("SELECT key, value FROM metadata"))
+        if metadata.get("schema_version") != str(CONCORD_CATALOG_SCHEMA_VERSION):
+            raise ConcordCatalogCompatibilityError(
+                "catalog schema version is incompatible."
+            )
+        application_id = connection.execute("PRAGMA application_id").fetchone()
+        if application_id != (CATALOG_APPLICATION_ID,):
+            raise ConcordCatalogCompatibilityError(
+                "catalog application identifier is incompatible."
+            )
+        expected_work = (work.module_id, work.class_id, work.work_id)
+        actual_work = (
+            metadata.get("work_module_id"),
+            metadata.get("work_class_id"),
+            metadata.get("work_id"),
+        )
+        if actual_work != expected_work:
+            raise ConcordCatalogIntegrityError(
+                "catalog work identity differs from its canonical path."
+            )
+        actual = source_inventory_digest(
+            canonical_source_inventory(workspace_root, work)
+        )
+        if metadata.get("source_digest") != actual:
+            raise ConcordCatalogSourceError(
+                "catalog is stale relative to canonical storage."
+            )
+        if connection.execute("PRAGMA integrity_check").fetchone() != ("ok",):
+            raise ConcordCatalogIntegrityError("catalog is corrupt.")
+        return connection
+    except (
+        ConcordCatalogCompatibilityError,
+        ConcordCatalogSourceError,
+        ConcordCatalogIntegrityError,
+    ):
+        try:
+            connection.close()
+        except UnboundLocalError:
+            pass
+        raise
+    except sqlite3.Error as error:
+        raise ConcordCatalogIntegrityError(f"catalog is corrupt: {error}") from error
+
+
+def query_catalog_records(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+    *,
+    snapshot_revision: int | None = None,
+    state: str = "all",
+) -> tuple[CatalogRecordRow, ...]:
+    if state not in {"all", "current", "historical"}:
+        raise ValueError("state must be current, historical, or all.")
+    if snapshot_revision is not None and state != "all":
+        raise ValueError("state filtering cannot be combined with snapshot_revision.")
+    connection = _open_verified(workspace_root, work)
+    try:
+        if snapshot_revision is None:
+            current_clause = {
+                "all": "",
+                "current": "WHERE EXISTS (SELECT 1 FROM snapshot_records x "
+                "WHERE x.record_kind=r.record_kind AND x.record_id=r.record_id "
+                "AND x.record_revision=r.record_revision AND x.is_current=1)",
+                "historical": "WHERE NOT EXISTS (SELECT 1 FROM snapshot_records x "
+                "WHERE x.record_kind=r.record_kind AND x.record_id=r.record_id "
+                "AND x.record_revision=r.record_revision AND x.is_current=1)",
+            }[state]
+            sql = f"""SELECT r.record_kind,r.record_id,r.record_revision,r.sha256,
+                (SELECT MAX(x.snapshot_revision) FROM snapshot_records x
+                 WHERE x.record_kind=r.record_kind AND x.record_id=r.record_id
+                 AND x.record_revision=r.record_revision),
+                EXISTS (SELECT 1 FROM snapshot_records x
+                 WHERE x.record_kind=r.record_kind AND x.record_id=r.record_id
+                 AND x.record_revision=r.record_revision AND x.is_current=1)
+                FROM record_revisions r {current_clause} ORDER BY 1,2,3"""
+            params: tuple[object, ...] = ()
+        else:
+            if type(snapshot_revision) is not int or snapshot_revision < 1:
+                raise ValueError("snapshot_revision must be positive.")
+            sql = """SELECT r.record_kind,r.record_id,r.record_revision,r.sha256,
+                s.snapshot_revision,s.is_current FROM snapshot_records s
+                JOIN record_revisions r USING(record_kind,record_id,record_revision)
+                WHERE s.snapshot_revision=? ORDER BY 1,2,3"""
+            params = (snapshot_revision,)
+        return tuple(
+            CatalogRecordRow(row[0], row[1], row[2], row[3], row[4], bool(row[5]))
+            for row in connection.execute(sql, params)
+        )
+    finally:
+        connection.close()

--- a/concord/storage_diagnostics.py
+++ b/concord/storage_diagnostics.py
@@ -1,0 +1,299 @@
+"""Privacy-safe deterministic diagnostics for Concord storage."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+
+from pds_core.routing_models import ModuleWorkRef
+
+from concord.storage import (
+    list_record_identities,
+    list_record_revisions,
+    list_work_snapshots,
+    load_current_record_graph,
+    load_current_snapshot,
+    read_canonical_bytes,
+)
+from concord.storage_catalog import _open_verified
+from concord.storage_errors import (
+    ConcordCatalogError,
+    ConcordStorageError,
+    ConcordStorageGraphIntegrityError,
+    ConcordStorageIntegrityError,
+    ConcordStorageNotFoundError,
+    ConcordStorageReadError,
+    ConcordStorageValidationError,
+)
+from concord.storage_paths import (
+    catalog_lock_path,
+    catalog_path,
+    state_path,
+    write_lock_path,
+)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class StorageIssue:
+    code: str
+    message: str
+    severity: str = "error"
+    work: ModuleWorkRef | None = None
+    record_kind: str | None = None
+    record_id: str | None = None
+    record_revision: int | None = None
+    snapshot_revision: int | None = None
+    relative_path: str | None = None
+    field_path: tuple[str | int, ...] = ()
+    related_references: tuple[str, ...] = ()
+
+    @property
+    def sort_key(self) -> tuple[object, ...]:
+        return (
+            self.code,
+            self.record_kind or "",
+            self.record_id or "",
+            self.record_revision or 0,
+            self.snapshot_revision or 0,
+            self.relative_path or "",
+            tuple(str(part) for part in self.field_path),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class LockObservation:
+    path: Path
+    present: bool
+    byte_size: int | None
+    sha256: str | None
+
+
+def inspect_storage_locks(
+    workspace_root: str | Path, work: ModuleWorkRef
+) -> tuple[LockObservation, ...]:
+    result = []
+    for path in (
+        write_lock_path(workspace_root, work),
+        catalog_lock_path(workspace_root, work),
+    ):
+        if not path.exists() and not path.is_symlink():
+            result.append(LockObservation(path, False, None, None))
+            continue
+        data = read_canonical_bytes(path)
+        result.append(
+            LockObservation(path, True, len(data), hashlib.sha256(data).hexdigest())
+        )
+    return tuple(result)
+
+
+def inspect_catalog_status(workspace_root: str | Path, work: ModuleWorkRef) -> str:
+    path = catalog_path(workspace_root, work)
+    if not path.exists() and not path.is_symlink():
+        return "missing"
+    try:
+        connection = _open_verified(workspace_root, work)
+    except ConcordCatalogError as error:
+        name = type(error).__name__.lower()
+        return (
+            "stale"
+            if "source" in name
+            else "incompatible"
+            if "compatibility" in name
+            else "corrupt"
+        )
+    connection.close()
+    return "current"
+
+
+def collect_storage_issues(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+    *,
+    standards_library: object | None = None,
+) -> tuple[StorageIssue, ...]:
+    issues: list[StorageIssue] = []
+    try:
+        loaded = load_current_record_graph(
+            workspace_root, work, standards_library=standards_library
+        )
+        current = load_current_snapshot(workspace_root, work)
+        snapshots = list_work_snapshots(workspace_root, work)
+        selected_revisions: set[tuple[str, str, int]] = set()
+        from concord.storage import load_work_snapshot
+
+        for revision in snapshots:
+            snapshot, _ = load_work_snapshot(workspace_root, work, revision)
+            selected_revisions.update(
+                (r.record_kind, r.record_id, r.record_revision)
+                for r in snapshot.records
+            )
+        for kind, record_id in list_record_identities(workspace_root, work):
+            revisions = list_record_revisions(workspace_root, work, kind, record_id)
+            if revisions and revisions != tuple(range(1, max(revisions) + 1)):
+                issues.append(
+                    StorageIssue(
+                        code="storage.record.revision_gap",
+                        message="Record revision history has a gap.",
+                        work=work,
+                        record_kind=kind,
+                        record_id=record_id,
+                    )
+                )
+            for revision in revisions:
+                if (kind, record_id, revision) not in selected_revisions:
+                    issues.append(
+                        StorageIssue(
+                            code="storage.record.orphan_revision",
+                            message=(
+                                "Immutable record revision is not selected by any "
+                                "snapshot."
+                            ),
+                            work=work,
+                            record_kind=kind,
+                            record_id=record_id,
+                            record_revision=revision,
+                        )
+                    )
+        for revision in snapshots:
+            if revision > current.snapshot_revision:
+                issues.append(
+                    StorageIssue(
+                        code="storage.snapshot.orphan",
+                        message=(
+                            "Immutable snapshot is not selected by the current chain."
+                        ),
+                        work=work,
+                        snapshot_revision=revision,
+                    )
+                )
+        if loaded.snapshot_revision != current.snapshot_revision:
+            raise AssertionError
+    except ConcordStorageGraphIntegrityError as error:
+        for graph_issue in error.issues:
+            issues.append(
+                StorageIssue(
+                    code=graph_issue.code,
+                    message=graph_issue.message,
+                    work=work,
+                    record_kind=graph_issue.record_kind,
+                    record_id=graph_issue.record_id,
+                    field_path=graph_issue.field_path,
+                    related_references=tuple(
+                        f"{reference.record_kind}:{reference.record_id}"
+                        for reference in graph_issue.related_references
+                    ),
+                )
+            )
+    except ConcordStorageNotFoundError:
+        issues.append(
+            StorageIssue(
+                code="storage.current.missing",
+                message="A required canonical storage object is missing.",
+                work=work,
+            )
+        )
+    except ConcordStorageReadError:
+        issues.append(
+            StorageIssue(
+                code="storage.read.failed",
+                message="Canonical Concord storage could not be read strictly.",
+                work=work,
+            )
+        )
+    except ConcordStorageIntegrityError:
+        issues.append(
+            StorageIssue(
+                code="storage.integrity.invalid",
+                message="Canonical Concord storage failed integrity validation.",
+                work=work,
+            )
+        )
+    except ConcordStorageValidationError as error:
+        code = (
+            "storage.standards_context.required"
+            if "standards_library is required" in str(error)
+            else "storage.validation.failed"
+        )
+        issues.append(
+            StorageIssue(
+                code=code,
+                message="Canonical Concord storage validation could not complete.",
+                work=work,
+            )
+        )
+    except ConcordStorageError:
+        issues.append(
+            StorageIssue(
+                code="storage.failed",
+                message="Canonical Concord storage validation failed.",
+                work=work,
+            )
+        )
+    canonical_state = state_path(workspace_root, work)
+    expected = {
+        "work.json",
+        "records",
+        "snapshots",
+        "current.json",
+        "derived",
+        ".locks",
+    }
+    try:
+        for entry in canonical_state.iterdir():
+            if entry.name in expected:
+                continue
+            issues.append(
+                StorageIssue(
+                    code="storage.path.unexpected_entry",
+                    message="Storage-owned state contains an unexpected entry.",
+                    work=work,
+                    relative_path=entry.name,
+                )
+            )
+    except FileNotFoundError:
+        pass
+    for observation in inspect_storage_locks(workspace_root, work):
+        if observation.present:
+            issues.append(
+                StorageIssue(
+                    code="storage.lock.present",
+                    message=(
+                        "A storage lock is present; age alone does not authorize "
+                        "removal."
+                    ),
+                    severity="warning",
+                    work=work,
+                    relative_path=observation.path.name,
+                )
+            )
+    status = inspect_catalog_status(workspace_root, work)
+    if status != "current":
+        issues.append(
+            StorageIssue(
+                code=f"storage.catalog.{status}",
+                message=f"Derived catalog status is {status}.",
+                severity="warning",
+                work=work,
+            )
+        )
+    return tuple(sorted(issues, key=lambda issue: issue.sort_key))
+
+
+def validate_storage(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+    *,
+    standards_library: object | None = None,
+) -> None:
+    issues = tuple(
+        issue
+        for issue in collect_storage_issues(
+            workspace_root, work, standards_library=standards_library
+        )
+        if issue.severity == "error"
+    )
+    if issues:
+        raise ConcordStorageError(
+            f"Concord storage has {len(issues)} integrity issue(s)."
+        )

--- a/concord/storage_errors.py
+++ b/concord/storage_errors.py
@@ -1,0 +1,87 @@
+"""Public exception taxonomy for Concord canonical storage."""
+
+from concord.validation_diagnostics import ValidationIssue
+
+
+class ConcordStorageError(RuntimeError):
+    pass
+
+
+class ConcordStorageValidationError(ConcordStorageError, ValueError):
+    pass
+
+
+class ConcordStorageReadError(ConcordStorageError):
+    pass
+
+
+class ConcordStorageNotFoundError(ConcordStorageReadError):
+    pass
+
+
+class ConcordStorageWriteError(ConcordStorageError):
+    pass
+
+
+class ConcordStorageConflictError(ConcordStorageWriteError):
+    pass
+
+
+class ConcordStoragePartialSuccessError(ConcordStorageWriteError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        durable_paths: tuple[str, ...],
+        pointer_published: bool,
+        snapshot_revision: int | None,
+        snapshot_sha256: str | None,
+    ) -> None:
+        self.durable_paths = durable_paths
+        self.pointer_published = pointer_published
+        self.snapshot_revision = snapshot_revision
+        self.snapshot_sha256 = snapshot_sha256
+        super().__init__(message)
+
+
+class ConcordStorageIntegrityError(ConcordStorageError):
+    pass
+
+
+class ConcordStorageGraphIntegrityError(ConcordStorageIntegrityError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        issues: tuple[ValidationIssue, ...],
+    ) -> None:
+        self.issues = issues
+        super().__init__(message)
+
+
+class ConcordCatalogError(ConcordStorageError):
+    pass
+
+
+class ConcordCatalogNotFoundError(ConcordCatalogError):
+    pass
+
+
+class ConcordCatalogConflictError(ConcordCatalogError):
+    pass
+
+
+class ConcordCatalogSourceError(ConcordCatalogError):
+    pass
+
+
+class ConcordCatalogIntegrityError(ConcordCatalogError):
+    pass
+
+
+class ConcordCatalogCompatibilityError(ConcordCatalogError):
+    pass
+
+
+class ConcordCatalogBuildError(ConcordCatalogError):
+    pass

--- a/concord/storage_models.py
+++ b/concord/storage_models.py
@@ -1,0 +1,197 @@
+"""Versioned immutable metadata for canonical Concord storage."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Literal, TypeAlias
+
+from pds_core.routing_models import ModuleWorkRef, validate_module_work_ref
+
+from concord.record_registry import descriptor_for_kind
+from concord.storage_errors import ConcordStorageValidationError
+
+JsonValue: TypeAlias = (
+    None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
+)
+CONCORD_STORAGE_SCHEMA_VERSION = "1"
+CONCORD_NATIVE_RECORD_CONTRACT_VERSION = "1"
+CONCORD_CATALOG_SCHEMA_VERSION = 1
+_DIGEST = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _work(value: object) -> ModuleWorkRef:
+    if not isinstance(value, ModuleWorkRef):
+        raise ConcordStorageValidationError("work must be a ModuleWorkRef.")
+    try:
+        result = validate_module_work_ref(value)
+    except ValueError as error:
+        raise ConcordStorageValidationError(str(error)) from error
+    if result.module_id != "concord":
+        raise ConcordStorageValidationError('work.module_id must be "concord".')
+    return result
+
+
+def _revision(value: object, name: str) -> int:
+    if type(value) is not int or value < 1:
+        raise ConcordStorageValidationError(f"{name} must be a positive integer.")
+    return value
+
+
+def _digest(value: object, name: str) -> str:
+    if not isinstance(value, str) or _DIGEST.fullmatch(value) is None:
+        raise ConcordStorageValidationError(
+            f"{name} must be a lowercase SHA-256 digest."
+        )
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class ConcordWorkMarker:
+    schema_version: str
+    record_type: Literal["concord_work"]
+    work: ModuleWorkRef
+    activity_id: str
+    native_record_contract_version: str
+
+    def __post_init__(self) -> None:
+        work = _work(self.work)
+        if (
+            self.schema_version != CONCORD_STORAGE_SCHEMA_VERSION
+            or self.record_type != "concord_work"
+        ):
+            raise ConcordStorageValidationError(
+                "unsupported Concord work marker schema."
+            )
+        if self.activity_id != work.work_id:
+            raise ConcordStorageValidationError("activity_id must equal work.work_id.")
+        if (
+            self.native_record_contract_version
+            != CONCORD_NATIVE_RECORD_CONTRACT_VERSION
+        ):
+            raise ConcordStorageValidationError(
+                "unsupported native record contract version."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class ConcordRecordRevision:
+    schema_version: str
+    record_type: Literal["concord_record_revision"]
+    work: ModuleWorkRef
+    record_kind: str
+    record_id: str
+    record_revision: int
+    record_contract_version: str
+    body: dict[str, JsonValue]
+
+    def __post_init__(self) -> None:
+        _work(self.work)
+        descriptor_for_kind(self.record_kind)
+        _revision(self.record_revision, "record_revision")
+        if (
+            self.schema_version != CONCORD_STORAGE_SCHEMA_VERSION
+            or self.record_type != "concord_record_revision"
+        ):
+            raise ConcordStorageValidationError("unsupported record revision schema.")
+        if self.record_contract_version != CONCORD_NATIVE_RECORD_CONTRACT_VERSION:
+            raise ConcordStorageValidationError("unsupported record contract version.")
+        if not isinstance(self.record_id, str) or not isinstance(self.body, dict):
+            raise ConcordStorageValidationError(
+                "record revision identity and body are invalid."
+            )
+
+
+@dataclass(frozen=True, slots=True, order=True)
+class ConcordRecordRevisionRef:
+    record_kind: str
+    record_id: str
+    record_revision: int
+    sha256: str
+
+    def __post_init__(self) -> None:
+        descriptor_for_kind(self.record_kind)
+        _revision(self.record_revision, "record_revision")
+        _digest(self.sha256, "sha256")
+
+
+@dataclass(frozen=True, slots=True)
+class ConcordWorkSnapshot:
+    schema_version: str
+    record_type: Literal["concord_work_snapshot"]
+    work: ModuleWorkRef
+    snapshot_revision: int
+    previous_snapshot_revision: int | None
+    previous_snapshot_sha256: str | None
+    records: tuple[ConcordRecordRevisionRef, ...]
+
+    def __post_init__(self) -> None:
+        _work(self.work)
+        _revision(self.snapshot_revision, "snapshot_revision")
+        if (
+            self.schema_version != CONCORD_STORAGE_SCHEMA_VERSION
+            or self.record_type != "concord_work_snapshot"
+        ):
+            raise ConcordStorageValidationError("unsupported work snapshot schema.")
+        if self.snapshot_revision == 1:
+            if (
+                self.previous_snapshot_revision is not None
+                or self.previous_snapshot_sha256 is not None
+            ):
+                raise ConcordStorageValidationError(
+                    "initial snapshot must not have a predecessor."
+                )
+        else:
+            if self.previous_snapshot_revision != self.snapshot_revision - 1:
+                raise ConcordStorageValidationError(
+                    "snapshot predecessor revision must be contiguous."
+                )
+            _digest(self.previous_snapshot_sha256, "previous_snapshot_sha256")
+        if (
+            type(self.records) is not tuple
+            or tuple(sorted(self.records, key=lambda r: (r.record_kind, r.record_id)))
+            != self.records
+        ):
+            raise ConcordStorageValidationError(
+                "snapshot records must be deterministically ordered."
+            )
+        identities = [(r.record_kind, r.record_id) for r in self.records]
+        if len(identities) != len(set(identities)):
+            raise ConcordStorageValidationError(
+                "snapshot record identities must be unique."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class ConcordCurrentSnapshot:
+    schema_version: str
+    record_type: Literal["concord_current_snapshot"]
+    work: ModuleWorkRef
+    snapshot_revision: int
+    snapshot_sha256: str
+
+    def __post_init__(self) -> None:
+        _work(self.work)
+        _revision(self.snapshot_revision, "snapshot_revision")
+        _digest(self.snapshot_sha256, "snapshot_sha256")
+        if (
+            self.schema_version != CONCORD_STORAGE_SCHEMA_VERSION
+            or self.record_type != "concord_current_snapshot"
+        ):
+            raise ConcordStorageValidationError("unsupported current snapshot schema.")
+
+
+@dataclass(frozen=True, slots=True)
+class ConcordStorageCommitResult:
+    work: ModuleWorkRef
+    snapshot_revision: int
+    snapshot_sha256: str
+    created_record_revisions: tuple[ConcordRecordRevisionRef, ...]
+    no_op: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class ConcordLoadedRecordGraph:
+    graph: Any
+    snapshot_revision: int
+    snapshot_sha256: str

--- a/concord/storage_paths.py
+++ b/concord/storage_paths.py
@@ -1,0 +1,107 @@
+"""Containment-safe canonical paths beneath a Core module work root."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pds_core.identifiers import validate_identifier
+from pds_core.routes import module_work_dir, safe_module_work_descendant
+from pds_core.routing_models import ModuleWorkRef
+from pds_core.workspace import resolve_workspace_root
+
+from concord.record_registry import descriptor_for_kind
+from concord.storage_errors import ConcordStorageValidationError
+
+
+def _work(work: ModuleWorkRef) -> ModuleWorkRef:
+    if not isinstance(work, ModuleWorkRef) or work.module_id != "concord":
+        raise ConcordStorageValidationError("work must identify the concord module.")
+    return work
+
+
+def _revision(value: object, name: str) -> int:
+    if type(value) is not int or value < 1:
+        raise ConcordStorageValidationError(f"{name} must be a positive integer.")
+    return value
+
+
+def work_root(root: str | Path, work: ModuleWorkRef) -> Path:
+    return module_work_dir(resolve_workspace_root(root), _work(work))
+
+
+def state_path(root: str | Path, work: ModuleWorkRef, *parts: str) -> Path:
+    relative = "/".join(("state", *parts))
+    try:
+        return safe_module_work_descendant(
+            resolve_workspace_root(root), _work(work), relative
+        )
+    except ValueError as error:
+        raise ConcordStorageValidationError(str(error)) from error
+
+
+def work_marker_path(root: str | Path, work: ModuleWorkRef) -> Path:
+    return state_path(root, work, "work.json")
+
+
+def records_path(root: str | Path, work: ModuleWorkRef) -> Path:
+    return state_path(root, work, "records")
+
+
+def record_identity_path(
+    root: str | Path, work: ModuleWorkRef, kind: str, record_id: str
+) -> Path:
+    descriptor_for_kind(kind)
+    try:
+        validated_id = validate_identifier(record_id, "record_id")
+    except ValueError as error:
+        raise ConcordStorageValidationError(str(error)) from error
+    return state_path(root, work, "records", kind, validated_id)
+
+
+def record_revisions_path(
+    root: str | Path, work: ModuleWorkRef, kind: str, record_id: str
+) -> Path:
+    return record_identity_path(root, work, kind, record_id) / "revisions"
+
+
+def record_revision_path(
+    root: str | Path, work: ModuleWorkRef, kind: str, record_id: str, revision: int
+) -> Path:
+    return (
+        record_revisions_path(root, work, kind, record_id)
+        / f"{_revision(revision, 'record_revision')}.json"
+    )
+
+
+def snapshots_path(root: str | Path, work: ModuleWorkRef) -> Path:
+    return state_path(root, work, "snapshots")
+
+
+def snapshot_path(root: str | Path, work: ModuleWorkRef, revision: int) -> Path:
+    return (
+        snapshots_path(root, work) / f"{_revision(revision, 'snapshot_revision')}.json"
+    )
+
+
+def current_snapshot_path(root: str | Path, work: ModuleWorkRef) -> Path:
+    return state_path(root, work, "current.json")
+
+
+def derived_path(root: str | Path, work: ModuleWorkRef) -> Path:
+    return state_path(root, work, "derived")
+
+
+def catalog_path(root: str | Path, work: ModuleWorkRef) -> Path:
+    return derived_path(root, work) / "catalog.sqlite"
+
+
+def locks_path(root: str | Path, work: ModuleWorkRef) -> Path:
+    return state_path(root, work, ".locks")
+
+
+def write_lock_path(root: str | Path, work: ModuleWorkRef) -> Path:
+    return locks_path(root, work) / "write.lock"
+
+
+def catalog_lock_path(root: str | Path, work: ModuleWorkRef) -> Path:
+    return locks_path(root, work) / "catalog.lock"

--- a/concord/storage_serialization.py
+++ b/concord/storage_serialization.py
@@ -1,0 +1,298 @@
+"""Deterministic canonical JSON and strict storage-envelope conversion."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any, Callable, Literal, TypeVar, cast
+
+from pds_core.routing_models import module_work_ref_from_dict, module_work_ref_to_dict
+
+from concord.model_conversion import record_from_dict, record_to_dict
+from concord.record_registry import descriptor_for_kind
+from concord.storage_errors import (
+    ConcordStorageReadError,
+    ConcordStorageValidationError,
+)
+from concord.storage_models import (
+    ConcordCurrentSnapshot,
+    ConcordRecordRevision,
+    ConcordRecordRevisionRef,
+    ConcordWorkMarker,
+    ConcordWorkSnapshot,
+    JsonValue,
+)
+
+T = TypeVar("T")
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    try:
+        return (
+            json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n"
+        ).encode("utf-8")
+    except (TypeError, ValueError, UnicodeError) as error:
+        raise ConcordStorageValidationError(
+            f"value is not canonical JSON: {error}"
+        ) from error
+
+
+def strict_json_loads(data: bytes) -> dict[str, Any]:
+    if data.startswith(b"\xef\xbb\xbf"):
+        raise ConcordStorageReadError(
+            "canonical JSON must not contain a byte-order mark."
+        )
+    try:
+        text = data.decode("utf-8", errors="strict")
+        value = json.loads(text, object_pairs_hook=_pairs, parse_constant=_constant)
+    except (UnicodeError, json.JSONDecodeError, ValueError) as error:
+        raise ConcordStorageReadError(f"invalid canonical JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise ConcordStorageReadError("canonical JSON top level must be an object.")
+    return value
+
+
+def _pairs(items: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in items:
+        if key in result:
+            raise ValueError(f"duplicate JSON key {key!r}.")
+        result[key] = value
+    return result
+
+
+def _constant(value: str) -> None:
+    raise ValueError(f"invalid JSON constant {value}.")
+
+
+def _mapping(value: object, keys: set[str], name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping) or any(not isinstance(k, str) for k in value):
+        raise ConcordStorageValidationError(
+            f"{name} must be an object with string keys."
+        )
+    actual = set(cast(Mapping[str, object], value))
+    if actual != keys:
+        raise ConcordStorageValidationError(
+            f"{name} fields differ from the supported schema."
+        )
+    return cast(Mapping[str, object], value)
+
+
+def _string(value: object, name: str) -> str:
+    if not isinstance(value, str):
+        raise ConcordStorageValidationError(f"{name} must be a string.")
+    return value
+
+
+def _int(value: object, name: str) -> int:
+    if type(value) is not int:
+        raise ConcordStorageValidationError(f"{name} must be an integer.")
+    return value
+
+
+def marker_to_dict(value: ConcordWorkMarker) -> dict[str, object]:
+    return {
+        "schema_version": value.schema_version,
+        "record_type": value.record_type,
+        "work": module_work_ref_to_dict(value.work),
+        "activity_id": value.activity_id,
+        "native_record_contract_version": value.native_record_contract_version,
+    }
+
+
+def marker_from_dict(data: object) -> ConcordWorkMarker:
+    m = _mapping(
+        data,
+        {
+            "schema_version",
+            "record_type",
+            "work",
+            "activity_id",
+            "native_record_contract_version",
+        },
+        "work marker",
+    )
+    return ConcordWorkMarker(
+        _string(m["schema_version"], "schema_version"),
+        cast(Literal["concord_work"], _string(m["record_type"], "record_type")),
+        module_work_ref_from_dict(m["work"]),
+        _string(m["activity_id"], "activity_id"),
+        _string(m["native_record_contract_version"], "native_record_contract_version"),
+    )
+
+
+def revision_to_dict(value: ConcordRecordRevision) -> dict[str, object]:
+    return {
+        "schema_version": value.schema_version,
+        "record_type": value.record_type,
+        "work": module_work_ref_to_dict(value.work),
+        "record_kind": value.record_kind,
+        "record_id": value.record_id,
+        "record_revision": value.record_revision,
+        "record_contract_version": value.record_contract_version,
+        "body": value.body,
+    }
+
+
+def revision_from_dict(data: object) -> ConcordRecordRevision:
+    m = _mapping(
+        data,
+        {
+            "schema_version",
+            "record_type",
+            "work",
+            "record_kind",
+            "record_id",
+            "record_revision",
+            "record_contract_version",
+            "body",
+        },
+        "record revision",
+    )
+    kind = _string(m["record_kind"], "record_kind")
+    descriptor = descriptor_for_kind(kind)
+    body = m["body"]
+    if not isinstance(body, dict) or any(not isinstance(k, str) for k in body):
+        raise ConcordStorageValidationError("body must be an object.")
+    record = record_from_dict(kind, body)
+    if record_to_dict(record) != body:
+        raise ConcordStorageValidationError("record body does not round-trip exactly.")
+    record_id = _string(m["record_id"], "record_id")
+    if getattr(record, descriptor.identity_field) != record_id:
+        raise ConcordStorageValidationError(
+            "record body identity differs from envelope."
+        )
+    return ConcordRecordRevision(
+        _string(m["schema_version"], "schema_version"),
+        cast(
+            Literal["concord_record_revision"],
+            _string(m["record_type"], "record_type"),
+        ),
+        module_work_ref_from_dict(m["work"]),
+        kind,
+        record_id,
+        _int(m["record_revision"], "record_revision"),
+        _string(m["record_contract_version"], "record_contract_version"),
+        cast(dict[str, JsonValue], body),
+    )
+
+
+def ref_to_dict(value: ConcordRecordRevisionRef) -> dict[str, object]:
+    return {
+        "record_kind": value.record_kind,
+        "record_id": value.record_id,
+        "record_revision": value.record_revision,
+        "sha256": value.sha256,
+    }
+
+
+def ref_from_dict(data: object) -> ConcordRecordRevisionRef:
+    m = _mapping(
+        data,
+        {"record_kind", "record_id", "record_revision", "sha256"},
+        "record revision reference",
+    )
+    return ConcordRecordRevisionRef(
+        _string(m["record_kind"], "record_kind"),
+        _string(m["record_id"], "record_id"),
+        _int(m["record_revision"], "record_revision"),
+        _string(m["sha256"], "sha256"),
+    )
+
+
+def snapshot_to_dict(value: ConcordWorkSnapshot) -> dict[str, object]:
+    return {
+        "schema_version": value.schema_version,
+        "record_type": value.record_type,
+        "work": module_work_ref_to_dict(value.work),
+        "snapshot_revision": value.snapshot_revision,
+        "previous_snapshot_revision": value.previous_snapshot_revision,
+        "previous_snapshot_sha256": value.previous_snapshot_sha256,
+        "records": [ref_to_dict(r) for r in value.records],
+    }
+
+
+def snapshot_from_dict(data: object) -> ConcordWorkSnapshot:
+    m = _mapping(
+        data,
+        {
+            "schema_version",
+            "record_type",
+            "work",
+            "snapshot_revision",
+            "previous_snapshot_revision",
+            "previous_snapshot_sha256",
+            "records",
+        },
+        "work snapshot",
+    )
+    records = m["records"]
+    if not isinstance(records, list):
+        raise ConcordStorageValidationError("records must be an array.")
+    prev_rev = m["previous_snapshot_revision"]
+    prev_digest = m["previous_snapshot_sha256"]
+    if prev_rev is not None:
+        prev_rev = _int(prev_rev, "previous_snapshot_revision")
+    if prev_digest is not None:
+        prev_digest = _string(prev_digest, "previous_snapshot_sha256")
+    return ConcordWorkSnapshot(
+        _string(m["schema_version"], "schema_version"),
+        cast(
+            Literal["concord_work_snapshot"],
+            _string(m["record_type"], "record_type"),
+        ),
+        module_work_ref_from_dict(m["work"]),
+        _int(m["snapshot_revision"], "snapshot_revision"),
+        prev_rev,
+        prev_digest,
+        tuple(ref_from_dict(r) for r in records),
+    )
+
+
+def current_to_dict(value: ConcordCurrentSnapshot) -> dict[str, object]:
+    return {
+        "schema_version": value.schema_version,
+        "record_type": value.record_type,
+        "work": module_work_ref_to_dict(value.work),
+        "snapshot_revision": value.snapshot_revision,
+        "snapshot_sha256": value.snapshot_sha256,
+    }
+
+
+def current_from_dict(data: object) -> ConcordCurrentSnapshot:
+    m = _mapping(
+        data,
+        {
+            "schema_version",
+            "record_type",
+            "work",
+            "snapshot_revision",
+            "snapshot_sha256",
+        },
+        "current snapshot",
+    )
+    return ConcordCurrentSnapshot(
+        _string(m["schema_version"], "schema_version"),
+        cast(
+            Literal["concord_current_snapshot"],
+            _string(m["record_type"], "record_type"),
+        ),
+        module_work_ref_from_dict(m["work"]),
+        _int(m["snapshot_revision"], "snapshot_revision"),
+        _string(m["snapshot_sha256"], "snapshot_sha256"),
+    )
+
+
+def serialize(value: object) -> bytes:
+    converters: tuple[tuple[type[object], Callable[[Any], dict[str, object]]], ...] = (
+        (ConcordWorkMarker, marker_to_dict),
+        (ConcordRecordRevision, revision_to_dict),
+        (ConcordWorkSnapshot, snapshot_to_dict),
+        (ConcordCurrentSnapshot, current_to_dict),
+    )
+    for cls, converter in converters:
+        if isinstance(value, cls):
+            return canonical_json_bytes(converter(value))
+    raise ConcordStorageValidationError(
+        f"unsupported storage model {type(value).__name__}."
+    )

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,13 +29,15 @@ The repository now contains:
 * fifteen accepted Architecture Decision Records;
 * a detailed `pds-core` integration requirements specification covering
   released PDS2 routing and academic-registry contracts;
-* and an implemented immutable native record, exact mapping-conversion, and pure
-  graph-validation layer.
+* an implemented immutable native record, exact mapping-conversion, and pure
+  graph-validation layer;
+* and canonical guarded persistence with immutable history, atomic snapshots,
+  strict reads, diagnostics, and a disposable catalog.
 
 Implementation follows the v0.2.0 vertical-slice sequence tracked by
 [`Paper-Data-Suite/pds-concord#22`](https://github.com/Paper-Data-Suite/pds-concord/issues/22).
-The package baseline and foundational native models are complete. Later issues
-add persistence and teacher workflows, routing, publication, and consumer
+The package baseline, foundational native models, and persistence substrate are
+complete. Later issues add teacher workflows, routing, publication, and consumer
 integration without collapsing those responsibilities. No routing or
 publication entry point is currently declared.
 
@@ -46,6 +48,15 @@ publication entry point is currently declared.
 Documents the supported Python imports, structural and graph-validation split,
 exact mapping conversion, Core standards validation boundary, controlled
 extensions, supersession semantics, and deliberately deferred operations.
+
+### 11. Canonical storage implementation
+
+[`implementation/canonical-storage.md`](implementation/canonical-storage.md)
+
+Documents storage ownership, exact layout and versions, immutable revisions and
+snapshots, atomic pointer semantics, expected-revision commits, strict reads,
+standards validation, catalog nonauthority, diagnostics, interruption, and
+conservative recovery.
 
 ## Recommended Reading Order
 

--- a/docs/implementation/canonical-storage.md
+++ b/docs/implementation/canonical-storage.md
@@ -1,0 +1,135 @@
+# Canonical Storage and Guarded Persistence
+
+Concord owns canonical native state only beneath the `state/` descendant of the
+exact Core `ModuleWorkRef(module_id="concord", class_id=..., work_id=...)` work
+root. Core continues to own workspace resolution, class metadata, work-root and
+safe-descendant construction, routes, retained scans, academic registration,
+and publication. Concord does not inspect or modify sibling namespaces such as
+`routes/`, `exports/`, `rendered/`, or `attachments/`.
+
+## Canonical layout and versions
+
+```text
+state/
+  work.json
+  records/<record_kind>/<record_id>/revisions/<record_revision>.json
+  snapshots/<snapshot_revision>.json
+  current.json
+  derived/catalog.sqlite
+  .locks/write.lock
+  .locks/catalog.lock
+```
+
+Storage schema version, native-record contract version, and catalog schema
+version are respectively `"1"`, `"1"`, and `1`. Canonical JSON is UTF-8,
+sorted, two-space indented, finite-number-only JSON with LF endings and exactly
+one final newline. Strict readers reject duplicate keys, unknown or missing
+fields, invalid UTF-8, byte-order marks, nonstandard constants, wrong primitive
+types, unsupported versions, symlinks, and any disagreement among path,
+envelope, body, work, revision, or digest identity.
+
+## Bootstrap and commits
+
+The first commit requires an existing writable Core workspace and matching Core
+class. Its complete graph contains exactly one Activity and at least one Session.
+Concord creates no workspace or class implicitly. Standards-based or mixed
+graphs, and graphs containing standards-backed Criteria or Scores, require an
+explicit Core `StandardsLibrary` and must pass Core standards validation.
+
+`commit_record_batch` acquires the versioned, work-qualified `write.lock`,
+re-reads expected state, merges candidate identities without deletion, validates
+the complete graph, and then writes in this order:
+
+1. changed record revisions, created exclusively and verified byte-for-byte;
+2. one immutable snapshot binding exact record digests and its predecessor;
+3. one temporary current pointer, atomically installed with `os.replace`;
+4. a strict reload of the complete selected graph.
+
+Every later commit supplies the exact expected current snapshot revision. A
+stale writer conflicts even if one candidate body matches current state. Exact
+no-op replay creates neither record revisions nor a snapshot. Storage revision
+numbers describe immutable versions of one durable identity; they never create
+or replace domain `supersedes_*` relationships.
+
+Before any initial, advancing, or replayed commit can proceed, Concord proves
+that snapshot history is exactly contiguous from revision 1 through the current
+snapshot and that every selected record has exactly contiguous revisions from 1
+through its selected revision. Any orphan, gap, unexpected identity, or newer
+unselected history blocks all future writes until separately reviewed
+reconciliation. Writers never fill a gap beneath ambiguous newer history.
+
+The current pointer is the only mutable canonical JSON file. Readers never infer
+current state from the largest filename. An exclusive-write failure before file
+synchronization removes the partial file when that can be proven safe; failed
+cleanup is reported. Synchronized files whose directory durability cannot be
+confirmed are preserved and reported as structured partial success. Before
+pointer publication, durable new files remain noncurrent. After pointer
+publication, final-verification failures explicitly report that canonical state
+is already committed, including its snapshot revision and digest. Failure to
+remove `write.lock` or `catalog.lock` is surfaced rather than suppressed,
+including on exact no-op replay.
+
+## Strict reads and reconstruction
+
+Public read APIs load exact markers, record revisions, snapshots, the current
+pointer, current records, and the complete current `ConcordRecordGraph`.
+Enumeration is bounded to known directory levels and class work discovery reads
+only each candidate `state/work.json`. Reads create no directories, locks,
+catalogs, pointers, or repairs. Graph reconstruction never consults SQLite.
+Loading snapshot N proves every declared predecessor identity and exact digest
+back through snapshot 1; checking only N-1 or choosing filenames by order is
+insufficient.
+
+## Catalog nonauthority
+
+`state/derived/catalog.sqlite` is disposable lookup and audit state. A rebuild
+holds only `catalog.lock`, inventories strict canonical sources using sorted
+POSIX relative path, byte size, and SHA-256 tuples, builds a complete temporary
+database, repeats the inventory, atomically replaces the database only when the
+source is unchanged, and verifies the installed result. Metadata records the
+application and schema identifiers, build time, work identity, current snapshot
+identity, source digest and counts. The catalog stores only minimized lookup
+metadata—kind, identity, revision, canonical relative path, digest, and snapshot
+selection—and never stores complete native record bodies, notes, rationale,
+privacy data, or evidence lineage. Queries support current, historical, all, and
+exact-snapshot projections.
+
+A missing, stale, incompatible, or corrupt catalog fails clearly and never
+changes canonical JSON. Recovery is full rebuild after a successful canonical
+audit; catalog rows are never patched as repair.
+
+## Diagnostics, interruption, and recovery
+
+Storage diagnostics are deterministic and omit record bodies, names, review
+notes, moderation rationale, credentials, and evidence content. Lock inspection
+reports path, size, and byte fingerprint. Lock age alone never proves inactivity.
+Storage validation accepts the Core standards context required by standards-
+based data and reports `storage.standards_context.required` when it is absent.
+Graph-integrity diagnostics preserve native validation codes, record identity,
+field paths, and privacy-safe related references without collapsing them into a
+generic text classification.
+
+Recovery follows these rules:
+
+- Diagnose before repairing and preserve immutable history.
+- Never edit record revisions or snapshots in place.
+- Never select the highest revision or snapshot automatically.
+- Preserve and report orphan revisions and snapshots; do not select or delete
+  them based on name, time, or apparent semantic validity.
+- Never alter bytes to satisfy a digest or reconstruct a corrupt pointer by
+  guessing.
+- Never clear a lock solely because it appears old.
+- Never patch catalog rows; validate canonical JSON and rebuild the whole
+  catalog.
+
+Backups must capture canonical `state/` JSON consistently. The derived catalog
+may be omitted because it is rebuildable. Backup tooling, institutional
+retention, legal deletion, cloud synchronization, and automatic repair remain
+outside this layer.
+
+## Follow-on boundary
+
+Later Activity, Session, Group, Artifact, Review, Moderation, Scoring, routing,
+and publication issues must use these APIs. This implementation does not create
+teacher workflows, PDS2 routes, scans, rendered Artifacts, publication records
+or manifests, Meridian adapters, Grades, standards aggregation, or reports.

--- a/scripts/smoke_test_wheel.py
+++ b/scripts/smoke_test_wheel.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import subprocess
 import tempfile
+import textwrap
 import venv
 from pathlib import Path
 
@@ -13,6 +14,107 @@ from pathlib import Path
 def _run(command: list[str], cwd: Path) -> None:
     subprocess.run(
         command, cwd=cwd, check=True, env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+    )
+
+
+def _storage_smoke_code() -> str:
+    return textwrap.dedent(
+        """
+        from dataclasses import replace
+        from datetime import datetime, timezone
+        from pathlib import Path
+        import tempfile
+        from pds_core.class_metadata import (
+            create_class_metadata,
+            write_class_metadata_for_class,
+        )
+        from pds_core.workspace import ensure_workspace_root
+        from concord.model_conversion import record_from_dict
+        from concord.storage import (
+            commit_record_batch,
+            load_current_record_graph,
+            load_record_revision,
+        )
+        from concord.storage_catalog import rebuild_catalog, query_catalog_records
+
+        with tempfile.TemporaryDirectory(prefix="concord-installed-storage-") as raw:
+            root = ensure_workspace_root(Path(raw) / "workspace")
+            metadata = create_class_metadata(
+                "class-smoke",
+                "2026-2027",
+                created_at=datetime(2026, 8, 5, tzinfo=timezone.utc),
+            )
+            write_class_metadata_for_class(root, metadata)
+            provenance = {
+                "actor": {
+                    "actor_kind": "authorized_adult",
+                    "actor_id": "actor-smoke",
+                    "owning_system": "core",
+                },
+                "timestamp": "2026-08-05T12:00:00+00:00",
+                "source_kind": "manual",
+            }
+            activity = record_from_dict(
+                "activity",
+                {
+                    "activity_id": "activity-smoke",
+                    "class_reference": {
+                        "module_id": "core",
+                        "record_kind": "class",
+                        "record_id": "class-smoke",
+                    },
+                    "title": "Synthetic smoke activity",
+                    "activity_type": "local:smoke",
+                    "scoring_orientation": "evidence_only",
+                    "status": "active",
+                    "created_provenance": provenance,
+                    "focus_standard_ids": [],
+                    "criterion_set_ids": [],
+                    "external_reference_ids": [],
+                },
+            )
+            session = record_from_dict(
+                "session",
+                {
+                    "session_id": "session-smoke",
+                    "activity_id": "activity-smoke",
+                    "sequence": 1,
+                    "status": "active",
+                    "created_provenance": provenance,
+                },
+            )
+            first = commit_record_batch(
+                root,
+                activity.work_reference,
+                (activity, session),
+                expected_snapshot_revision=None,
+            )
+            changed = replace(session, notes="Synthetic installed-wheel revision.")
+            second = commit_record_batch(
+                root,
+                activity.work_reference,
+                (changed,),
+                expected_snapshot_revision=first.snapshot_revision,
+            )
+            loaded = load_current_record_graph(root, activity.work_reference)
+            old, _ = load_record_revision(
+                root,
+                activity.work_reference,
+                "session",
+                session.session_id,
+                1,
+            )
+            assert loaded.snapshot_revision == second.snapshot_revision == 2
+            assert old == session and loaded.graph.sessions == (changed,)
+            rebuild_catalog(root, activity.work_reference)
+            current = query_catalog_records(
+                root, activity.work_reference, state="current"
+            )
+            historical = query_catalog_records(
+                root, activity.work_reference, snapshot_revision=1
+            )
+            assert len(current) == 2 and historical
+        """
     )
 
 
@@ -61,6 +163,7 @@ def smoke_test(concord_wheel: Path, core_wheel: Path) -> None:
             [str(python), "-m", "concord", "--version"],
         ):
             _run(command, outside)
+        _run([str(python), "-c", _storage_smoke_code()], outside)
 
 
 def main() -> int:

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,819 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.routing_models import ModuleWorkRef
+from pds_core.standards import StandardDefinition, StandardsLibrary, StandardsProfile
+from pds_core.workspace import ensure_workspace_root
+
+import concord.storage as storage_module
+import concord.storage_catalog as storage_catalog_module
+from concord.model_conversion import record_from_dict, record_to_dict
+from concord.models import Activity, Session
+from concord.storage import (
+    commit_record_batch,
+    list_record_revisions,
+    list_work_snapshots,
+    load_current_record_graph,
+    load_current_snapshot,
+    load_record_revision,
+    load_work_snapshot,
+)
+from concord.storage_catalog import (
+    _open_verified,
+    query_catalog_records,
+    rebuild_catalog,
+)
+from concord.storage_diagnostics import (
+    collect_storage_issues,
+    inspect_catalog_status,
+    inspect_storage_locks,
+    validate_storage,
+)
+from concord.storage_errors import (
+    ConcordCatalogBuildError,
+    ConcordCatalogIntegrityError,
+    ConcordStorageConflictError,
+    ConcordStorageIntegrityError,
+    ConcordStoragePartialSuccessError,
+    ConcordStorageValidationError,
+    ConcordStorageWriteError,
+)
+from concord.storage_models import (
+    CONCORD_NATIVE_RECORD_CONTRACT_VERSION,
+    CONCORD_STORAGE_SCHEMA_VERSION,
+    ConcordCurrentSnapshot,
+    ConcordRecordRevision,
+    ConcordWorkSnapshot,
+)
+from concord.storage_paths import (
+    catalog_lock_path,
+    catalog_path,
+    current_snapshot_path,
+    record_revision_path,
+    snapshot_path,
+    write_lock_path,
+)
+from concord.storage_serialization import (
+    serialize,
+    snapshot_from_dict,
+    strict_json_loads,
+)
+
+FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "native_records"
+    / "evidence_only_activity.json"
+)
+STANDARDS_FIXTURE = FIXTURE.with_name("standards_activity.json")
+
+
+def _commit_initial(root: Path, activity: Activity, session: Session) -> None:
+    commit_record_batch(
+        root,
+        activity.work_reference,
+        (activity, session),
+        expected_snapshot_revision=None,
+    )
+
+
+def _three_snapshots(root: Path, activity: Activity, session: Session) -> Session:
+    _commit_initial(root, activity, session)
+    second_session = replace(session, notes="Synthetic revision two.")
+    commit_record_batch(
+        root,
+        activity.work_reference,
+        (second_session,),
+        expected_snapshot_revision=1,
+    )
+    third_session = replace(session, notes="Synthetic revision three.")
+    commit_record_batch(
+        root,
+        activity.work_reference,
+        (third_session,),
+        expected_snapshot_revision=2,
+    )
+    return third_session
+
+
+def _symlink_or_skip(link: Path, target: Path) -> None:
+    try:
+        link.symlink_to(target, target_is_directory=target.is_dir())
+    except (OSError, NotImplementedError) as error:
+        pytest.skip(f"symlink creation is unavailable: {error}")
+
+
+def _standards_library() -> StandardsLibrary:
+    return StandardsLibrary(
+        standards=(
+            StandardDefinition(
+                standard_id="standard-1",
+                code="SYN.1",
+                source="synthetic",
+                short_name="Synthetic standard",
+                description="Privacy-safe standard used only by tests.",
+                available_modules=("concord",),
+            ),
+        ),
+        profiles=(
+            StandardsProfile(
+                profile_id="profile-1",
+                standards=("standard-1",),
+                title="Synthetic standards profile",
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def storage_case(tmp_path: Path) -> tuple[Path, Activity, Session]:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    metadata = create_class_metadata(
+        "class-1",
+        "2026-2027",
+        created_at=datetime(2026, 8, 5, tzinfo=timezone.utc),
+    )
+    write_class_metadata_for_class(root, metadata)
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    activity = record_from_dict("activity", fixture["records"][0]["body"])
+    session = record_from_dict("session", fixture["records"][1]["body"])
+    assert isinstance(activity, Activity)
+    assert isinstance(session, Session)
+    return root, activity, session
+
+
+def test_initial_commit_and_strict_graph_load(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    result = commit_record_batch(
+        root,
+        activity.work_reference,
+        (activity, session),
+        expected_snapshot_revision=None,
+    )
+    loaded = load_current_record_graph(root, activity.work_reference)
+    assert result.snapshot_revision == loaded.snapshot_revision == 1
+    assert loaded.graph.activities == (activity,)
+    assert loaded.graph.sessions == (session,)
+    assert current_snapshot_path(root, activity.work_reference).is_file()
+
+
+def test_initial_activity_only_is_rejected_before_canonical_writes(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, _ = storage_case
+    with pytest.raises(ConcordStorageValidationError):
+        commit_record_batch(
+            root,
+            activity.work_reference,
+            (activity,),
+            expected_snapshot_revision=None,
+        )
+    assert not current_snapshot_path(root, activity.work_reference).exists()
+
+
+def test_revision_history_noop_and_stale_guard(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    first = commit_record_batch(
+        root,
+        activity.work_reference,
+        (activity, session),
+        expected_snapshot_revision=None,
+    )
+    changed = replace(session, notes="Synthetic follow-up note.")
+    second = commit_record_batch(
+        root,
+        activity.work_reference,
+        (changed,),
+        expected_snapshot_revision=first.snapshot_revision,
+    )
+    replay = commit_record_batch(
+        root,
+        activity.work_reference,
+        (changed,),
+        expected_snapshot_revision=second.snapshot_revision,
+    )
+    assert second.snapshot_revision == 2
+    assert replay.no_op
+    assert list_record_revisions(
+        root, activity.work_reference, "session", session.session_id
+    ) == (1, 2)
+    assert list_work_snapshots(root, activity.work_reference) == (1, 2)
+    old, _ = load_record_revision(
+        root, activity.work_reference, "session", session.session_id, 1
+    )
+    assert old == session
+    with pytest.raises(ConcordStorageConflictError):
+        commit_record_batch(
+            root,
+            activity.work_reference,
+            (replace(changed, notes="Another note."),),
+            expected_snapshot_revision=1,
+        )
+
+
+def test_catalog_rebuild_is_derived_and_supports_history(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    commit_record_batch(
+        root,
+        activity.work_reference,
+        (activity, session),
+        expected_snapshot_revision=None,
+    )
+    rebuild_catalog(root, activity.work_reference)
+    current = query_catalog_records(root, activity.work_reference, snapshot_revision=1)
+    assert {(row.record_kind, row.record_id) for row in current} == {
+        ("activity", activity.activity_id),
+        ("session", session.session_id),
+    }
+
+
+def test_record_digest_tampering_is_rejected(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    commit_record_batch(
+        root,
+        activity.work_reference,
+        (activity, session),
+        expected_snapshot_revision=None,
+    )
+    path = record_revision_path(
+        root, activity.work_reference, "session", session.session_id, 1
+    )
+    path.write_bytes(path.read_bytes().replace(b"active", b"planned"))
+    with pytest.raises(Exception, match="digest mismatch"):
+        load_current_record_graph(root, activity.work_reference)
+
+
+def test_newer_orphan_record_revision_blocks_commit(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    _commit_initial(root, activity, session)
+    revision_one = record_revision_path(
+        root, activity.work_reference, "session", session.session_id, 1
+    )
+    revision_three = record_revision_path(
+        root, activity.work_reference, "session", session.session_id, 3
+    )
+    revision_three.write_bytes(revision_one.read_bytes())
+
+    with pytest.raises(ConcordStorageIntegrityError):
+        commit_record_batch(
+            root,
+            activity.work_reference,
+            (replace(session, notes="Blocked revision."),),
+            expected_snapshot_revision=1,
+        )
+
+    assert load_current_snapshot(root, activity.work_reference).snapshot_revision == 1
+    assert not record_revision_path(
+        root, activity.work_reference, "session", session.session_id, 2
+    ).exists()
+
+
+def test_newer_orphan_snapshot_blocks_commit(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    _commit_initial(root, activity, session)
+    first, _ = load_work_snapshot(root, activity.work_reference, 1)
+    orphan = ConcordWorkSnapshot(
+        CONCORD_STORAGE_SCHEMA_VERSION,
+        "concord_work_snapshot",
+        activity.work_reference,
+        3,
+        2,
+        "a" * 64,
+        first.records,
+    )
+    snapshot_path(root, activity.work_reference, 3).write_bytes(serialize(orphan))
+
+    with pytest.raises(ConcordStorageIntegrityError):
+        commit_record_batch(
+            root,
+            activity.work_reference,
+            (replace(session, notes="Blocked snapshot."),),
+            expected_snapshot_revision=1,
+        )
+
+    assert not snapshot_path(root, activity.work_reference, 2).exists()
+    assert load_current_snapshot(root, activity.work_reference).snapshot_revision == 1
+
+
+@pytest.mark.parametrize("orphan_kind", ["record", "snapshot"])
+def test_initial_creation_rejects_orphan_canonical_history(
+    storage_case: tuple[Path, Activity, Session], orphan_kind: str
+) -> None:
+    root, activity, session = storage_case
+    if orphan_kind == "record":
+        envelope = ConcordRecordRevision(
+            CONCORD_STORAGE_SCHEMA_VERSION,
+            "concord_record_revision",
+            activity.work_reference,
+            "session",
+            session.session_id,
+            1,
+            CONCORD_NATIVE_RECORD_CONTRACT_VERSION,
+            record_to_dict(session),
+        )
+        path = record_revision_path(
+            root, activity.work_reference, "session", session.session_id, 1
+        )
+    else:
+        envelope = ConcordWorkSnapshot(
+            CONCORD_STORAGE_SCHEMA_VERSION,
+            "concord_work_snapshot",
+            activity.work_reference,
+            1,
+            None,
+            None,
+            (),
+        )
+        path = snapshot_path(root, activity.work_reference, 1)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(serialize(envelope))
+
+    with pytest.raises(ConcordStorageIntegrityError):
+        commit_record_batch(
+            root,
+            activity.work_reference,
+            (activity, session),
+            expected_snapshot_revision=None,
+        )
+    assert not current_snapshot_path(root, activity.work_reference).exists()
+
+
+def test_failed_file_fsync_removes_partial_file(
+    storage_case: tuple[Path, Activity, Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, activity, session = storage_case
+    marker = storage_module.work_marker_path(root, activity.work_reference)
+    file_syncs = 0
+
+    def fail_fsync(_descriptor: int) -> None:
+        nonlocal file_syncs
+        file_syncs += 1
+        if file_syncs == 2:
+            raise OSError("synthetic file fsync failure")
+
+    monkeypatch.setattr(storage_module.os, "fsync", fail_fsync)
+    monkeypatch.setattr(
+        storage_module, "_fsync_directory_if_supported", lambda _path: None
+    )
+    with pytest.raises(Exception, match="could not write"):
+        _commit_initial(root, activity, session)
+    assert not marker.exists()
+    assert not current_snapshot_path(root, activity.work_reference).exists()
+
+
+def test_failed_partial_file_cleanup_is_reported(
+    storage_case: tuple[Path, Activity, Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, activity, session = storage_case
+    marker = storage_module.work_marker_path(root, activity.work_reference)
+    original_unlink = Path.unlink
+    file_syncs = 0
+
+    def fail_fsync(_descriptor: int) -> None:
+        nonlocal file_syncs
+        file_syncs += 1
+        if file_syncs == 2:
+            raise OSError("synthetic file fsync failure")
+
+    def selective_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        if path == marker:
+            raise OSError("synthetic partial cleanup failure")
+        original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(storage_module.os, "fsync", fail_fsync)
+    monkeypatch.setattr(
+        storage_module, "_fsync_directory_if_supported", lambda _path: None
+    )
+    monkeypatch.setattr(Path, "unlink", selective_unlink)
+    with pytest.raises(ConcordStoragePartialSuccessError) as captured:
+        _commit_initial(root, activity, session)
+    assert str(marker) in captured.value.durable_paths
+    assert captured.value.pointer_published is False
+
+
+def test_directory_fsync_failure_reports_synchronized_path(
+    storage_case: tuple[Path, Activity, Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, activity, session = storage_case
+    marker = storage_module.work_marker_path(root, activity.work_reference)
+
+    def fail_directory_sync(path: Path) -> None:
+        if path == marker.parent:
+            raise OSError("synthetic directory fsync failure")
+
+    monkeypatch.setattr(
+        storage_module, "_fsync_directory_if_supported", fail_directory_sync
+    )
+    with pytest.raises(ConcordStoragePartialSuccessError) as captured:
+        _commit_initial(root, activity, session)
+    assert marker.exists()
+    assert str(marker) in captured.value.durable_paths
+    assert captured.value.pointer_published is False
+
+
+def test_current_pointer_directory_fsync_failure_reports_published_state(
+    storage_case: tuple[Path, Activity, Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, activity, session = storage_case
+    current = current_snapshot_path(root, activity.work_reference)
+    state_syncs = 0
+
+    def fail_current_directory_sync(path: Path) -> None:
+        nonlocal state_syncs
+        if path != current.parent:
+            return
+        state_syncs += 1
+        if state_syncs == 2:
+            raise OSError("synthetic current pointer directory fsync failure")
+
+    with monkeypatch.context() as fault:
+        fault.setattr(
+            storage_module,
+            "_fsync_directory_if_supported",
+            fail_current_directory_sync,
+        )
+        with pytest.raises(ConcordStoragePartialSuccessError) as captured:
+            _commit_initial(root, activity, session)
+
+    pointer = load_current_snapshot(root, activity.work_reference)
+    assert captured.value.pointer_published is True
+    assert captured.value.snapshot_revision == pointer.snapshot_revision == 1
+    assert captured.value.snapshot_sha256 == pointer.snapshot_sha256
+    graph = load_current_record_graph(root, activity.work_reference).graph
+    assert graph.activities == (activity,)
+    assert graph.sessions == (session,)
+
+
+def test_write_lock_content_failure_does_not_leave_lock(
+    storage_case: tuple[Path, Activity, Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, activity, session = storage_case
+    lock = write_lock_path(root, activity.work_reference)
+    current = current_snapshot_path(root, activity.work_reference)
+
+    def fail_lock_content(*_args: object, **_kwargs: object) -> bytes:
+        raise OSError("synthetic write lock content failure")
+
+    monkeypatch.setattr(storage_module, "_lock_bytes", fail_lock_content)
+    with pytest.raises(ConcordStorageWriteError, match="durably acquire"):
+        _commit_initial(root, activity, session)
+
+    assert not lock.exists()
+    assert not current.exists()
+
+
+def test_post_pointer_verification_failure_reports_committed_state(
+    storage_case: tuple[Path, Activity, Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, activity, session = storage_case
+
+    def fail_verification(*_args: object, **_kwargs: object) -> object:
+        raise ConcordStorageIntegrityError("synthetic final verification failure")
+
+    with monkeypatch.context() as fault:
+        fault.setattr(storage_module, "load_current_record_graph", fail_verification)
+        with pytest.raises(ConcordStoragePartialSuccessError) as captured:
+            _commit_initial(root, activity, session)
+
+    current = load_current_snapshot(root, activity.work_reference)
+    assert captured.value.pointer_published is True
+    assert captured.value.snapshot_revision == current.snapshot_revision == 1
+    assert captured.value.snapshot_sha256 == current.snapshot_sha256
+    assert load_current_record_graph(root, activity.work_reference).graph.sessions == (
+        session,
+    )
+
+
+def test_write_lock_cleanup_failure_after_success_is_partial(
+    storage_case: tuple[Path, Activity, Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, activity, session = storage_case
+    lock = write_lock_path(root, activity.work_reference)
+    original_unlink = Path.unlink
+
+    def selective_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        if path == lock:
+            raise OSError("synthetic lock cleanup failure")
+        original_unlink(path, *args, **kwargs)
+
+    with monkeypatch.context() as fault:
+        fault.setattr(Path, "unlink", selective_unlink)
+        with pytest.raises(ConcordStoragePartialSuccessError) as captured:
+            _commit_initial(root, activity, session)
+    assert captured.value.pointer_published is True
+    assert str(lock) in captured.value.durable_paths
+    assert load_current_snapshot(root, activity.work_reference).snapshot_revision == 1
+    original_unlink(lock)
+
+
+def test_write_lock_cleanup_failure_after_noop_is_partial(
+    storage_case: tuple[Path, Activity, Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, activity, session = storage_case
+    _commit_initial(root, activity, session)
+    lock = write_lock_path(root, activity.work_reference)
+    original_unlink = Path.unlink
+
+    def selective_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        if path == lock:
+            raise OSError("synthetic no-op lock cleanup failure")
+        original_unlink(path, *args, **kwargs)
+
+    with monkeypatch.context() as fault:
+        fault.setattr(Path, "unlink", selective_unlink)
+        with pytest.raises(ConcordStoragePartialSuccessError) as captured:
+            commit_record_batch(
+                root,
+                activity.work_reference,
+                (session,),
+                expected_snapshot_revision=1,
+            )
+    assert captured.value.pointer_published is False
+    assert str(lock) in captured.value.durable_paths
+    original_unlink(lock)
+
+
+def test_catalog_excludes_complete_record_bodies(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    _commit_initial(root, activity, session)
+    path = rebuild_catalog(root, activity.work_reference)
+    connection = sqlite3.connect(path)
+    try:
+        columns = tuple(
+            row[1] for row in connection.execute("PRAGMA table_info(record_revisions)")
+        )
+    finally:
+        connection.close()
+    assert columns == (
+        "record_kind",
+        "record_id",
+        "record_revision",
+        "sha256",
+        "relative_path",
+    )
+    assert "body_json" not in columns
+    assert query_catalog_records(root, activity.work_reference, state="current")
+    assert (
+        query_catalog_records(root, activity.work_reference, state="historical") == ()
+    )
+    assert query_catalog_records(root, activity.work_reference, state="all")
+    assert query_catalog_records(root, activity.work_reference, snapshot_revision=1)
+
+
+def test_catalog_lock_cleanup_failure_after_install_is_reported(
+    storage_case: tuple[Path, Activity, Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, activity, session = storage_case
+    _commit_initial(root, activity, session)
+    lock = catalog_lock_path(root, activity.work_reference)
+    original_unlink = Path.unlink
+
+    def selective_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        if path == lock:
+            raise OSError("synthetic catalog lock cleanup failure")
+        original_unlink(path, *args, **kwargs)
+
+    with monkeypatch.context() as fault:
+        fault.setattr(Path, "unlink", selective_unlink)
+        with pytest.raises(ConcordCatalogBuildError, match="installed successfully"):
+            rebuild_catalog(root, activity.work_reference)
+    assert catalog_path(root, activity.work_reference).is_file()
+    _open_verified(root, activity.work_reference).close()
+    original_unlink(lock)
+
+
+def test_catalog_lock_content_failure_does_not_leave_lock(
+    storage_case: tuple[Path, Activity, Session], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root, activity, session = storage_case
+    _commit_initial(root, activity, session)
+    lock = catalog_lock_path(root, activity.work_reference)
+    catalog = catalog_path(root, activity.work_reference)
+    original_canonical_json_bytes = storage_catalog_module.canonical_json_bytes
+
+    def fail_catalog_lock_content(value: object) -> bytes:
+        if isinstance(value, dict) and value.get("purpose") == "catalog_rebuild":
+            raise OSError("synthetic catalog lock content failure")
+        return original_canonical_json_bytes(value)
+
+    monkeypatch.setattr(
+        storage_catalog_module,
+        "canonical_json_bytes",
+        fail_catalog_lock_content,
+    )
+    with pytest.raises(ConcordCatalogBuildError, match="catalog rebuild failed"):
+        rebuild_catalog(root, activity.work_reference)
+
+    assert not lock.exists()
+    assert not catalog.exists()
+
+
+def test_snapshot_predecessor_work_identity_mismatch_is_rejected(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    _three_snapshots(root, activity, session)
+    work = activity.work_reference
+    second_path = snapshot_path(root, work, 2)
+    third_path = snapshot_path(root, work, 3)
+    second = snapshot_from_dict(strict_json_loads(second_path.read_bytes()))
+    other_work = ModuleWorkRef(
+        module_id="concord", class_id="other-class", work_id=work.work_id
+    )
+    altered_second = replace(second, work=other_work)
+    altered_second_bytes = serialize(altered_second)
+    second_path.write_bytes(altered_second_bytes)
+    third = snapshot_from_dict(strict_json_loads(third_path.read_bytes()))
+    third_path.write_bytes(
+        serialize(
+            replace(
+                third,
+                previous_snapshot_sha256=hashlib.sha256(
+                    altered_second_bytes
+                ).hexdigest(),
+            )
+        )
+    )
+    with pytest.raises(ConcordStorageIntegrityError, match="predecessor identity"):
+        load_work_snapshot(root, work, 3)
+
+
+def test_snapshot_predecessor_revision_identity_mismatch_is_rejected(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    _three_snapshots(root, activity, session)
+    work = activity.work_reference
+    second_path = snapshot_path(root, work, 2)
+    third_path = snapshot_path(root, work, 3)
+    original_third_bytes = third_path.read_bytes()
+    second_path.write_bytes(original_third_bytes)
+    third = snapshot_from_dict(strict_json_loads(original_third_bytes))
+    third_path.write_bytes(
+        serialize(
+            replace(
+                third,
+                previous_snapshot_sha256=hashlib.sha256(
+                    original_third_bytes
+                ).hexdigest(),
+            )
+        )
+    )
+    with pytest.raises(ConcordStorageIntegrityError, match="predecessor identity"):
+        load_work_snapshot(root, work, 3)
+
+
+def test_intermediate_snapshot_digest_corruption_is_rejected(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    _three_snapshots(root, activity, session)
+    first_path = snapshot_path(root, activity.work_reference, 1)
+    first_path.write_bytes(first_path.read_bytes() + b" ")
+    with pytest.raises(ConcordStorageIntegrityError, match="predecessor digest"):
+        load_work_snapshot(root, activity.work_reference, 3)
+
+
+def test_symlinked_current_pointer_is_rejected(
+    storage_case: tuple[Path, Activity, Session], tmp_path: Path
+) -> None:
+    root, activity, session = storage_case
+    _commit_initial(root, activity, session)
+    current = current_snapshot_path(root, activity.work_reference)
+    external = tmp_path / "external-current.json"
+    external.write_bytes(current.read_bytes())
+    current.unlink()
+    _symlink_or_skip(current, external)
+    with pytest.raises(ConcordStorageIntegrityError):
+        load_current_snapshot(root, activity.work_reference)
+
+
+def test_symlinked_write_lock_is_rejected(
+    storage_case: tuple[Path, Activity, Session], tmp_path: Path
+) -> None:
+    root, activity, _ = storage_case
+    lock = write_lock_path(root, activity.work_reference)
+    lock.parent.mkdir(parents=True, exist_ok=True)
+    external = tmp_path / "external-lock.json"
+    external.write_text("{}\n", encoding="utf-8")
+    _symlink_or_skip(lock, external)
+    with pytest.raises(ConcordStorageIntegrityError):
+        inspect_storage_locks(root, activity.work_reference)
+
+
+def test_symlinked_catalog_is_rejected(
+    storage_case: tuple[Path, Activity, Session], tmp_path: Path
+) -> None:
+    root, activity, session = storage_case
+    _commit_initial(root, activity, session)
+    catalog = rebuild_catalog(root, activity.work_reference)
+    external = tmp_path / "external-catalog.sqlite"
+    external.write_bytes(catalog.read_bytes())
+    catalog.unlink()
+    _symlink_or_skip(catalog, external)
+    with pytest.raises(ConcordCatalogIntegrityError):
+        query_catalog_records(root, activity.work_reference)
+
+
+def test_broken_symlinked_catalog_is_not_reported_missing(
+    storage_case: tuple[Path, Activity, Session], tmp_path: Path
+) -> None:
+    root, activity, _ = storage_case
+    catalog = catalog_path(root, activity.work_reference)
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    external = tmp_path / "nonexistent-external-catalog.sqlite"
+    _symlink_or_skip(catalog, external)
+
+    assert inspect_catalog_status(root, activity.work_reference) == "corrupt"
+
+
+def test_storage_validation_accepts_required_standards_context(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, _, _ = storage_case
+    fixture = json.loads(STANDARDS_FIXTURE.read_text(encoding="utf-8"))
+    records = tuple(
+        record_from_dict(envelope["record_kind"], envelope["body"])
+        for envelope in fixture["records"]
+    )
+    activity = next(record for record in records if isinstance(record, Activity))
+    library = _standards_library()
+    commit_record_batch(
+        root,
+        activity.work_reference,
+        records,
+        expected_snapshot_revision=None,
+        standards_library=library,
+    )
+
+    validate_storage(root, activity.work_reference, standards_library=library)
+    without_context = collect_storage_issues(root, activity.work_reference)
+    assert "storage.standards_context.required" in {
+        issue.code for issue in without_context
+    }
+
+
+def test_graph_diagnostics_preserve_native_issue_identity_and_privacy(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    sensitive_note = "SENSITIVE-NOTE-MUST-NOT-APPEAR"
+    _commit_initial(root, activity, replace(session, notes=sensitive_note))
+    work = activity.work_reference
+    snapshot_file = snapshot_path(root, work, 1)
+    snapshot = snapshot_from_dict(strict_json_loads(snapshot_file.read_bytes()))
+    activity_only = tuple(
+        reference
+        for reference in snapshot.records
+        if reference.record_kind == "activity"
+    )
+    altered_snapshot = replace(snapshot, records=activity_only)
+    altered_bytes = serialize(altered_snapshot)
+    snapshot_file.write_bytes(altered_bytes)
+    pointer = ConcordCurrentSnapshot(
+        CONCORD_STORAGE_SCHEMA_VERSION,
+        "concord_current_snapshot",
+        work,
+        1,
+        hashlib.sha256(altered_bytes).hexdigest(),
+    )
+    current_snapshot_path(root, work).write_bytes(serialize(pointer))
+
+    issues = collect_storage_issues(root, work)
+    graph_issue = next(
+        issue for issue in issues if issue.code == "activity.session.required"
+    )
+    assert graph_issue.record_kind == "activity"
+    assert graph_issue.record_id == activity.activity_id
+    assert graph_issue.field_path == ("activity_id",)
+    rendered = "\n".join(
+        f"{issue.code} {issue.message} {issue.related_references}" for issue in issues
+    )
+    assert sensitive_note not in rendered
+    assert "Moderation rationale" not in rendered
+    assert "raw evidence" not in rendered

--- a/tests/test_storage_contracts.py
+++ b/tests/test_storage_contracts.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pds_core.routing_models import ModuleWorkRef
+
+from concord.storage_errors import (
+    ConcordStorageReadError,
+    ConcordStorageValidationError,
+)
+from concord.storage_models import (
+    CONCORD_NATIVE_RECORD_CONTRACT_VERSION,
+    CONCORD_STORAGE_SCHEMA_VERSION,
+    ConcordCurrentSnapshot,
+    ConcordRecordRevisionRef,
+    ConcordWorkMarker,
+    ConcordWorkSnapshot,
+)
+from concord.storage_paths import (
+    catalog_path,
+    current_snapshot_path,
+    record_revision_path,
+    snapshot_path,
+    work_marker_path,
+)
+from concord.storage_serialization import (
+    canonical_json_bytes,
+    marker_from_dict,
+    serialize,
+    strict_json_loads,
+)
+
+
+@pytest.fixture
+def work() -> ModuleWorkRef:
+    return ModuleWorkRef(
+        module_id="concord", class_id="class-test", work_id="activity-test"
+    )
+
+
+def test_canonical_paths_are_exact_and_work_scoped(
+    tmp_path: Path, work: ModuleWorkRef
+) -> None:
+    base = (
+        tmp_path
+        / "classes"
+        / "class-test"
+        / "modules"
+        / "concord"
+        / "work"
+        / "activity-test"
+        / "state"
+    )
+    assert work_marker_path(tmp_path, work) == base / "work.json"
+    assert current_snapshot_path(tmp_path, work) == base / "current.json"
+    assert snapshot_path(tmp_path, work, 2) == base / "snapshots" / "2.json"
+    assert record_revision_path(tmp_path, work, "session", "session-1", 3) == (
+        base / "records" / "session" / "session-1" / "revisions" / "3.json"
+    )
+    assert catalog_path(tmp_path, work) == base / "derived" / "catalog.sqlite"
+
+
+@pytest.mark.parametrize("revision", [0, -1, True, 1.0, "1"])
+def test_paths_reject_non_positive_integer_revisions(
+    tmp_path: Path, work: ModuleWorkRef, revision: object
+) -> None:
+    with pytest.raises(ConcordStorageValidationError):
+        snapshot_path(tmp_path, work, revision)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "record_id",
+    ["", "../escape", "a/b", "a\\b", " C", "C ", "C:\\escape", "\x00"],
+)
+def test_paths_reject_unsafe_record_identifiers(
+    tmp_path: Path, work: ModuleWorkRef, record_id: str
+) -> None:
+    with pytest.raises(ConcordStorageValidationError):
+        record_revision_path(tmp_path, work, "session", record_id, 1)
+
+
+def test_marker_serialization_is_deterministic(work: ModuleWorkRef) -> None:
+    marker = ConcordWorkMarker(
+        CONCORD_STORAGE_SCHEMA_VERSION,
+        "concord_work",
+        work,
+        work.work_id,
+        CONCORD_NATIVE_RECORD_CONTRACT_VERSION,
+    )
+    data = serialize(marker)
+    assert data.endswith(b"\n") and not data.endswith(b"\n\n")
+    assert serialize(marker) == data
+    assert marker_from_dict(strict_json_loads(data)) == marker
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b'{"a": 1, "a": 2}\n',
+        b"\xef\xbb\xbf{}\n",
+        b'{"value": NaN}\n',
+        b"[]\n",
+        b"\xff",
+    ],
+)
+def test_strict_json_rejects_noncanonical_inputs(data: bytes) -> None:
+    with pytest.raises(ConcordStorageReadError):
+        strict_json_loads(data)
+
+
+def test_snapshot_references_must_be_sorted_unique_and_valid(
+    work: ModuleWorkRef,
+) -> None:
+    first = ConcordRecordRevisionRef("session", "session-2", 1, "a" * 64)
+    second = ConcordRecordRevisionRef("activity", "activity-test", 1, "b" * 64)
+    with pytest.raises(ConcordStorageValidationError):
+        ConcordWorkSnapshot(
+            CONCORD_STORAGE_SCHEMA_VERSION,
+            "concord_work_snapshot",
+            work,
+            1,
+            None,
+            None,
+            (first, second),
+        )
+    with pytest.raises(ConcordStorageValidationError):
+        ConcordRecordRevisionRef("session", "session-1", 1, "A" * 64)
+
+
+def test_current_pointer_rejects_boolean_revision(work: ModuleWorkRef) -> None:
+    with pytest.raises(ConcordStorageValidationError):
+        ConcordCurrentSnapshot(
+            CONCORD_STORAGE_SCHEMA_VERSION,
+            "concord_current_snapshot",
+            work,
+            True,
+            "a" * 64,
+        )
+
+
+def test_canonical_json_rejects_non_finite_numbers() -> None:
+    with pytest.raises(ConcordStorageValidationError):
+        canonical_json_bytes({"value": float("inf")})


### PR DESCRIPTION
## Summary

Implement Concord-owned canonical filesystem storage and guarded persistence for the immutable native record models introduced in #24.

This change establishes the persistence substrate for the v0.2.0 teacher-local Activity vertical slice without adding teacher workflows, routing, scan intake, publication, Meridian integration, or grading behavior.

## Key changes

### Canonical storage contracts

* Add versioned immutable work markers.
* Add versioned native record-revision envelopes.
* Add immutable work snapshots selecting exact record revisions.
* Add an atomic current-snapshot pointer.
* Use deterministic UTF-8 canonical JSON with strict schema validation.
* Verify exact SHA-256 digests for records and snapshots.

### Core-qualified storage paths

* Store Concord state beneath the exact Core `ModuleWorkRef` work root.
* Use Core public path and safe-descendant APIs.
* Reject unsafe identifiers, traversal, absolute paths, drive-qualified paths, symlinks, and containment violations.
* Keep Concord state isolated beneath the `state/` namespace.

### Guarded persistence

* Support validated multi-record commits.
* Require exact expected-snapshot revisions for optimistic concurrency.
* Preserve immutable record and snapshot history.
* Perform exact no-op replay without creating unnecessary revisions.
* Reject noncontiguous or orphaned record and snapshot histories before advancing current state.
* Keep storage revision separate from native domain supersession.

### Durability and interruption handling

* Create immutable files exclusively.
* Flush and synchronize record, snapshot, and lock files.
* Synchronize containing directories where supported.
* Publish `current.json` through atomic replacement.
* Record pointer publication before post-replacement directory synchronization.
* Report structured partial success when durable state may already exist.
* Preserve published state when final verification fails.
* Surface retained write and catalog locks rather than silently reporting success.

### Strict reads and reconstruction

* Load exact work markers, record revisions, snapshots, current pointers, and current records.
* Validate complete snapshot predecessor chains back to revision 1.
* Verify path, envelope, record-body, work, revision, and digest identity.
* Reconstruct the current `ConcordRecordGraph` without consulting SQLite.
* Require applicable Core standards validation for standards-based records.

### Derived catalog

* Add a disposable per-Activity SQLite catalog.
* Rebuild the catalog completely from canonical JSON.
* Use deterministic source inventories and exact source digests.
* Abort replacement if canonical state changes during rebuilding.
* Support current, historical, all, and exact-snapshot record queries.
* Store only minimized lookup metadata—never complete native record bodies.
* Treat missing, stale, corrupt, or incompatible catalogs as derived-state failures.

### Diagnostics and recovery

* Add deterministic, privacy-safe storage diagnostics.
* Preserve native graph-validation issue codes, record identities, and field paths.
* Report orphan record revisions and snapshots.
* Inspect locks using byte size and SHA-256 fingerprints.
* Treat broken or symlinked canonical paths as unsafe.
* Document conservative recovery boundaries and prohibit in-place history edits, highest-revision guessing, automatic orphan promotion, and row-level SQLite repair.

### Shared record registry

* Add one authoritative descriptor registry for:

  * canonical record kind;
  * model type;
  * identity field;
  * graph collection.

This removes duplicated mappings across conversion, validation, storage, and catalog code.

## Documentation

Add:

```text
docs/implementation/canonical-storage.md
```

Update:

* `README.md`
* `docs/README.md`
* `CHANGELOG.md`

## Local validation

* Full repository suite: **105 passed**
* Capability-based Windows symlink skips: **4 skipped**
* Ruff: passed
* Strict Mypy: passed across 28 source files
* Documentation validation: passed
* Wheel and sdist builds: passed
* Twine validation: passed
* Package checks: passed
* Isolated installed-wheel persistence smoke test: passed
* `git diff --check`: passed
* Validation left no repository residue

The skipped tests require Windows symlink privileges. They skip only after an actual operating-system symlink-creation failure; production safeguards remain enabled.

## Out of scope

This pull request does not add:

* teacher-facing Activity or Session workflows;
* PDS2 route registration;
* QR generation;
* scan intake or filing;
* Artifact rendering;
* Review or Moderation workflows;
* scoring workflows;
* publication manifests;
* Core Academic Work Registration;
* Publication Records;
* Meridian adapters;
* Grade calculation;
* standards-proficiency aggregation;
* reports;
* or authorization policy.

Closes #25.
