### PR TITLE
Implement Concord academic result publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Explicit Core Academic Work Registration for Concord Activities plus immutable
+  `concord_academic_result_manifest_v1` generation with semantic no-churn
+  revisioning and publication-safe projection.
+- A separate `paper_data_suite.publication_producers` Concord profile, explicit
+  first publication/supersession/withdrawal, Core catalog reconciliation,
+  deterministic publication-series status, and partial-success recovery.
+- Direct `concord publication ...` commands and an Activity-scoped teacher
+  Publication menu with read-only preview, deliberate confirmations, and no
+  implicit publication from scoring mutations.
 - Explicit Artifact Review workflows with coherent readiness/outcome state,
   one current supersession lineage per Artifact, and auditable Review
   correction history.

--- a/README.md
+++ b/README.md
@@ -20,9 +20,12 @@ management with preserved correction history.
 Concord now provides explicit Artifact Review and evidence Moderation with
 preserved history, exact Subject scope, immutable external-evidence lineage,
 plus teacher-controlled Criterion Sets, Scoring Scales, Score Records, Score
-Evidence Links, non-score dispositions, and Score revision history. Concord
-still does **not** publish academic results or calculate Grades; publication is
-issue #31 and Meridian owns downstream grading/reporting policy.
+Evidence Links, non-score dispositions, and Score revision history. Concord now
+also publishes explicitly registered Activity results as immutable
+`concord_academic_result_manifest_v1` revisions through Core Publication Records
+and the derived academic catalog. Concord does **not** calculate Grades or
+proficiency; Meridian owns downstream grading/reporting policy, and issue #32
+owns the consumer-neutral manifest reader.
 
 ## Requirements and installation
 
@@ -49,7 +52,8 @@ concord menu
 
 The main menu provides Activity Management, Activity opening, Workspace
 Settings, global Scan Routing, contextual Artifact Pages with assembly,
-Author/Subject, Review, Moderation, and Scoring workflows, Help, and Quit.
+Author/Subject, Review, Moderation, Scoring, and explicit Publication workflows,
+Help, and Quit.
 Controlled teacher screens use:
 
 ```text
@@ -61,7 +65,8 @@ Q. Quit
 
 Every menu write shows a focused review screen and requires the operation word
 `CREATE`, `RENDER`, `ASSEMBLE`, `ROUTE`, `RESOLVE`, `UPDATE`, `ADD`,
-`CORRECT`, `REVIEW`, `MODERATE`, `SCORE`, `REVISE`, `END`, or `REASSIGN`.
+`CORRECT`, `REVIEW`, `MODERATE`, `SCORE`, `REVISE`, `END`, `REASSIGN`,
+`REGISTER`, `GENERATE`, `PUBLISH`, `WITHDRAW`, or `REBUILD`.
 The menu clears between stages,
 paginates long selections after ten items, and does not display raw record
 bodies or complete graphs.
@@ -91,6 +96,10 @@ concord artifact page prepare|list|show
 concord artifact render
 concord scan route
 concord scan review list|show|resolve
+concord publication register|registration-show|registration-update
+concord publication manifest-preview|manifest-generate|manifest-list|manifest-show
+concord publication publish|supersede|withdraw|series-show
+concord publication catalog-list|catalog-rebuild
 ```
 
 Mutating direct commands require explicit actor context. Every write after the
@@ -141,6 +150,9 @@ Detailed behavior is documented in the
 [workflow implementation guide](docs/implementation/activity-session-group-workflows.md).
 Criterion, Scale, and Score behavior is documented in the
 [scoring implementation guide](docs/implementation/criterion-scale-score-recording.md).
+Academic-result registration, manifest generation, publication lifecycle, and
+catalog reconciliation are documented in the
+[publication implementation guide](docs/implementation/academic-result-publication.md).
 Canonical persistence and recovery rules remain documented in the
 [canonical storage guide](docs/implementation/canonical-storage.md).
 
@@ -166,8 +178,9 @@ inspection, isolated installed-wheel workflow/menu smoke tests, and
 
 Core exposes routing through `paper_data_suite.modules` and publication through
 `paper_data_suite.publication_producers`. These remain independent integration
-surfaces. Concord declares exactly the routing entry point; publication remains
-absent until issue #31.
+surfaces. Concord declares exactly one routing profile and one separate
+publication-producer profile. Publication profile discovery is metadata-only and
+does not require a sibling PDS package or mutate the workspace.
 
 The implementation sequence is tracked by
 [umbrella issue #22](https://github.com/Paper-Data-Suite/pds-concord/issues/22).

--- a/concord/academic_result_manifest.py
+++ b/concord/academic_result_manifest.py
@@ -1,0 +1,3264 @@
+"""Pure Concord Academic Result Manifest v1 contract.
+
+This module performs no workspace discovery or persistence. It owns only the
+immutable public value objects, strict JSON conversion, whole-manifest
+validation, shared capability derivation, semantic projection digests, and
+canonical UTF-8 JSON bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+import unicodedata
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Final, Literal, NoReturn, TypeAlias, cast
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+from pds_core.publication_records import PublicationCapability
+from pds_core.routing_models import (
+    ModuleRecordRef,
+    ModuleWorkRef,
+    RoutingModelError,
+    module_record_ref_from_dict,
+    module_record_ref_to_dict,
+    module_work_ref_from_dict,
+    module_work_ref_to_dict,
+)
+
+from concord.pds_contract import (
+    ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+    ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+    CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+    CONCORD_ACTIVITY_CONTRACT_VERSION,
+    CONCORD_ACTIVITY_RECORD_KIND,
+    CONCORD_MODULE_ID,
+)
+
+JsonScalar: TypeAlias = str | int | float | bool
+ScoreKind: TypeAlias = Literal["standard_backed", "local"]
+ScoreDisposition: TypeAlias = Literal[
+    "scored",
+    "insufficient_evidence",
+    "absent",
+    "excused",
+    "not_observed",
+    "not_applicable",
+    "deferred",
+]
+ScoreBasis: TypeAlias = Literal[
+    "linked_evidence", "professional_judgment", "mixed_basis"
+]
+CurrentState: TypeAlias = Literal["current", "superseded"]
+RevisionReason: TypeAlias = Literal[
+    "initial",
+    "native_state_change",
+    "evidence_lineage_change",
+    "moderation_change",
+    "projection_correction",
+    "privacy_correction",
+    "contract_migration",
+]
+
+PROJECTION_DIGEST_ALGORITHM: Final[str] = "sha256"
+PUBLICATION_KIND: Final[str] = "academic_result_set"
+
+_SCORE_KINDS = frozenset({"standard_backed", "local"})
+_SCORE_DISPOSITIONS = frozenset(
+    {
+        "scored",
+        "insufficient_evidence",
+        "absent",
+        "excused",
+        "not_observed",
+        "not_applicable",
+        "deferred",
+    }
+)
+_SCORE_BASES = frozenset(
+    {"linked_evidence", "professional_judgment", "mixed_basis"}
+)
+_CURRENT_STATES = frozenset({"current", "superseded"})
+_REVISION_REASONS = frozenset(
+    {
+        "initial",
+        "native_state_change",
+        "evidence_lineage_change",
+        "moderation_change",
+        "projection_correction",
+        "privacy_correction",
+        "contract_migration",
+    }
+)
+_TARGET_KINDS = frozenset(
+    {
+        "core_student",
+        "concord_group",
+        "concord_session",
+        "concord_activity",
+        "concord_artifact_instance",
+    }
+)
+_SUBJECT_KINDS = _TARGET_KINDS | frozenset({"external_record"})
+_CRITERION_KINDS = _SCORE_KINDS
+_CRITERION_SET_KINDS = frozenset({"standard_backed", "local", "mixed"})
+_CRITERION_SET_SCOPES = frozenset({"reusable", "activity_specific"})
+_SCALE_TYPES = frozenset(
+    {"numeric", "ordinal", "categorical", "binary", "teacher_defined"}
+)
+_SCALE_STATUSES = frozenset(
+    {"draft", "active", "inactive", "archived", "superseded"}
+)
+_CRITERION_SET_STATUSES = _SCALE_STATUSES
+_CRITERION_STATUSES = frozenset({"draft", "active", "inactive", "archived"})
+_LINK_STATUSES = frozenset({"active", "inactive", "superseded", "rejected"})
+_LINK_SIGNIFICANCE = frozenset(
+    {
+        "primary",
+        "corroborating",
+        "contextual",
+        "qualifying",
+        "counterevidence",
+        "background",
+    }
+)
+_MODERATION_STATUSES = frozenset(
+    {
+        "accepted",
+        "accepted_with_qualification",
+        "insufficient",
+        "disputed",
+        "rejected",
+        "not_used_for_scoring",
+    }
+)
+_MODERATION_PERMITTED_USES = frozenset(
+    {
+        "support_group_score",
+        "support_named_subject",
+        "corroborate_only",
+        "formative_only",
+        "not_independently_determine_score",
+        "not_be_used_for_scoring",
+    }
+)
+_PRIVACY_CLASSIFICATIONS = frozenset(
+    {
+        "teacher_restricted",
+        "teacher_and_subjects",
+        "group_and_teacher",
+        "classroom_shared",
+        "inherited",
+        "external_policy",
+    }
+)
+_SCORING_ORIENTATIONS = frozenset(
+    {"evidence_only", "standards_based", "mixed", "local_criteria_only"}
+)
+_EVIDENCE_KINDS = frozenset(
+    {
+        "artifact_instance",
+        "artifact_page",
+        "teacher_rationale",
+        "scoreform_result",
+        "quillan_response",
+        "external_record",
+    }
+)
+_MODERATION_REQUIREMENTS = frozenset({"required", "not_required"})
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_WINDOWS_ABSOLUTE = re.compile(r"^[A-Za-z]:[\\/]")
+_SECRET_SHAPED = re.compile(
+    r"(?i)(?:password|passwd|api[_ -]?key|access[_ -]?token|secret)\s*[:=]"
+)
+
+_TOP_LEVEL_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "record_type",
+        "contract_version",
+        "producer_module_id",
+        "generated_at",
+        "record_set",
+        "work",
+        "source_activity",
+        "projection",
+        "activity_context",
+        "criterion_sets",
+        "criteria",
+        "scoring_scales",
+        "scores",
+        "score_evidence_links",
+        "moderation_records",
+        "standards_result_projection",
+        "privacy",
+    }
+)
+
+
+class ConcordAcademicResultManifestError(Exception):
+    """Base error for the Concord public manifest contract."""
+
+
+class ConcordAcademicResultManifestValidationError(
+    ConcordAcademicResultManifestError, ValueError
+):
+    """A manifest value violates the v1 public contract."""
+
+
+class ConcordAcademicResultManifestDecodeError(
+    ConcordAcademicResultManifestValidationError
+):
+    """Manifest JSON cannot be decoded without violating the v1 contract."""
+
+
+def _fail(message: str) -> NoReturn:
+    raise ConcordAcademicResultManifestValidationError(message)
+
+
+def _identifier(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        _fail(f"{field} must be a safe identifier.")
+    try:
+        return validate_identifier(value, field)
+    except (IdentifierValidationError, TypeError, ValueError) as error:
+        raise ConcordAcademicResultManifestValidationError(
+            f"{field} must be a safe identifier."
+        ) from error
+
+
+def _optional_identifier(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    return _identifier(value, field)
+
+
+def _lower_kind(value: object, field: str) -> str:
+    text = _identifier(value, field)
+    if text != text.lower():
+        _fail(f"{field} must be lowercase.")
+    return text
+
+
+def _positive_int(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        _fail(f"{field} must be a positive integer.")
+    return value
+
+
+def _nonnegative_int(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        _fail(f"{field} must be a nonnegative integer.")
+    return value
+
+
+def _bool(value: object, field: str) -> bool:
+    if not isinstance(value, bool):
+        _fail(f"{field} must be a Boolean.")
+    return value
+
+
+def _public_text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail(f"{field} must be nonempty and trimmed.")
+    if any(
+        unicodedata.category(character) in {"Cc", "Cf", "Cs", "Zl", "Zp"}
+        for character in value
+    ):
+        _fail(f"{field} must be control-free.")
+    lowered = value.lower()
+    if (
+        _SECRET_SHAPED.search(value) is not None
+        or _WINDOWS_ABSOLUTE.match(value) is not None
+        or "file://" in lowered
+        or "/users/" in lowered
+        or "/home/" in lowered
+    ):
+        _fail(f"{field} contains unsafe publication text.")
+    return value
+
+
+def _optional_public_text(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    return _public_text(value, field)
+
+
+def _timestamp(value: object, field: str) -> datetime:
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        _fail(f"{field} must be a timezone-aware datetime.")
+    try:
+        if value.utcoffset() is None:
+            _fail(f"{field} must be a timezone-aware datetime.")
+    except Exception as error:
+        raise ConcordAcademicResultManifestValidationError(
+            f"{field} must be a valid timezone-aware datetime."
+        ) from error
+    return value
+
+
+def _timestamp_from_json(value: object, field: str) -> datetime:
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail(f"{field} must be an ISO 8601 timestamp string.")
+    candidate = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as error:
+        raise ConcordAcademicResultManifestValidationError(
+            f"{field} must be a valid ISO 8601 timestamp."
+        ) from error
+    return _timestamp(parsed, field)
+
+
+def _timestamp_to_json(value: datetime) -> str:
+    normalized = _timestamp(value, "timestamp").astimezone(timezone.utc)
+    return normalized.isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _digest(value: object, field: str) -> str:
+    if not isinstance(value, str) or _SHA256.fullmatch(value) is None:
+        _fail(f"{field} must be a lowercase SHA-256 digest.")
+    return value
+
+
+def _scalar(value: object, field: str) -> JsonScalar:
+    if not isinstance(value, (str, int, float, bool)):
+        _fail(f"{field} must be a non-null JSON scalar.")
+    if isinstance(value, float) and not math.isfinite(value):
+        _fail(f"{field} must be finite.")
+    return value
+
+
+def _scalar_key(value: JsonScalar) -> tuple[type[object], JsonScalar]:
+    return (type(value), value)
+
+
+def _controlled(value: object, field: str, allowed: frozenset[str]) -> str:
+    if not isinstance(value, str) or value not in allowed:
+        _fail(f"{field} must be one of: {', '.join(sorted(allowed))}.")
+    return value
+
+
+def _tuple_identifiers(
+    value: Sequence[str],
+    field: str,
+    *,
+    nonempty: bool = False,
+) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes, bytearray)):
+        _fail(f"{field} must be an array of identifiers.")
+    result = tuple(
+        _identifier(item, f"{field}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if nonempty and not result:
+        _fail(f"{field} must not be empty.")
+    if len(set(result)) != len(result):
+        _fail(f"{field} must not contain duplicates.")
+    return result
+
+
+def _tuple_values(
+    value: Sequence[object],
+    expected: type[object],
+    field: str,
+) -> tuple[object, ...]:
+    if isinstance(value, (str, bytes, bytearray)):
+        _fail(f"{field} must be an array.")
+    result = tuple(value)
+    if any(not isinstance(item, expected) for item in result):
+        _fail(f"{field} contains an invalid value.")
+    return result
+
+
+def _exact_mapping(
+    value: object, keys: frozenset[str], field: str
+) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        _fail(f"{field} must be an object.")
+    if any(not isinstance(key, str) for key in value):
+        _fail(f"{field} keys must be strings.")
+    actual = frozenset(cast(Mapping[str, object], value).keys())
+    if actual != keys:
+        missing = sorted(keys - actual)
+        unknown = sorted(actual - keys)
+        details: list[str] = []
+        if missing:
+            details.append("missing " + ", ".join(missing))
+        if unknown:
+            details.append("unknown " + ", ".join(unknown))
+        _fail(f"{field} has an invalid key set ({'; '.join(details)}).")
+    return cast(Mapping[str, object], value)
+
+
+def _array(value: object, field: str) -> tuple[object, ...]:
+    if not isinstance(value, list):
+        _fail(f"{field} must be a JSON array.")
+    return tuple(value)
+
+
+def _module_work(value: object, field: str) -> ModuleWorkRef:
+    if isinstance(value, ModuleWorkRef):
+        return value
+    try:
+        return module_work_ref_from_dict(value)
+    except (RoutingModelError, TypeError, ValueError) as error:
+        raise ConcordAcademicResultManifestValidationError(
+            f"{field} is invalid."
+        ) from error
+
+
+def _module_record(value: object, field: str) -> ModuleRecordRef:
+    if isinstance(value, ModuleRecordRef):
+        return value
+    try:
+        return module_record_ref_from_dict(value)
+    except (RoutingModelError, TypeError, ValueError) as error:
+        raise ConcordAcademicResultManifestValidationError(
+            f"{field} is invalid."
+        ) from error
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestRecordSet:
+    record_set_id: str
+    revision: int
+
+    def __post_init__(self) -> None:
+        if self.record_set_id != CONCORD_ACADEMIC_RESULT_RECORD_SET_ID:
+            _fail('record_set_id must be exactly "academic_results".')
+        _positive_int(self.revision, "record_set.revision")
+
+
+@dataclass(frozen=True, slots=True)
+class PublicActor:
+    actor_kind: str
+    actor_id: str
+    owning_system: str
+
+    def __post_init__(self) -> None:
+        _controlled(
+            self.actor_kind,
+            "actor_kind",
+            frozenset(
+                {
+                    "core_student",
+                    "authorized_adult",
+                    "system",
+                    "external_actor",
+                }
+            ),
+        )
+        _identifier(self.actor_id, "actor_id")
+        _lower_kind(self.owning_system, "owning_system")
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestProjection:
+    source_snapshot_revision: int
+    projection_digest_algorithm: str
+    projection_digest: str
+    generated_by: PublicActor
+    revision_reason: RevisionReason
+
+    def __post_init__(self) -> None:
+        _positive_int(
+            self.source_snapshot_revision, "projection.source_snapshot_revision"
+        )
+        if self.projection_digest_algorithm != PROJECTION_DIGEST_ALGORITHM:
+            _fail('projection_digest_algorithm must be exactly "sha256".')
+        _digest(self.projection_digest, "projection.projection_digest")
+        if not isinstance(self.generated_by, PublicActor):
+            _fail("projection.generated_by must be a PublicActor.")
+        _controlled(
+            self.revision_reason,
+            "projection.revision_reason",
+            _REVISION_REASONS,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityContextProjection:
+    activity_id: str
+    class_id: str
+    title: str
+    scoring_orientation: str
+    standards_profile_id: str | None
+    focus_standard_ids: tuple[str, ...]
+    criterion_set_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        _identifier(self.activity_id, "activity_context.activity_id")
+        _identifier(self.class_id, "activity_context.class_id")
+        _public_text(self.title, "activity_context.title")
+        _controlled(
+            self.scoring_orientation,
+            "activity_context.scoring_orientation",
+            _SCORING_ORIENTATIONS,
+        )
+        _optional_identifier(
+            self.standards_profile_id,
+            "activity_context.standards_profile_id",
+        )
+        object.__setattr__(
+            self,
+            "focus_standard_ids",
+            _tuple_identifiers(
+                self.focus_standard_ids,
+                "activity_context.focus_standard_ids",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "criterion_set_ids",
+            _tuple_identifiers(
+                self.criterion_set_ids,
+                "activity_context.criterion_set_ids",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CriterionSetProjection:
+    criterion_set_id: str
+    lineage_id: str
+    revision: int
+    criterion_set_kind: str
+    scope: str
+    criterion_ids: tuple[str, ...]
+    status: str
+    supersedes_criterion_set_id: str | None
+    standards_profile_id: str | None
+
+    def __post_init__(self) -> None:
+        _identifier(self.criterion_set_id, "criterion_set_id")
+        _identifier(self.lineage_id, "criterion_set.lineage_id")
+        _positive_int(self.revision, "criterion_set.revision")
+        _controlled(
+            self.criterion_set_kind,
+            "criterion_set.criterion_set_kind",
+            _CRITERION_SET_KINDS,
+        )
+        _controlled(self.scope, "criterion_set.scope", _CRITERION_SET_SCOPES)
+        object.__setattr__(
+            self,
+            "criterion_ids",
+            _tuple_identifiers(
+                self.criterion_ids,
+                "criterion_set.criterion_ids",
+                nonempty=True,
+            ),
+        )
+        _controlled(
+            self.status, "criterion_set.status", _CRITERION_SET_STATUSES
+        )
+        _optional_identifier(
+            self.supersedes_criterion_set_id,
+            "criterion_set.supersedes_criterion_set_id",
+        )
+        _optional_identifier(
+            self.standards_profile_id,
+            "criterion_set.standards_profile_id",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CriterionProjection:
+    criterion_id: str
+    criterion_set_id: str
+    key: str
+    label: str
+    definition: str
+    criterion_kind: str
+    supported_target_kinds: tuple[str, ...]
+    status: str
+    standard_id: str | None
+    alignment_standard_ids: tuple[str, ...]
+    default_scoring_scale_id: str | None
+
+    def __post_init__(self) -> None:
+        _identifier(self.criterion_id, "criterion_id")
+        _identifier(self.criterion_set_id, "criterion.criterion_set_id")
+        _identifier(self.key, "criterion.key")
+        _public_text(self.label, "criterion.label")
+        _public_text(self.definition, "criterion.definition")
+        kind = _controlled(
+            self.criterion_kind,
+            "criterion.criterion_kind",
+            _CRITERION_KINDS,
+        )
+        targets = tuple(self.supported_target_kinds)
+        if not targets or len(set(targets)) != len(targets):
+            _fail("criterion.supported_target_kinds must be nonempty and unique.")
+        for index, target in enumerate(targets):
+            _controlled(
+                target,
+                f"criterion.supported_target_kinds[{index}]",
+                _TARGET_KINDS,
+            )
+        object.__setattr__(self, "supported_target_kinds", targets)
+        _controlled(self.status, "criterion.status", _CRITERION_STATUSES)
+        _optional_identifier(self.standard_id, "criterion.standard_id")
+        object.__setattr__(
+            self,
+            "alignment_standard_ids",
+            _tuple_identifiers(
+                self.alignment_standard_ids,
+                "criterion.alignment_standard_ids",
+            ),
+        )
+        _optional_identifier(
+            self.default_scoring_scale_id,
+            "criterion.default_scoring_scale_id",
+        )
+        if kind == "standard_backed" and self.standard_id is None:
+            _fail("standard-backed Criterion requires standard_id.")
+        if kind == "local" and self.standard_id is not None:
+            _fail("local Criterion forbids standard_id.")
+
+
+@dataclass(frozen=True, slots=True)
+class ScaleLevelProjection:
+    value: JsonScalar
+    label: str
+    meaning: str
+    position: int | None
+    description: str | None
+
+    def __post_init__(self) -> None:
+        _scalar(self.value, "scale_level.value")
+        _public_text(self.label, "scale_level.label")
+        _public_text(self.meaning, "scale_level.meaning")
+        if self.position is not None:
+            _positive_int(self.position, "scale_level.position")
+        _optional_public_text(self.description, "scale_level.description")
+
+
+@dataclass(frozen=True, slots=True)
+class ScoringScaleProjection:
+    scoring_scale_id: str
+    lineage_id: str
+    name: str
+    revision: int
+    scale_type: str
+    levels: tuple[ScaleLevelProjection, ...]
+    status: str
+    supersedes_scoring_scale_id: str | None
+
+    def __post_init__(self) -> None:
+        _identifier(self.scoring_scale_id, "scoring_scale_id")
+        _identifier(self.lineage_id, "scoring_scale.lineage_id")
+        _public_text(self.name, "scoring_scale.name")
+        _positive_int(self.revision, "scoring_scale.revision")
+        scale_type = _controlled(
+            self.scale_type, "scoring_scale.scale_type", _SCALE_TYPES
+        )
+        levels = tuple(self.levels)
+        if not levels or any(
+            not isinstance(level, ScaleLevelProjection) for level in levels
+        ):
+            _fail("scoring_scale.levels must contain ScaleLevelProjection values.")
+        object.__setattr__(self, "levels", levels)
+        keys = tuple(_scalar_key(level.value) for level in levels)
+        if len(set(keys)) != len(keys):
+            _fail("scoring_scale level values must be type-sensitively unique.")
+        positions = tuple(
+            level.position for level in levels if level.position is not None
+        )
+        if len(set(positions)) != len(positions):
+            _fail("scoring_scale positions must be unique.")
+        if positions and len(positions) != len(levels):
+            _fail("scoring_scale positions must be complete or absent.")
+        if scale_type == "numeric" and any(
+            isinstance(level.value, bool)
+            or not isinstance(level.value, (int, float))
+            for level in levels
+        ):
+            _fail("numeric Scale levels require int or float values.")
+        if scale_type == "ordinal" and any(
+            level.position is None for level in levels
+        ):
+            _fail("ordinal Scale levels require positions.")
+        if scale_type == "binary" and len(levels) != 2:
+            _fail("binary Scale requires exactly two levels.")
+        _controlled(self.status, "scoring_scale.status", _SCALE_STATUSES)
+        _optional_identifier(
+            self.supersedes_scoring_scale_id,
+            "scoring_scale.supersedes_scoring_scale_id",
+        )
+
+    def has_value(self, value: JsonScalar) -> bool:
+        key = _scalar_key(value)
+        return any(_scalar_key(level.value) == key for level in self.levels)
+
+
+@dataclass(frozen=True, slots=True)
+class TargetReferenceProjection:
+    target_kind: str
+    target_id: str
+    owning_system: str
+    contract_version: str | None
+
+    def __post_init__(self) -> None:
+        kind = _controlled(
+            self.target_kind, "target.target_kind", _TARGET_KINDS
+        )
+        _identifier(self.target_id, "target.target_id")
+        owner = _lower_kind(self.owning_system, "target.owning_system")
+        _optional_identifier(
+            self.contract_version, "target.contract_version"
+        )
+        expected_owner = "core" if kind == "core_student" else "concord"
+        if owner != expected_owner:
+            _fail(
+                f"{kind} target owning_system must be exactly "
+                f"{expected_owner}."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class SubjectReferenceProjection:
+    subject_kind: str
+    subject_id: str
+    owning_system: str
+    contract_version: str | None
+
+    def __post_init__(self) -> None:
+        _controlled(
+            self.subject_kind, "subject.subject_kind", _SUBJECT_KINDS
+        )
+        _identifier(self.subject_id, "subject.subject_id")
+        _lower_kind(self.owning_system, "subject.owning_system")
+        _optional_identifier(
+            self.contract_version, "subject.contract_version"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RecordReferenceProjection:
+    module_id: str
+    record_kind: str
+    record_id: str
+    contract_version: str | None
+
+    def __post_init__(self) -> None:
+        _lower_kind(self.module_id, "record_reference.module_id")
+        _lower_kind(self.record_kind, "record_reference.record_kind")
+        _identifier(self.record_id, "record_reference.record_id")
+        _optional_identifier(
+            self.contract_version, "record_reference.contract_version"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CorePublicationReferenceProjection:
+    publication_id: str
+    publication_schema_version: str | None
+
+    def __post_init__(self) -> None:
+        _identifier(self.publication_id, "publication_reference.publication_id")
+        _optional_identifier(
+            self.publication_schema_version,
+            "publication_reference.publication_schema_version",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceLocatorProjection:
+    page_number: int | None
+    source_page_index: int | None
+    section_label: str | None
+    row_label: str | None
+    column_label: str | None
+    participant_label: str | None
+    session_id: str | None
+
+    def __post_init__(self) -> None:
+        if self.page_number is not None:
+            _positive_int(self.page_number, "evidence_locator.page_number")
+        if self.source_page_index is not None:
+            _nonnegative_int(
+                self.source_page_index,
+                "evidence_locator.source_page_index",
+            )
+        for field in (
+            "section_label",
+            "row_label",
+            "column_label",
+            "participant_label",
+        ):
+            _optional_public_text(
+                getattr(self, field), f"evidence_locator.{field}"
+            )
+        _optional_identifier(
+            self.session_id, "evidence_locator.session_id"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceReferenceProjection:
+    evidence_kind: str
+    owning_system: str
+    record_id: str
+    contract_version: str | None
+    source_publication_reference: CorePublicationReferenceProjection | None
+    immutable_source_version: str | None
+    locator: EvidenceLocatorProjection | None
+    subject_context: tuple[SubjectReferenceProjection, ...]
+    moderation_requirement: str | None
+
+    def __post_init__(self) -> None:
+        _controlled(
+            self.evidence_kind,
+            "evidence_reference.evidence_kind",
+            _EVIDENCE_KINDS,
+        )
+        owner = _lower_kind(
+            self.owning_system, "evidence_reference.owning_system"
+        )
+        _identifier(self.record_id, "evidence_reference.record_id")
+        _optional_identifier(
+            self.contract_version,
+            "evidence_reference.contract_version",
+        )
+        if (
+            self.source_publication_reference is not None
+            and not isinstance(
+                self.source_publication_reference,
+                CorePublicationReferenceProjection,
+            )
+        ):
+            _fail(
+                "evidence_reference.source_publication_reference is invalid."
+            )
+        if self.immutable_source_version is not None:
+            version = _public_text(
+                self.immutable_source_version,
+                "evidence_reference.immutable_source_version",
+            )
+            if version.lower() in {"current", "latest", "mutable"}:
+                _fail(
+                    "immutable_source_version must identify an exact revision."
+                )
+        if self.locator is not None and not isinstance(
+            self.locator, EvidenceLocatorProjection
+        ):
+            _fail("evidence_reference.locator is invalid.")
+        subjects = tuple(self.subject_context)
+        if any(
+            not isinstance(subject, SubjectReferenceProjection)
+            for subject in subjects
+        ):
+            _fail("evidence_reference.subject_context is invalid.")
+        if len(set(subjects)) != len(subjects):
+            _fail(
+                "evidence_reference.subject_context must not contain duplicates."
+            )
+        object.__setattr__(self, "subject_context", subjects)
+        if self.moderation_requirement is not None:
+            _controlled(
+                self.moderation_requirement,
+                "evidence_reference.moderation_requirement",
+                _MODERATION_REQUIREMENTS,
+            )
+        if (
+            owner != CONCORD_MODULE_ID
+            and self.source_publication_reference is None
+            and self.immutable_source_version is None
+        ):
+            _fail(
+                "external evidence requires an exact immutable source version "
+                "or Core Publication Reference."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class StatusReasonProjection:
+    reason_code: str
+    recorded_by: PublicActor
+    recorded_at: datetime
+    related_record: RecordReferenceProjection | None
+
+    def __post_init__(self) -> None:
+        _identifier(self.reason_code, "status_reason.reason_code")
+        if not isinstance(self.recorded_by, PublicActor):
+            _fail("status_reason.recorded_by must be a PublicActor.")
+        _timestamp(self.recorded_at, "status_reason.recorded_at")
+        if self.related_record is not None and not isinstance(
+            self.related_record, RecordReferenceProjection
+        ):
+            _fail("status_reason.related_record is invalid.")
+
+
+@dataclass(frozen=True, slots=True)
+class ScoreProjection:
+    score_record_id: str
+    activity_id: str
+    session_id: str | None
+    target_reference: TargetReferenceProjection
+    criterion_id: str
+    score_kind: ScoreKind
+    standard_id: str | None
+    scoring_scale_id: str
+    disposition: ScoreDisposition
+    value: JsonScalar | None
+    basis: ScoreBasis
+    scorer: PublicActor
+    scored_at: datetime
+    moderation_complete: bool
+    status_reason: StatusReasonProjection | None
+    supersedes_score_record_id: str | None
+    current_state: CurrentState
+
+    def __post_init__(self) -> None:
+        _identifier(self.score_record_id, "score.score_record_id")
+        _identifier(self.activity_id, "score.activity_id")
+        _optional_identifier(self.session_id, "score.session_id")
+        if not isinstance(self.target_reference, TargetReferenceProjection):
+            _fail("score.target_reference is invalid.")
+        _identifier(self.criterion_id, "score.criterion_id")
+        kind = cast(
+            ScoreKind,
+            _controlled(self.score_kind, "score.score_kind", _SCORE_KINDS),
+        )
+        _optional_identifier(self.standard_id, "score.standard_id")
+        _identifier(self.scoring_scale_id, "score.scoring_scale_id")
+        disposition = cast(
+            ScoreDisposition,
+            _controlled(
+                self.disposition,
+                "score.disposition",
+                _SCORE_DISPOSITIONS,
+            ),
+        )
+        cast(
+            ScoreBasis,
+            _controlled(self.basis, "score.basis", _SCORE_BASES),
+        )
+        if not isinstance(self.scorer, PublicActor):
+            _fail("score.scorer must be a PublicActor.")
+        _timestamp(self.scored_at, "score.scored_at")
+        _bool(self.moderation_complete, "score.moderation_complete")
+        if self.status_reason is not None and not isinstance(
+            self.status_reason, StatusReasonProjection
+        ):
+            _fail("score.status_reason is invalid.")
+        _optional_identifier(
+            self.supersedes_score_record_id,
+            "score.supersedes_score_record_id",
+        )
+        _controlled(
+            self.current_state, "score.current_state", _CURRENT_STATES
+        )
+        if disposition == "scored":
+            if self.value is None:
+                _fail("scored Score requires value.")
+            _scalar(self.value, "score.value")
+            if self.status_reason is not None:
+                _fail("scored Score forbids status_reason.")
+            if not self.moderation_complete:
+                _fail("scored Score requires moderation_complete.")
+        else:
+            if self.value is not None:
+                _fail("non-score Score forbids value.")
+            if self.status_reason is None:
+                _fail("published non-score Score requires status_reason.")
+            if self.status_reason.reason_code != disposition:
+                _fail(
+                    "published non-score status reason must match disposition."
+                )
+        if kind == "standard_backed" and self.standard_id is None:
+            _fail("standard-backed Score requires standard_id.")
+        if kind == "local" and self.standard_id is not None:
+            _fail("local Score forbids standard_id.")
+
+
+@dataclass(frozen=True, slots=True)
+class ScoreEvidenceLinkProjection:
+    score_evidence_link_id: str
+    score_record_id: str
+    evidence_reference: EvidenceReferenceProjection
+    evidence_locator: EvidenceLocatorProjection | None
+    subject_context: tuple[SubjectReferenceProjection, ...]
+    relevance_description: str
+    significance: str | None
+    moderation_record_id: str | None
+    status: str
+    supersedes_score_evidence_link_id: str | None
+
+    def __post_init__(self) -> None:
+        _identifier(
+            self.score_evidence_link_id,
+            "score_evidence_link.score_evidence_link_id",
+        )
+        _identifier(
+            self.score_record_id,
+            "score_evidence_link.score_record_id",
+        )
+        if not isinstance(
+            self.evidence_reference, EvidenceReferenceProjection
+        ):
+            _fail("score_evidence_link.evidence_reference is invalid.")
+        if self.evidence_locator is not None and not isinstance(
+            self.evidence_locator, EvidenceLocatorProjection
+        ):
+            _fail("score_evidence_link.evidence_locator is invalid.")
+        subjects = tuple(self.subject_context)
+        if any(
+            not isinstance(subject, SubjectReferenceProjection)
+            for subject in subjects
+        ):
+            _fail("score_evidence_link.subject_context is invalid.")
+        if len(set(subjects)) != len(subjects):
+            _fail(
+                "score_evidence_link.subject_context must not contain "
+                "duplicates."
+            )
+        object.__setattr__(self, "subject_context", subjects)
+        _public_text(
+            self.relevance_description,
+            "score_evidence_link.relevance_description",
+        )
+        if self.significance is not None:
+            _controlled(
+                self.significance,
+                "score_evidence_link.significance",
+                _LINK_SIGNIFICANCE,
+            )
+        _optional_identifier(
+            self.moderation_record_id,
+            "score_evidence_link.moderation_record_id",
+        )
+        _controlled(
+            self.status, "score_evidence_link.status", _LINK_STATUSES
+        )
+        _optional_identifier(
+            self.supersedes_score_evidence_link_id,
+            "score_evidence_link.supersedes_score_evidence_link_id",
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ModerationProjection:
+    moderation_record_id: str
+    target_evidence_reference: EvidenceReferenceProjection
+    target_subject_references: tuple[SubjectReferenceProjection, ...]
+    status: str
+    permitted_use: str
+    qualification: str | None
+    supersedes_moderation_record_id: str | None
+    current_state: CurrentState
+
+    def __post_init__(self) -> None:
+        _identifier(
+            self.moderation_record_id,
+            "moderation.moderation_record_id",
+        )
+        if not isinstance(
+            self.target_evidence_reference,
+            EvidenceReferenceProjection,
+        ):
+            _fail("moderation.target_evidence_reference is invalid.")
+        subjects = tuple(self.target_subject_references)
+        if any(
+            not isinstance(subject, SubjectReferenceProjection)
+            for subject in subjects
+        ):
+            _fail("moderation.target_subject_references is invalid.")
+        if len(set(subjects)) != len(subjects):
+            _fail(
+                "moderation.target_subject_references must not contain "
+                "duplicates."
+            )
+        object.__setattr__(
+            self,
+            "target_subject_references",
+            tuple(
+                sorted(
+                    subjects,
+                    key=lambda item: (
+                        item.subject_kind,
+                        item.owning_system,
+                        item.subject_id,
+                        item.contract_version or "",
+                    ),
+                )
+            ),
+        )
+        status = _controlled(
+            self.status, "moderation.status", _MODERATION_STATUSES
+        )
+        permitted = _controlled(
+            self.permitted_use,
+            "moderation.permitted_use",
+            _MODERATION_PERMITTED_USES,
+        )
+        _optional_public_text(
+            self.qualification, "moderation.qualification"
+        )
+        _optional_identifier(
+            self.supersedes_moderation_record_id,
+            "moderation.supersedes_moderation_record_id",
+        )
+        _controlled(
+            self.current_state,
+            "moderation.current_state",
+            _CURRENT_STATES,
+        )
+        if (
+            status == "accepted_with_qualification"
+            and self.qualification is None
+        ):
+            _fail(
+                "accepted_with_qualification requires qualification."
+            )
+        if (
+            status != "accepted_with_qualification"
+            and self.qualification is not None
+        ):
+            _fail(
+                "qualification is allowed only for "
+                "accepted_with_qualification."
+            )
+        if (
+            status in {"rejected", "not_used_for_scoring"}
+            and permitted != "not_be_used_for_scoring"
+        ):
+            _fail(
+                "rejected/not-used Moderation cannot permit scoring."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class StandardsResultProjection:
+    score_record_id: str
+    standard_id: str
+
+    def __post_init__(self) -> None:
+        _identifier(
+            self.score_record_id,
+            "standards_result.score_record_id",
+        )
+        _identifier(self.standard_id, "standards_result.standard_id")
+
+
+@dataclass(frozen=True, slots=True)
+class PrivacyProjection:
+    classification: str
+    audience_references: tuple[SubjectReferenceProjection, ...]
+    policy_reference: RecordReferenceProjection | None
+    inherited_from: RecordReferenceProjection | None
+
+    def __post_init__(self) -> None:
+        classification = _controlled(
+            self.classification,
+            "privacy.classification",
+            _PRIVACY_CLASSIFICATIONS,
+        )
+        audiences = tuple(self.audience_references)
+        if any(
+            not isinstance(subject, SubjectReferenceProjection)
+            for subject in audiences
+        ):
+            _fail("privacy.audience_references is invalid.")
+        if len(set(audiences)) != len(audiences):
+            _fail("privacy.audience_references must not contain duplicates.")
+        object.__setattr__(
+            self,
+            "audience_references",
+            tuple(
+                sorted(
+                    audiences,
+                    key=lambda item: (
+                        item.subject_kind,
+                        item.owning_system,
+                        item.subject_id,
+                        item.contract_version or "",
+                    ),
+                )
+            ),
+        )
+        if self.policy_reference is not None and not isinstance(
+            self.policy_reference, RecordReferenceProjection
+        ):
+            _fail("privacy.policy_reference is invalid.")
+        if self.inherited_from is not None and not isinstance(
+            self.inherited_from, RecordReferenceProjection
+        ):
+            _fail("privacy.inherited_from is invalid.")
+        if classification == "inherited" and self.inherited_from is None:
+            _fail("inherited privacy requires inherited_from.")
+        if (
+            classification == "external_policy"
+            and self.policy_reference is None
+        ):
+            _fail("external_policy privacy requires policy_reference.")
+        if classification not in {"inherited", "external_policy"} and (
+            self.policy_reference is not None
+            or self.inherited_from is not None
+        ):
+            _fail(
+                "direct privacy classifications cannot carry resolution "
+                "references."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultManifest:
+    record_type: str
+    contract_version: str
+    producer_module_id: str
+    generated_at: datetime
+    record_set: ManifestRecordSet
+    work: ModuleWorkRef
+    source_activity: ModuleRecordRef
+    projection: ManifestProjection
+    activity_context: ActivityContextProjection
+    criterion_sets: tuple[CriterionSetProjection, ...]
+    criteria: tuple[CriterionProjection, ...]
+    scoring_scales: tuple[ScoringScaleProjection, ...]
+    scores: tuple[ScoreProjection, ...]
+    score_evidence_links: tuple[ScoreEvidenceLinkProjection, ...]
+    moderation_records: tuple[ModerationProjection, ...]
+    standards_result_projection: tuple[StandardsResultProjection, ...]
+    privacy: PrivacyProjection
+
+    def __post_init__(self) -> None:
+        if self.record_type != ACADEMIC_RESULT_MANIFEST_RECORD_TYPE:
+            _fail(
+                'record_type must be exactly '
+                '"concord_academic_result_manifest".'
+            )
+        if self.contract_version != ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION:
+            _fail(
+                'contract_version must be exactly '
+                '"concord_academic_result_manifest_v1".'
+            )
+        if self.producer_module_id != CONCORD_MODULE_ID:
+            _fail('producer_module_id must be exactly "concord".')
+        _timestamp(self.generated_at, "generated_at")
+        if not isinstance(self.record_set, ManifestRecordSet):
+            _fail("record_set is invalid.")
+        if not isinstance(self.work, ModuleWorkRef):
+            _fail("work must be a ModuleWorkRef.")
+        if not isinstance(self.source_activity, ModuleRecordRef):
+            _fail("source_activity must be a ModuleRecordRef.")
+        if not isinstance(self.projection, ManifestProjection):
+            _fail("projection is invalid.")
+        if not isinstance(
+            self.activity_context, ActivityContextProjection
+        ):
+            _fail("activity_context is invalid.")
+        if not isinstance(self.privacy, PrivacyProjection):
+            _fail("privacy is invalid.")
+        _require_projection_tuple(
+            self.criterion_sets,
+            CriterionSetProjection,
+            "criterion_sets",
+        )
+        _require_projection_tuple(
+            self.criteria, CriterionProjection, "criteria"
+        )
+        _require_projection_tuple(
+            self.scoring_scales,
+            ScoringScaleProjection,
+            "scoring_scales",
+        )
+        _require_projection_tuple(
+            self.scores, ScoreProjection, "scores"
+        )
+        _require_projection_tuple(
+            self.score_evidence_links,
+            ScoreEvidenceLinkProjection,
+            "score_evidence_links",
+        )
+        _require_projection_tuple(
+            self.moderation_records,
+            ModerationProjection,
+            "moderation_records",
+        )
+        _require_projection_tuple(
+            self.standards_result_projection,
+            StandardsResultProjection,
+            "standards_result_projection",
+        )
+
+
+def _require_projection_tuple(
+    values: Sequence[object],
+    expected: type[object],
+    field: str,
+) -> None:
+    if isinstance(values, (str, bytes, bytearray)):
+        _fail(f"{field} must be an array.")
+    if any(not isinstance(item, expected) for item in values):
+        _fail(f"{field} contains an invalid value.")
+
+
+def _criterion_set_sort_key(
+    value: CriterionSetProjection,
+) -> tuple[str, int, str]:
+    return (value.lineage_id, value.revision, value.criterion_set_id)
+
+
+def _scale_sort_key(
+    value: ScoringScaleProjection,
+) -> tuple[str, int, str]:
+    return (value.lineage_id, value.revision, value.scoring_scale_id)
+
+
+def _subject_sort_key(
+    value: SubjectReferenceProjection,
+) -> tuple[str, str, str, str]:
+    return (
+        value.subject_kind,
+        value.owning_system,
+        value.subject_id,
+        value.contract_version or "",
+    )
+
+
+def _validate_unique_ids(
+    values: Sequence[object],
+    attribute: str,
+    field: str,
+) -> None:
+    ids = tuple(cast(str, getattr(item, attribute)) for item in values)
+    if len(ids) != len(set(ids)):
+        _fail(f"{field} must not contain duplicate identities.")
+
+
+def _validate_supersession_state(
+    values: Sequence[object],
+    *,
+    id_attribute: str,
+    predecessor_attribute: str,
+    current_attribute: str,
+    field: str,
+) -> None:
+    ids = {
+        cast(str, getattr(item, id_attribute))
+        for item in values
+    }
+    predecessor_ids: list[str] = []
+    successor_count: dict[str, int] = {}
+    for item in values:
+        item_id = cast(str, getattr(item, id_attribute))
+        predecessor = cast(
+            str | None, getattr(item, predecessor_attribute)
+        )
+        if predecessor is None:
+            continue
+        if predecessor == item_id:
+            _fail(f"{field} supersession cannot self-reference.")
+        if predecessor not in ids:
+            _fail(f"{field} supersession predecessor is missing.")
+        predecessor_ids.append(predecessor)
+        successor_count[predecessor] = successor_count.get(predecessor, 0) + 1
+    if any(count > 1 for count in successor_count.values()):
+        _fail(f"{field} supersession cannot branch.")
+
+    predecessor_set = set(predecessor_ids)
+    for item in values:
+        item_id = cast(str, getattr(item, id_attribute))
+        expected = "superseded" if item_id in predecessor_set else "current"
+        if getattr(item, current_attribute) != expected:
+            _fail(
+                f"{field} current_state disagrees with explicit supersession."
+            )
+
+    predecessor_of = {
+        cast(str, getattr(item, id_attribute)): cast(
+            str | None, getattr(item, predecessor_attribute)
+        )
+        for item in values
+    }
+    for start in ids:
+        seen: set[str] = set()
+        cursor: str | None = start
+        while cursor is not None:
+            if cursor in seen:
+                _fail(f"{field} supersession contains a cycle.")
+            seen.add(cursor)
+            cursor = predecessor_of.get(cursor)
+
+
+def validate_academic_result_manifest(
+    value: AcademicResultManifest,
+) -> AcademicResultManifest:
+    """Validate all cross-record and digest invariants for one v1 manifest."""
+    if not isinstance(value, AcademicResultManifest):
+        raise ConcordAcademicResultManifestValidationError(
+            "manifest must be an AcademicResultManifest."
+        )
+    manifest = value
+
+    if manifest.work.module_id != CONCORD_MODULE_ID:
+        _fail('manifest work.module_id must be exactly "concord".')
+    expected_source = ModuleRecordRef(
+        module_id=CONCORD_MODULE_ID,
+        record_kind=CONCORD_ACTIVITY_RECORD_KIND,
+        record_id=manifest.work.work_id,
+        contract_version=CONCORD_ACTIVITY_CONTRACT_VERSION,
+    )
+    if manifest.source_activity != expected_source:
+        _fail(
+            "source_activity must identify the exact versioned Concord Activity."
+        )
+    if (
+        manifest.activity_context.activity_id != manifest.work.work_id
+        or manifest.activity_context.class_id != manifest.work.class_id
+    ):
+        _fail("activity_context identity must agree with manifest work.")
+    if manifest.activity_context.scoring_orientation == "evidence_only":
+        _fail("evidence_only Activity cannot produce academic results.")
+    if not manifest.scores:
+        _fail("academic-result manifest requires at least one Score.")
+
+    if tuple(sorted(manifest.criterion_sets, key=_criterion_set_sort_key)) != (
+        manifest.criterion_sets
+    ):
+        _fail("criterion_sets must use canonical lineage/revision/id order.")
+    if tuple(sorted(manifest.scoring_scales, key=_scale_sort_key)) != (
+        manifest.scoring_scales
+    ):
+        _fail("scoring_scales must use canonical lineage/revision/id order.")
+    if tuple(sorted(manifest.scores, key=lambda item: item.score_record_id)) != (
+        manifest.scores
+    ):
+        _fail("scores must be ordered by score_record_id.")
+    if tuple(
+        sorted(
+            manifest.score_evidence_links,
+            key=lambda item: (
+                item.score_record_id,
+                item.score_evidence_link_id,
+            ),
+        )
+    ) != manifest.score_evidence_links:
+        _fail(
+            "score_evidence_links must be ordered by "
+            "score_record_id/link_id."
+        )
+    if tuple(
+        sorted(
+            manifest.moderation_records,
+            key=lambda item: item.moderation_record_id,
+        )
+    ) != manifest.moderation_records:
+        _fail("moderation_records must be ordered by moderation_record_id.")
+    if tuple(
+        sorted(
+            manifest.standards_result_projection,
+            key=lambda item: item.score_record_id,
+        )
+    ) != manifest.standards_result_projection:
+        _fail(
+            "standards_result_projection must be ordered by score_record_id."
+        )
+
+    _validate_unique_ids(
+        manifest.criterion_sets,
+        "criterion_set_id",
+        "criterion_sets",
+    )
+    _validate_unique_ids(manifest.criteria, "criterion_id", "criteria")
+    _validate_unique_ids(
+        manifest.scoring_scales,
+        "scoring_scale_id",
+        "scoring_scales",
+    )
+    _validate_unique_ids(manifest.scores, "score_record_id", "scores")
+    _validate_unique_ids(
+        manifest.score_evidence_links,
+        "score_evidence_link_id",
+        "score_evidence_links",
+    )
+    _validate_unique_ids(
+        manifest.moderation_records,
+        "moderation_record_id",
+        "moderation_records",
+    )
+
+    set_by_id = {
+        item.criterion_set_id: item for item in manifest.criterion_sets
+    }
+    criterion_by_id = {
+        item.criterion_id: item for item in manifest.criteria
+    }
+    scale_by_id = {
+        item.scoring_scale_id: item for item in manifest.scoring_scales
+    }
+    score_by_id = {
+        item.score_record_id: item for item in manifest.scores
+    }
+    moderation_by_id = {
+        item.moderation_record_id: item
+        for item in manifest.moderation_records
+    }
+
+    expected_criterion_order: list[str] = []
+    for criterion_set in manifest.criterion_sets:
+        expected_criterion_order.extend(criterion_set.criterion_ids)
+        for criterion_id in criterion_set.criterion_ids:
+            criterion = criterion_by_id.get(criterion_id)
+            if criterion is None:
+                _fail("Criterion Set references a missing Criterion.")
+            if criterion.criterion_set_id != criterion_set.criterion_set_id:
+                _fail("Criterion parent Set identity is inconsistent.")
+        if (
+            criterion_set.criterion_set_kind == "standard_backed"
+            and any(
+                criterion_by_id[item].criterion_kind != "standard_backed"
+                for item in criterion_set.criterion_ids
+            )
+        ):
+            _fail("standard-backed Set contains a local Criterion.")
+        if (
+            criterion_set.criterion_set_kind == "local"
+            and any(
+                criterion_by_id[item].criterion_kind != "local"
+                for item in criterion_set.criterion_ids
+            )
+        ):
+            _fail("local Set contains a standard-backed Criterion.")
+    if tuple(expected_criterion_order) != tuple(
+        item.criterion_id for item in manifest.criteria
+    ):
+        _fail(
+            "criteria must follow projected Set order and declared member order."
+        )
+
+    required_set_ids = set(manifest.activity_context.criterion_set_ids)
+    used_scale_ids: set[str] = set()
+    for score in manifest.scores:
+        if score.activity_id != manifest.work.work_id:
+            _fail("Score activity_id must match manifest work.")
+        criterion = criterion_by_id.get(score.criterion_id)
+        if criterion is None:
+            _fail("Score references a missing Criterion.")
+        required_set_ids.add(criterion.criterion_set_id)
+        if criterion.criterion_set_id not in set_by_id:
+            _fail("Score Criterion belongs to a missing Criterion Set.")
+        if (
+            score.target_reference.target_kind
+            not in criterion.supported_target_kinds
+        ):
+            _fail("Score target is not supported by its Criterion.")
+        if score.score_kind != criterion.criterion_kind:
+            _fail("Score kind must match Criterion kind.")
+        if score.score_kind == "standard_backed":
+            if (
+                score.standard_id != criterion.standard_id
+                or score.standard_id
+                not in manifest.activity_context.focus_standard_ids
+            ):
+                _fail(
+                    "standard-backed Score must use its governing Focus Standard."
+                )
+            if manifest.activity_context.scoring_orientation not in {
+                "standards_based",
+                "mixed",
+            }:
+                _fail(
+                    "standard-backed Score is incompatible with Activity "
+                    "orientation."
+                )
+        else:
+            if manifest.activity_context.scoring_orientation not in {
+                "local_criteria_only",
+                "mixed",
+            }:
+                _fail(
+                    "local Score is incompatible with Activity orientation."
+                )
+        scale = scale_by_id.get(score.scoring_scale_id)
+        if scale is None:
+            _fail("Score references a missing Scoring Scale.")
+        used_scale_ids.add(score.scoring_scale_id)
+        if score.disposition == "scored":
+            if score.value is None or not scale.has_value(score.value):
+                _fail("Score value is not an exact Scale level.")
+
+    if set(set_by_id) != required_set_ids:
+        _fail(
+            "criterion_sets must contain exactly selected and Score-required "
+            "Set revisions."
+        )
+    if set(scale_by_id) != used_scale_ids:
+        _fail(
+            "scoring_scales must contain exactly the Scale revisions used by "
+            "Scores."
+        )
+
+    _validate_supersession_state(
+        manifest.scores,
+        id_attribute="score_record_id",
+        predecessor_attribute="supersedes_score_record_id",
+        current_attribute="current_state",
+        field="Score",
+    )
+    score_by_identity = {
+        score.score_record_id: score for score in manifest.scores
+    }
+    for score in manifest.scores:
+        predecessor_id = score.supersedes_score_record_id
+        if predecessor_id is not None:
+            score_predecessor = score_by_identity[predecessor_id]
+            if score.scored_at < score_predecessor.scored_at:
+                _fail("Score successor scored_at must not move backward.")
+    _validate_supersession_state(
+        manifest.moderation_records,
+        id_attribute="moderation_record_id",
+        predecessor_attribute="supersedes_moderation_record_id",
+        current_attribute="current_state",
+        field="Moderation",
+    )
+
+    link_ids = {
+        item.score_evidence_link_id
+        for item in manifest.score_evidence_links
+    }
+    link_successors: dict[str, int] = {}
+    for link in manifest.score_evidence_links:
+        if link.score_record_id not in score_by_id:
+            _fail("Score Evidence Link references a missing Score.")
+        link_predecessor_id = link.supersedes_score_evidence_link_id
+        if link_predecessor_id is not None:
+            if link_predecessor_id == link.score_evidence_link_id:
+                _fail("Score Evidence Link cannot supersede itself.")
+            if link_predecessor_id not in link_ids:
+                _fail(
+                    "Score Evidence Link supersession predecessor is missing."
+                )
+            link_successors[link_predecessor_id] = (
+                link_successors.get(link_predecessor_id, 0) + 1
+            )
+        if link.moderation_record_id is not None:
+            moderation = moderation_by_id.get(link.moderation_record_id)
+            if moderation is None:
+                _fail(
+                    "Score Evidence Link references a missing Moderation Record."
+                )
+            if (
+                moderation.target_evidence_reference
+                != link.evidence_reference
+            ):
+                _fail(
+                    "Moderation target evidence must equal the linked evidence."
+                )
+    if any(count > 1 for count in link_successors.values()):
+        _fail("Score Evidence Link supersession cannot branch.")
+
+    link_predecessor_of = {
+        item.score_evidence_link_id: item.supersedes_score_evidence_link_id
+        for item in manifest.score_evidence_links
+    }
+    for start in link_ids:
+        seen: set[str] = set()
+        cursor: str | None = start
+        while cursor is not None:
+            if cursor in seen:
+                _fail("Score Evidence Link supersession contains a cycle.")
+            seen.add(cursor)
+            cursor = link_predecessor_of.get(cursor)
+
+    link_by_id = {
+        item.score_evidence_link_id: item
+        for item in manifest.score_evidence_links
+    }
+    for link in manifest.score_evidence_links:
+        predecessor_id = link.supersedes_score_evidence_link_id
+        if predecessor_id is not None:
+            predecessor_link = link_by_id[predecessor_id]
+            if predecessor_link.score_record_id != link.score_record_id:
+                _fail(
+                    "Score Evidence Link successor must keep its Score parent."
+                )
+
+    superseded_link_ids = set(link_successors)
+    for score in manifest.scores:
+        active_links = tuple(
+            link
+            for link in manifest.score_evidence_links
+            if (
+                link.score_record_id == score.score_record_id
+                and link.status == "active"
+                and link.score_evidence_link_id not in superseded_link_ids
+            )
+        )
+        if score.basis == "linked_evidence" and not active_links:
+            _fail("linked_evidence Score requires an active Evidence Link.")
+        if score.basis == "professional_judgment" and active_links:
+            _fail(
+                "professional_judgment Score must not have active Evidence Links."
+            )
+        if score.basis == "mixed_basis" and not active_links:
+            _fail("mixed_basis Score requires an active Evidence Link.")
+
+    standard_scores = {
+        score.score_record_id: score
+        for score in manifest.scores
+        if score.score_kind == "standard_backed"
+    }
+    standard_rows = {
+        row.score_record_id: row
+        for row in manifest.standards_result_projection
+    }
+    if len(standard_rows) != len(manifest.standards_result_projection):
+        _fail(
+            "standards_result_projection must not contain duplicate Scores."
+        )
+    if set(standard_rows) != set(standard_scores):
+        _fail(
+            "standards_result_projection must contain exactly the "
+            "standard-backed Scores."
+        )
+    for score_id, row in standard_rows.items():
+        score = standard_scores[score_id]
+        if row.standard_id != score.standard_id:
+            _fail(
+                "standards result standard must equal the Score governing "
+                "standard."
+            )
+
+    expected_digest = calculate_semantic_projection_digest(manifest)
+    if manifest.projection.projection_digest != expected_digest:
+        _fail("projection_digest does not match the semantic public projection.")
+
+    return manifest
+
+
+def derive_manifest_capabilities(
+    manifest: AcademicResultManifest,
+) -> tuple[PublicationCapability, ...]:
+    """Derive only the exact shared Core capabilities present in the manifest."""
+    validate_academic_result_manifest(manifest)
+    capabilities: list[PublicationCapability] = ["criterion_scores"]
+    if any(score.score_kind == "standard_backed" for score in manifest.scores):
+        capabilities.append("standards_ratings")
+    score_by_id = {
+        score.score_record_id: score for score in manifest.scores
+    }
+    if any(
+        link.moderation_record_id is not None
+        and score_by_id[link.score_record_id].disposition == "scored"
+        for link in manifest.score_evidence_links
+    ):
+        capabilities.append("moderated_scores")
+    return tuple(capabilities)
+
+
+def _actor_to_dict(value: PublicActor) -> dict[str, object]:
+    return {
+        "actor_kind": value.actor_kind,
+        "actor_id": value.actor_id,
+        "owning_system": value.owning_system,
+    }
+
+
+def _subject_to_dict(
+    value: SubjectReferenceProjection,
+) -> dict[str, object]:
+    return {
+        "subject_kind": value.subject_kind,
+        "subject_id": value.subject_id,
+        "owning_system": value.owning_system,
+        "contract_version": value.contract_version,
+    }
+
+
+def _record_reference_to_dict(
+    value: RecordReferenceProjection,
+) -> dict[str, object]:
+    return {
+        "module_id": value.module_id,
+        "record_kind": value.record_kind,
+        "record_id": value.record_id,
+        "contract_version": value.contract_version,
+    }
+
+
+def _publication_reference_to_dict(
+    value: CorePublicationReferenceProjection,
+) -> dict[str, object]:
+    return {
+        "publication_id": value.publication_id,
+        "publication_schema_version": value.publication_schema_version,
+    }
+
+
+def _locator_to_dict(
+    value: EvidenceLocatorProjection,
+) -> dict[str, object]:
+    return {
+        "page_number": value.page_number,
+        "source_page_index": value.source_page_index,
+        "section_label": value.section_label,
+        "row_label": value.row_label,
+        "column_label": value.column_label,
+        "participant_label": value.participant_label,
+        "session_id": value.session_id,
+    }
+
+
+def _evidence_reference_to_dict(
+    value: EvidenceReferenceProjection,
+) -> dict[str, object]:
+    return {
+        "evidence_kind": value.evidence_kind,
+        "owning_system": value.owning_system,
+        "record_id": value.record_id,
+        "contract_version": value.contract_version,
+        "source_publication_reference": (
+            _publication_reference_to_dict(
+                value.source_publication_reference
+            )
+            if value.source_publication_reference is not None
+            else None
+        ),
+        "immutable_source_version": value.immutable_source_version,
+        "locator": (
+            _locator_to_dict(value.locator)
+            if value.locator is not None
+            else None
+        ),
+        "subject_context": [
+            _subject_to_dict(subject) for subject in value.subject_context
+        ],
+        "moderation_requirement": value.moderation_requirement,
+    }
+
+
+def _moderation_to_dict(
+    value: ModerationProjection,
+) -> dict[str, object]:
+    result: dict[str, object] = {
+        "moderation_record_id": value.moderation_record_id,
+        "target_evidence_reference": _evidence_reference_to_dict(
+            value.target_evidence_reference
+        ),
+        "target_subject_references": [
+            _subject_to_dict(subject)
+            for subject in value.target_subject_references
+        ],
+        "status": value.status,
+        "permitted_use": value.permitted_use,
+        "supersedes_moderation_record_id": (
+            value.supersedes_moderation_record_id
+        ),
+        "current_state": value.current_state,
+    }
+    if value.qualification is not None:
+        result["qualification"] = value.qualification
+    return result
+
+
+def _score_to_dict(value: ScoreProjection) -> dict[str, object]:
+    result: dict[str, object] = {
+        "score_record_id": value.score_record_id,
+        "activity_id": value.activity_id,
+        "session_id": value.session_id,
+        "target_reference": {
+            "target_kind": value.target_reference.target_kind,
+            "target_id": value.target_reference.target_id,
+            "owning_system": value.target_reference.owning_system,
+            "contract_version": value.target_reference.contract_version,
+        },
+        "criterion_id": value.criterion_id,
+        "score_kind": value.score_kind,
+        "standard_id": value.standard_id,
+        "scoring_scale_id": value.scoring_scale_id,
+        "disposition": value.disposition,
+        "basis": value.basis,
+        "scorer": _actor_to_dict(value.scorer),
+        "scored_at": _timestamp_to_json(value.scored_at),
+        "moderation_complete": value.moderation_complete,
+        "supersedes_score_record_id": value.supersedes_score_record_id,
+        "current_state": value.current_state,
+    }
+    if value.disposition == "scored":
+        result["value"] = value.value
+    else:
+        reason = value.status_reason
+        if reason is None:
+            _fail("published non-score Score requires status_reason.")
+        result["status_reason"] = {
+            "reason_code": reason.reason_code,
+            "recorded_by": _actor_to_dict(reason.recorded_by),
+            "recorded_at": _timestamp_to_json(reason.recorded_at),
+            "related_record": (
+                _record_reference_to_dict(reason.related_record)
+                if reason.related_record is not None
+                else None
+            ),
+        }
+    return result
+
+
+def academic_result_manifest_to_dict(
+    value: AcademicResultManifest,
+) -> dict[str, object]:
+    """Convert one fully validated manifest to its exact JSON-native shape."""
+    manifest = validate_academic_result_manifest(value)
+    return _manifest_to_dict_unvalidated(manifest)
+
+
+def _manifest_to_dict_unvalidated(
+    manifest: AcademicResultManifest,
+) -> dict[str, object]:
+    return {
+        "record_type": manifest.record_type,
+        "contract_version": manifest.contract_version,
+        "producer_module_id": manifest.producer_module_id,
+        "generated_at": _timestamp_to_json(manifest.generated_at),
+        "record_set": {
+            "record_set_id": manifest.record_set.record_set_id,
+            "revision": manifest.record_set.revision,
+        },
+        "work": module_work_ref_to_dict(manifest.work),
+        "source_activity": module_record_ref_to_dict(
+            manifest.source_activity
+        ),
+        "projection": {
+            "source_snapshot_revision": (
+                manifest.projection.source_snapshot_revision
+            ),
+            "projection_digest_algorithm": (
+                manifest.projection.projection_digest_algorithm
+            ),
+            "projection_digest": manifest.projection.projection_digest,
+            "generated_by": _actor_to_dict(
+                manifest.projection.generated_by
+            ),
+            "revision_reason": manifest.projection.revision_reason,
+        },
+        "activity_context": {
+            "activity_id": manifest.activity_context.activity_id,
+            "class_id": manifest.activity_context.class_id,
+            "title": manifest.activity_context.title,
+            "scoring_orientation": (
+                manifest.activity_context.scoring_orientation
+            ),
+            "standards_profile_id": (
+                manifest.activity_context.standards_profile_id
+            ),
+            "focus_standard_ids": list(
+                manifest.activity_context.focus_standard_ids
+            ),
+            "criterion_set_ids": list(
+                manifest.activity_context.criterion_set_ids
+            ),
+        },
+        "criterion_sets": [
+            {
+                "criterion_set_id": item.criterion_set_id,
+                "lineage_id": item.lineage_id,
+                "revision": item.revision,
+                "criterion_set_kind": item.criterion_set_kind,
+                "scope": item.scope,
+                "criterion_ids": list(item.criterion_ids),
+                "status": item.status,
+                "supersedes_criterion_set_id": (
+                    item.supersedes_criterion_set_id
+                ),
+                "standards_profile_id": item.standards_profile_id,
+            }
+            for item in manifest.criterion_sets
+        ],
+        "criteria": [
+            {
+                "criterion_id": item.criterion_id,
+                "criterion_set_id": item.criterion_set_id,
+                "key": item.key,
+                "label": item.label,
+                "definition": item.definition,
+                "criterion_kind": item.criterion_kind,
+                "supported_target_kinds": list(
+                    item.supported_target_kinds
+                ),
+                "status": item.status,
+                "standard_id": item.standard_id,
+                "alignment_standard_ids": list(
+                    item.alignment_standard_ids
+                ),
+                "default_scoring_scale_id": (
+                    item.default_scoring_scale_id
+                ),
+            }
+            for item in manifest.criteria
+        ],
+        "scoring_scales": [
+            {
+                "scoring_scale_id": item.scoring_scale_id,
+                "lineage_id": item.lineage_id,
+                "name": item.name,
+                "revision": item.revision,
+                "scale_type": item.scale_type,
+                "levels": [
+                    {
+                        "value": level.value,
+                        "label": level.label,
+                        "meaning": level.meaning,
+                        "position": level.position,
+                        "description": level.description,
+                    }
+                    for level in item.levels
+                ],
+                "status": item.status,
+                "supersedes_scoring_scale_id": (
+                    item.supersedes_scoring_scale_id
+                ),
+            }
+            for item in manifest.scoring_scales
+        ],
+        "scores": [_score_to_dict(item) for item in manifest.scores],
+        "score_evidence_links": [
+            {
+                "score_evidence_link_id": item.score_evidence_link_id,
+                "score_record_id": item.score_record_id,
+                "evidence_reference": _evidence_reference_to_dict(
+                    item.evidence_reference
+                ),
+                "evidence_locator": (
+                    _locator_to_dict(item.evidence_locator)
+                    if item.evidence_locator is not None
+                    else None
+                ),
+                "subject_context": [
+                    _subject_to_dict(subject)
+                    for subject in item.subject_context
+                ],
+                "relevance_description": item.relevance_description,
+                "significance": item.significance,
+                "moderation_record_id": item.moderation_record_id,
+                "status": item.status,
+                "supersedes_score_evidence_link_id": (
+                    item.supersedes_score_evidence_link_id
+                ),
+            }
+            for item in manifest.score_evidence_links
+        ],
+        "moderation_records": [
+            _moderation_to_dict(item)
+            for item in manifest.moderation_records
+        ],
+        "standards_result_projection": [
+            {
+                "score_record_id": item.score_record_id,
+                "standard_id": item.standard_id,
+            }
+            for item in manifest.standards_result_projection
+        ],
+        "privacy": {
+            "classification": manifest.privacy.classification,
+            "audience_references": [
+                _subject_to_dict(subject)
+                for subject in manifest.privacy.audience_references
+            ],
+            "policy_reference": (
+                _record_reference_to_dict(
+                    manifest.privacy.policy_reference
+                )
+                if manifest.privacy.policy_reference is not None
+                else None
+            ),
+            "inherited_from": (
+                _record_reference_to_dict(manifest.privacy.inherited_from)
+                if manifest.privacy.inherited_from is not None
+                else None
+            ),
+        },
+    }
+
+
+def _semantic_projection_dict(
+    manifest: AcademicResultManifest,
+) -> dict[str, object]:
+    data = _manifest_to_dict_unvalidated(manifest)
+    data.pop("generated_at")
+    projection = cast(dict[str, object], data.pop("projection"))
+    del projection
+    record_set = cast(dict[str, object], data["record_set"])
+    data["record_set"] = {
+        "record_set_id": record_set["record_set_id"],
+    }
+    return data
+
+
+def _canonical_json_bytes(value: object) -> bytes:
+    try:
+        text = json.dumps(
+            value,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    except (TypeError, ValueError) as error:
+        raise ConcordAcademicResultManifestValidationError(
+            "manifest contains a non-canonical JSON value."
+        ) from error
+    return (text + "\n").encode("utf-8")
+
+
+def calculate_semantic_projection_digest(
+    manifest: AcademicResultManifest,
+) -> str:
+    """Hash only the semantic public projection, excluding revision envelope."""
+    if not isinstance(manifest, AcademicResultManifest):
+        raise ConcordAcademicResultManifestValidationError(
+            "manifest must be an AcademicResultManifest."
+        )
+    return hashlib.sha256(
+        _canonical_json_bytes(_semantic_projection_dict(manifest))
+    ).hexdigest()
+
+
+def with_semantic_projection_digest(
+    manifest: AcademicResultManifest,
+) -> AcademicResultManifest:
+    """Return a validated copy carrying its calculated semantic digest."""
+    if not isinstance(manifest, AcademicResultManifest):
+        raise ConcordAcademicResultManifestValidationError(
+            "manifest must be an AcademicResultManifest."
+        )
+    digest = calculate_semantic_projection_digest(manifest)
+    candidate = replace(
+        manifest,
+        projection=replace(
+            manifest.projection,
+            projection_digest=digest,
+        ),
+    )
+    return validate_academic_result_manifest(candidate)
+
+
+def academic_result_manifest_to_bytes(
+    value: AcademicResultManifest,
+) -> bytes:
+    """Return canonical UTF-8 JSON with exactly one final LF."""
+    return _canonical_json_bytes(academic_result_manifest_to_dict(value))
+
+
+class _DuplicateJsonKeyError(ValueError):
+    pass
+
+
+class _InvalidJsonConstantError(ValueError):
+    pass
+
+
+def _reject_duplicate_pairs(
+    pairs: list[tuple[str, object]],
+) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKeyError(key)
+        result[key] = value
+    return result
+
+
+def _reject_constant(value: str) -> NoReturn:
+    raise _InvalidJsonConstantError(value)
+
+
+def academic_result_manifest_from_bytes(
+    data: bytes,
+) -> AcademicResultManifest:
+    """Decode strict UTF-8 canonical-shape JSON and validate the whole manifest."""
+    if not isinstance(data, bytes):
+        raise ConcordAcademicResultManifestDecodeError(
+            "manifest data must be bytes."
+        )
+    if data.startswith(b"\xef\xbb\xbf"):
+        raise ConcordAcademicResultManifestDecodeError(
+            "manifest must not contain a UTF-8 BOM."
+        )
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise ConcordAcademicResultManifestDecodeError(
+            "manifest must be valid UTF-8."
+        ) from error
+    if not text.endswith("\n") or text.endswith("\n\n"):
+        raise ConcordAcademicResultManifestDecodeError(
+            "manifest must end with exactly one LF."
+        )
+    try:
+        raw = json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_pairs,
+            parse_constant=_reject_constant,
+        )
+    except (
+        json.JSONDecodeError,
+        _DuplicateJsonKeyError,
+        _InvalidJsonConstantError,
+    ) as error:
+        raise ConcordAcademicResultManifestDecodeError(
+            "manifest JSON is invalid."
+        ) from error
+    manifest = academic_result_manifest_from_dict(raw)
+    if academic_result_manifest_to_bytes(manifest) != data:
+        raise ConcordAcademicResultManifestDecodeError(
+            "manifest JSON is not canonical."
+        )
+    return manifest
+
+
+def academic_result_manifest_from_dict(
+    data: object,
+) -> AcademicResultManifest:
+    """Parse an exact JSON-native v1 mapping and validate the whole manifest."""
+    mapping = _exact_mapping(data, _TOP_LEVEL_KEYS, "manifest")
+    manifest = AcademicResultManifest(
+        record_type=_required_str(mapping["record_type"], "record_type"),
+        contract_version=_required_str(
+            mapping["contract_version"], "contract_version"
+        ),
+        producer_module_id=_required_str(
+            mapping["producer_module_id"], "producer_module_id"
+        ),
+        generated_at=_timestamp_from_json(
+            mapping["generated_at"], "generated_at"
+        ),
+        record_set=_record_set_from_dict(mapping["record_set"]),
+        work=_module_work(mapping["work"], "work"),
+        source_activity=_module_record(
+            mapping["source_activity"], "source_activity"
+        ),
+        projection=_projection_from_dict(mapping["projection"]),
+        activity_context=_activity_context_from_dict(
+            mapping["activity_context"]
+        ),
+        criterion_sets=tuple(
+            _criterion_set_from_dict(item)
+            for item in _array(mapping["criterion_sets"], "criterion_sets")
+        ),
+        criteria=tuple(
+            _criterion_from_dict(item)
+            for item in _array(mapping["criteria"], "criteria")
+        ),
+        scoring_scales=tuple(
+            _scale_from_dict(item)
+            for item in _array(
+                mapping["scoring_scales"], "scoring_scales"
+            )
+        ),
+        scores=tuple(
+            _score_from_dict(item)
+            for item in _array(mapping["scores"], "scores")
+        ),
+        score_evidence_links=tuple(
+            _score_link_from_dict(item)
+            for item in _array(
+                mapping["score_evidence_links"],
+                "score_evidence_links",
+            )
+        ),
+        moderation_records=tuple(
+            _moderation_from_dict(item)
+            for item in _array(
+                mapping["moderation_records"], "moderation_records"
+            )
+        ),
+        standards_result_projection=tuple(
+            _standards_result_from_dict(item)
+            for item in _array(
+                mapping["standards_result_projection"],
+                "standards_result_projection",
+            )
+        ),
+        privacy=_privacy_from_dict(mapping["privacy"]),
+    )
+    return validate_academic_result_manifest(manifest)
+
+
+def _required_str(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        _fail(f"{field} must be a string.")
+    return value
+
+
+def _optional_str(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    return _required_str(value, field)
+
+
+def _record_set_from_dict(value: object) -> ManifestRecordSet:
+    mapping = _exact_mapping(
+        value,
+        frozenset({"record_set_id", "revision"}),
+        "record_set",
+    )
+    return ManifestRecordSet(
+        record_set_id=_required_str(
+            mapping["record_set_id"], "record_set.record_set_id"
+        ),
+        revision=_positive_int(
+            mapping["revision"], "record_set.revision"
+        ),
+    )
+
+
+def _actor_from_dict(value: object, field: str) -> PublicActor:
+    mapping = _exact_mapping(
+        value,
+        frozenset({"actor_kind", "actor_id", "owning_system"}),
+        field,
+    )
+    return PublicActor(
+        actor_kind=_required_str(
+            mapping["actor_kind"], f"{field}.actor_kind"
+        ),
+        actor_id=_required_str(mapping["actor_id"], f"{field}.actor_id"),
+        owning_system=_required_str(
+            mapping["owning_system"], f"{field}.owning_system"
+        ),
+    )
+
+
+def _projection_from_dict(value: object) -> ManifestProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {
+                "source_snapshot_revision",
+                "projection_digest_algorithm",
+                "projection_digest",
+                "generated_by",
+                "revision_reason",
+            }
+        ),
+        "projection",
+    )
+    return ManifestProjection(
+        source_snapshot_revision=_positive_int(
+            mapping["source_snapshot_revision"],
+            "projection.source_snapshot_revision",
+        ),
+        projection_digest_algorithm=_required_str(
+            mapping["projection_digest_algorithm"],
+            "projection.projection_digest_algorithm",
+        ),
+        projection_digest=_required_str(
+            mapping["projection_digest"],
+            "projection.projection_digest",
+        ),
+        generated_by=_actor_from_dict(
+            mapping["generated_by"], "projection.generated_by"
+        ),
+        revision_reason=cast(
+            RevisionReason,
+            _required_str(
+                mapping["revision_reason"],
+                "projection.revision_reason",
+            ),
+        ),
+    )
+
+
+def _activity_context_from_dict(
+    value: object,
+) -> ActivityContextProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {
+                "activity_id",
+                "class_id",
+                "title",
+                "scoring_orientation",
+                "standards_profile_id",
+                "focus_standard_ids",
+                "criterion_set_ids",
+            }
+        ),
+        "activity_context",
+    )
+    return ActivityContextProjection(
+        activity_id=_required_str(
+            mapping["activity_id"], "activity_context.activity_id"
+        ),
+        class_id=_required_str(
+            mapping["class_id"], "activity_context.class_id"
+        ),
+        title=_required_str(
+            mapping["title"], "activity_context.title"
+        ),
+        scoring_orientation=_required_str(
+            mapping["scoring_orientation"],
+            "activity_context.scoring_orientation",
+        ),
+        standards_profile_id=_optional_str(
+            mapping["standards_profile_id"],
+            "activity_context.standards_profile_id",
+        ),
+        focus_standard_ids=tuple(
+            _required_str(
+                item, f"activity_context.focus_standard_ids[{index}]"
+            )
+            for index, item in enumerate(
+                _array(
+                    mapping["focus_standard_ids"],
+                    "activity_context.focus_standard_ids",
+                )
+            )
+        ),
+        criterion_set_ids=tuple(
+            _required_str(
+                item, f"activity_context.criterion_set_ids[{index}]"
+            )
+            for index, item in enumerate(
+                _array(
+                    mapping["criterion_set_ids"],
+                    "activity_context.criterion_set_ids",
+                )
+            )
+        ),
+    )
+
+
+def _criterion_set_from_dict(value: object) -> CriterionSetProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {
+                "criterion_set_id",
+                "lineage_id",
+                "revision",
+                "criterion_set_kind",
+                "scope",
+                "criterion_ids",
+                "status",
+                "supersedes_criterion_set_id",
+                "standards_profile_id",
+            }
+        ),
+        "criterion_set",
+    )
+    return CriterionSetProjection(
+        criterion_set_id=_required_str(
+            mapping["criterion_set_id"], "criterion_set.criterion_set_id"
+        ),
+        lineage_id=_required_str(
+            mapping["lineage_id"], "criterion_set.lineage_id"
+        ),
+        revision=_positive_int(
+            mapping["revision"], "criterion_set.revision"
+        ),
+        criterion_set_kind=_required_str(
+            mapping["criterion_set_kind"],
+            "criterion_set.criterion_set_kind",
+        ),
+        scope=_required_str(mapping["scope"], "criterion_set.scope"),
+        criterion_ids=tuple(
+            _required_str(
+                item, f"criterion_set.criterion_ids[{index}]"
+            )
+            for index, item in enumerate(
+                _array(
+                    mapping["criterion_ids"],
+                    "criterion_set.criterion_ids",
+                )
+            )
+        ),
+        status=_required_str(mapping["status"], "criterion_set.status"),
+        supersedes_criterion_set_id=_optional_str(
+            mapping["supersedes_criterion_set_id"],
+            "criterion_set.supersedes_criterion_set_id",
+        ),
+        standards_profile_id=_optional_str(
+            mapping["standards_profile_id"],
+            "criterion_set.standards_profile_id",
+        ),
+    )
+
+
+def _criterion_from_dict(value: object) -> CriterionProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {
+                "criterion_id",
+                "criterion_set_id",
+                "key",
+                "label",
+                "definition",
+                "criterion_kind",
+                "supported_target_kinds",
+                "status",
+                "standard_id",
+                "alignment_standard_ids",
+                "default_scoring_scale_id",
+            }
+        ),
+        "criterion",
+    )
+    return CriterionProjection(
+        criterion_id=_required_str(
+            mapping["criterion_id"], "criterion.criterion_id"
+        ),
+        criterion_set_id=_required_str(
+            mapping["criterion_set_id"], "criterion.criterion_set_id"
+        ),
+        key=_required_str(mapping["key"], "criterion.key"),
+        label=_required_str(mapping["label"], "criterion.label"),
+        definition=_required_str(
+            mapping["definition"], "criterion.definition"
+        ),
+        criterion_kind=_required_str(
+            mapping["criterion_kind"], "criterion.criterion_kind"
+        ),
+        supported_target_kinds=tuple(
+            _required_str(
+                item, f"criterion.supported_target_kinds[{index}]"
+            )
+            for index, item in enumerate(
+                _array(
+                    mapping["supported_target_kinds"],
+                    "criterion.supported_target_kinds",
+                )
+            )
+        ),
+        status=_required_str(mapping["status"], "criterion.status"),
+        standard_id=_optional_str(
+            mapping["standard_id"], "criterion.standard_id"
+        ),
+        alignment_standard_ids=tuple(
+            _required_str(
+                item, f"criterion.alignment_standard_ids[{index}]"
+            )
+            for index, item in enumerate(
+                _array(
+                    mapping["alignment_standard_ids"],
+                    "criterion.alignment_standard_ids",
+                )
+            )
+        ),
+        default_scoring_scale_id=_optional_str(
+            mapping["default_scoring_scale_id"],
+            "criterion.default_scoring_scale_id",
+        ),
+    )
+
+
+def _scale_level_from_dict(value: object) -> ScaleLevelProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {"value", "label", "meaning", "position", "description"}
+        ),
+        "scale_level",
+    )
+    position_raw = mapping["position"]
+    return ScaleLevelProjection(
+        value=_scalar(mapping["value"], "scale_level.value"),
+        label=_required_str(mapping["label"], "scale_level.label"),
+        meaning=_required_str(mapping["meaning"], "scale_level.meaning"),
+        position=(
+            None
+            if position_raw is None
+            else _positive_int(position_raw, "scale_level.position")
+        ),
+        description=_optional_str(
+            mapping["description"], "scale_level.description"
+        ),
+    )
+
+
+def _scale_from_dict(value: object) -> ScoringScaleProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {
+                "scoring_scale_id",
+                "lineage_id",
+                "name",
+                "revision",
+                "scale_type",
+                "levels",
+                "status",
+                "supersedes_scoring_scale_id",
+            }
+        ),
+        "scoring_scale",
+    )
+    return ScoringScaleProjection(
+        scoring_scale_id=_required_str(
+            mapping["scoring_scale_id"],
+            "scoring_scale.scoring_scale_id",
+        ),
+        lineage_id=_required_str(
+            mapping["lineage_id"], "scoring_scale.lineage_id"
+        ),
+        name=_required_str(mapping["name"], "scoring_scale.name"),
+        revision=_positive_int(
+            mapping["revision"], "scoring_scale.revision"
+        ),
+        scale_type=_required_str(
+            mapping["scale_type"], "scoring_scale.scale_type"
+        ),
+        levels=tuple(
+            _scale_level_from_dict(item)
+            for item in _array(
+                mapping["levels"], "scoring_scale.levels"
+            )
+        ),
+        status=_required_str(mapping["status"], "scoring_scale.status"),
+        supersedes_scoring_scale_id=_optional_str(
+            mapping["supersedes_scoring_scale_id"],
+            "scoring_scale.supersedes_scoring_scale_id",
+        ),
+    )
+
+
+def _target_from_dict(value: object) -> TargetReferenceProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {
+                "target_kind",
+                "target_id",
+                "owning_system",
+                "contract_version",
+            }
+        ),
+        "target_reference",
+    )
+    return TargetReferenceProjection(
+        target_kind=_required_str(
+            mapping["target_kind"], "target_reference.target_kind"
+        ),
+        target_id=_required_str(
+            mapping["target_id"], "target_reference.target_id"
+        ),
+        owning_system=_required_str(
+            mapping["owning_system"],
+            "target_reference.owning_system",
+        ),
+        contract_version=_optional_str(
+            mapping["contract_version"],
+            "target_reference.contract_version",
+        ),
+    )
+
+
+def _subject_from_dict(
+    value: object, field: str
+) -> SubjectReferenceProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {
+                "subject_kind",
+                "subject_id",
+                "owning_system",
+                "contract_version",
+            }
+        ),
+        field,
+    )
+    return SubjectReferenceProjection(
+        subject_kind=_required_str(
+            mapping["subject_kind"], f"{field}.subject_kind"
+        ),
+        subject_id=_required_str(
+            mapping["subject_id"], f"{field}.subject_id"
+        ),
+        owning_system=_required_str(
+            mapping["owning_system"], f"{field}.owning_system"
+        ),
+        contract_version=_optional_str(
+            mapping["contract_version"], f"{field}.contract_version"
+        ),
+    )
+
+
+def _record_reference_from_dict(
+    value: object, field: str
+) -> RecordReferenceProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {
+                "module_id",
+                "record_kind",
+                "record_id",
+                "contract_version",
+            }
+        ),
+        field,
+    )
+    return RecordReferenceProjection(
+        module_id=_required_str(
+            mapping["module_id"], f"{field}.module_id"
+        ),
+        record_kind=_required_str(
+            mapping["record_kind"], f"{field}.record_kind"
+        ),
+        record_id=_required_str(
+            mapping["record_id"], f"{field}.record_id"
+        ),
+        contract_version=_optional_str(
+            mapping["contract_version"], f"{field}.contract_version"
+        ),
+    )
+
+
+def _publication_reference_from_dict(
+    value: object,
+) -> CorePublicationReferenceProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {"publication_id", "publication_schema_version"}
+        ),
+        "publication_reference",
+    )
+    return CorePublicationReferenceProjection(
+        publication_id=_required_str(
+            mapping["publication_id"],
+            "publication_reference.publication_id",
+        ),
+        publication_schema_version=_optional_str(
+            mapping["publication_schema_version"],
+            "publication_reference.publication_schema_version",
+        ),
+    )
+
+
+def _locator_from_dict(
+    value: object, field: str
+) -> EvidenceLocatorProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {
+                "page_number",
+                "source_page_index",
+                "section_label",
+                "row_label",
+                "column_label",
+                "participant_label",
+                "session_id",
+            }
+        ),
+        field,
+    )
+    page = mapping["page_number"]
+    source_page = mapping["source_page_index"]
+    return EvidenceLocatorProjection(
+        page_number=(
+            None
+            if page is None
+            else _positive_int(page, f"{field}.page_number")
+        ),
+        source_page_index=(
+            None
+            if source_page is None
+            else _nonnegative_int(
+                source_page, f"{field}.source_page_index"
+            )
+        ),
+        section_label=_optional_str(
+            mapping["section_label"], f"{field}.section_label"
+        ),
+        row_label=_optional_str(
+            mapping["row_label"], f"{field}.row_label"
+        ),
+        column_label=_optional_str(
+            mapping["column_label"], f"{field}.column_label"
+        ),
+        participant_label=_optional_str(
+            mapping["participant_label"], f"{field}.participant_label"
+        ),
+        session_id=_optional_str(
+            mapping["session_id"], f"{field}.session_id"
+        ),
+    )
+
+
+def _evidence_reference_from_dict(
+    value: object,
+) -> EvidenceReferenceProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {
+                "evidence_kind",
+                "owning_system",
+                "record_id",
+                "contract_version",
+                "source_publication_reference",
+                "immutable_source_version",
+                "locator",
+                "subject_context",
+                "moderation_requirement",
+            }
+        ),
+        "evidence_reference",
+    )
+    publication = mapping["source_publication_reference"]
+    locator = mapping["locator"]
+    return EvidenceReferenceProjection(
+        evidence_kind=_required_str(
+            mapping["evidence_kind"],
+            "evidence_reference.evidence_kind",
+        ),
+        owning_system=_required_str(
+            mapping["owning_system"],
+            "evidence_reference.owning_system",
+        ),
+        record_id=_required_str(
+            mapping["record_id"], "evidence_reference.record_id"
+        ),
+        contract_version=_optional_str(
+            mapping["contract_version"],
+            "evidence_reference.contract_version",
+        ),
+        source_publication_reference=(
+            None
+            if publication is None
+            else _publication_reference_from_dict(publication)
+        ),
+        immutable_source_version=_optional_str(
+            mapping["immutable_source_version"],
+            "evidence_reference.immutable_source_version",
+        ),
+        locator=(
+            None
+            if locator is None
+            else _locator_from_dict(
+                locator, "evidence_reference.locator"
+            )
+        ),
+        subject_context=tuple(
+            _subject_from_dict(
+                item, f"evidence_reference.subject_context[{index}]"
+            )
+            for index, item in enumerate(
+                _array(
+                    mapping["subject_context"],
+                    "evidence_reference.subject_context",
+                )
+            )
+        ),
+        moderation_requirement=_optional_str(
+            mapping["moderation_requirement"],
+            "evidence_reference.moderation_requirement",
+        ),
+    )
+
+
+def _status_reason_from_dict(value: object) -> StatusReasonProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {
+                "reason_code",
+                "recorded_by",
+                "recorded_at",
+                "related_record",
+            }
+        ),
+        "status_reason",
+    )
+    related = mapping["related_record"]
+    return StatusReasonProjection(
+        reason_code=_required_str(
+            mapping["reason_code"], "status_reason.reason_code"
+        ),
+        recorded_by=_actor_from_dict(
+            mapping["recorded_by"], "status_reason.recorded_by"
+        ),
+        recorded_at=_timestamp_from_json(
+            mapping["recorded_at"], "status_reason.recorded_at"
+        ),
+        related_record=(
+            None
+            if related is None
+            else _record_reference_from_dict(
+                related, "status_reason.related_record"
+            )
+        ),
+    )
+
+
+def _score_from_dict(value: object) -> ScoreProjection:
+    if not isinstance(value, Mapping):
+        _fail("score must be an object.")
+    if any(not isinstance(key, str) for key in value):
+        _fail("score keys must be strings.")
+    mapping = cast(Mapping[str, object], value)
+    base_keys = frozenset(
+        {
+            "score_record_id",
+            "activity_id",
+            "session_id",
+            "target_reference",
+            "criterion_id",
+            "score_kind",
+            "standard_id",
+            "scoring_scale_id",
+            "disposition",
+            "basis",
+            "scorer",
+            "scored_at",
+            "moderation_complete",
+            "supersedes_score_record_id",
+            "current_state",
+        }
+    )
+    disposition_raw = mapping.get("disposition")
+    disposition = _required_str(disposition_raw, "score.disposition")
+    if disposition == "scored":
+        expected_keys = base_keys | frozenset({"value"})
+    else:
+        expected_keys = base_keys | frozenset({"status_reason"})
+    actual_keys = frozenset(mapping.keys())
+    if actual_keys != expected_keys:
+        missing = sorted(expected_keys - actual_keys)
+        unknown = sorted(actual_keys - expected_keys)
+        details: list[str] = []
+        if missing:
+            details.append("missing " + ", ".join(missing))
+        if unknown:
+            details.append("unknown " + ", ".join(unknown))
+        _fail(
+            "score has an invalid key set "
+            f"({'; '.join(details)})."
+        )
+
+    if disposition == "scored":
+        value_raw = mapping["value"]
+        status_reason = None
+    else:
+        value_raw = None
+        status_reason = _status_reason_from_dict(
+            mapping["status_reason"]
+        )
+
+    return ScoreProjection(
+        score_record_id=_required_str(
+            mapping["score_record_id"], "score.score_record_id"
+        ),
+        activity_id=_required_str(
+            mapping["activity_id"], "score.activity_id"
+        ),
+        session_id=_optional_str(
+            mapping["session_id"], "score.session_id"
+        ),
+        target_reference=_target_from_dict(
+            mapping["target_reference"]
+        ),
+        criterion_id=_required_str(
+            mapping["criterion_id"], "score.criterion_id"
+        ),
+        score_kind=cast(
+            ScoreKind,
+            _required_str(mapping["score_kind"], "score.score_kind"),
+        ),
+        standard_id=_optional_str(
+            mapping["standard_id"], "score.standard_id"
+        ),
+        scoring_scale_id=_required_str(
+            mapping["scoring_scale_id"], "score.scoring_scale_id"
+        ),
+        disposition=cast(ScoreDisposition, disposition),
+        value=(
+            None if value_raw is None else _scalar(value_raw, "score.value")
+        ),
+        basis=cast(
+            ScoreBasis,
+            _required_str(mapping["basis"], "score.basis"),
+        ),
+        scorer=_actor_from_dict(mapping["scorer"], "score.scorer"),
+        scored_at=_timestamp_from_json(
+            mapping["scored_at"], "score.scored_at"
+        ),
+        moderation_complete=_bool(
+            mapping["moderation_complete"], "score.moderation_complete"
+        ),
+        status_reason=status_reason,
+        supersedes_score_record_id=_optional_str(
+            mapping["supersedes_score_record_id"],
+            "score.supersedes_score_record_id",
+        ),
+        current_state=cast(
+            CurrentState,
+            _required_str(
+                mapping["current_state"], "score.current_state"
+            ),
+        ),
+    )
+
+def _score_link_from_dict(
+    value: object,
+) -> ScoreEvidenceLinkProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {
+                "score_evidence_link_id",
+                "score_record_id",
+                "evidence_reference",
+                "evidence_locator",
+                "subject_context",
+                "relevance_description",
+                "significance",
+                "moderation_record_id",
+                "status",
+                "supersedes_score_evidence_link_id",
+            }
+        ),
+        "score_evidence_link",
+    )
+    locator = mapping["evidence_locator"]
+    return ScoreEvidenceLinkProjection(
+        score_evidence_link_id=_required_str(
+            mapping["score_evidence_link_id"],
+            "score_evidence_link.score_evidence_link_id",
+        ),
+        score_record_id=_required_str(
+            mapping["score_record_id"],
+            "score_evidence_link.score_record_id",
+        ),
+        evidence_reference=_evidence_reference_from_dict(
+            mapping["evidence_reference"]
+        ),
+        evidence_locator=(
+            None
+            if locator is None
+            else _locator_from_dict(
+                locator, "score_evidence_link.evidence_locator"
+            )
+        ),
+        subject_context=tuple(
+            _subject_from_dict(
+                item, f"score_evidence_link.subject_context[{index}]"
+            )
+            for index, item in enumerate(
+                _array(
+                    mapping["subject_context"],
+                    "score_evidence_link.subject_context",
+                )
+            )
+        ),
+        relevance_description=_required_str(
+            mapping["relevance_description"],
+            "score_evidence_link.relevance_description",
+        ),
+        significance=_optional_str(
+            mapping["significance"],
+            "score_evidence_link.significance",
+        ),
+        moderation_record_id=_optional_str(
+            mapping["moderation_record_id"],
+            "score_evidence_link.moderation_record_id",
+        ),
+        status=_required_str(
+            mapping["status"], "score_evidence_link.status"
+        ),
+        supersedes_score_evidence_link_id=_optional_str(
+            mapping["supersedes_score_evidence_link_id"],
+            "score_evidence_link.supersedes_score_evidence_link_id",
+        ),
+    )
+
+
+def _moderation_from_dict(value: object) -> ModerationProjection:
+    if not isinstance(value, Mapping):
+        _fail("moderation must be an object.")
+    if any(not isinstance(key, str) for key in value):
+        _fail("moderation keys must be strings.")
+    mapping = cast(Mapping[str, object], value)
+    base_keys = frozenset(
+        {
+            "moderation_record_id",
+            "target_evidence_reference",
+            "target_subject_references",
+            "status",
+            "permitted_use",
+            "supersedes_moderation_record_id",
+            "current_state",
+        }
+    )
+    status = _required_str(mapping.get("status"), "moderation.status")
+    expected_keys = (
+        base_keys | frozenset({"qualification"})
+        if status == "accepted_with_qualification"
+        else base_keys
+    )
+    actual_keys = frozenset(mapping.keys())
+    if actual_keys != expected_keys:
+        missing = sorted(expected_keys - actual_keys)
+        unknown = sorted(actual_keys - expected_keys)
+        details: list[str] = []
+        if missing:
+            details.append("missing " + ", ".join(missing))
+        if unknown:
+            details.append("unknown " + ", ".join(unknown))
+        _fail(
+            "moderation has an invalid key set "
+            f"({'; '.join(details)})."
+        )
+    return ModerationProjection(
+        moderation_record_id=_required_str(
+            mapping["moderation_record_id"],
+            "moderation.moderation_record_id",
+        ),
+        target_evidence_reference=_evidence_reference_from_dict(
+            mapping["target_evidence_reference"]
+        ),
+        target_subject_references=tuple(
+            _subject_from_dict(
+                item, f"moderation.target_subject_references[{index}]"
+            )
+            for index, item in enumerate(
+                _array(
+                    mapping["target_subject_references"],
+                    "moderation.target_subject_references",
+                )
+            )
+        ),
+        status=status,
+        permitted_use=_required_str(
+            mapping["permitted_use"], "moderation.permitted_use"
+        ),
+        qualification=(
+            _required_str(
+                mapping["qualification"], "moderation.qualification"
+            )
+            if "qualification" in mapping
+            else None
+        ),
+        supersedes_moderation_record_id=_optional_str(
+            mapping["supersedes_moderation_record_id"],
+            "moderation.supersedes_moderation_record_id",
+        ),
+        current_state=cast(
+            CurrentState,
+            _required_str(
+                mapping["current_state"], "moderation.current_state"
+            ),
+        ),
+    )
+
+def _standards_result_from_dict(
+    value: object,
+) -> StandardsResultProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset({"score_record_id", "standard_id"}),
+        "standards_result",
+    )
+    return StandardsResultProjection(
+        score_record_id=_required_str(
+            mapping["score_record_id"],
+            "standards_result.score_record_id",
+        ),
+        standard_id=_required_str(
+            mapping["standard_id"], "standards_result.standard_id"
+        ),
+    )
+
+
+def _privacy_from_dict(value: object) -> PrivacyProjection:
+    mapping = _exact_mapping(
+        value,
+        frozenset(
+            {
+                "classification",
+                "audience_references",
+                "policy_reference",
+                "inherited_from",
+            }
+        ),
+        "privacy",
+    )
+    policy = mapping["policy_reference"]
+    inherited = mapping["inherited_from"]
+    return PrivacyProjection(
+        classification=_required_str(
+            mapping["classification"], "privacy.classification"
+        ),
+        audience_references=tuple(
+            _subject_from_dict(
+                item, f"privacy.audience_references[{index}]"
+            )
+            for index, item in enumerate(
+                _array(
+                    mapping["audience_references"],
+                    "privacy.audience_references",
+                )
+            )
+        ),
+        policy_reference=(
+            None
+            if policy is None
+            else _record_reference_from_dict(
+                policy, "privacy.policy_reference"
+            )
+        ),
+        inherited_from=(
+            None
+            if inherited is None
+            else _record_reference_from_dict(
+                inherited, "privacy.inherited_from"
+            )
+        ),
+    )
+
+
+__all__ = [
+    "ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION",
+    "ACADEMIC_RESULT_MANIFEST_RECORD_TYPE",
+    "AcademicResultManifest",
+    "ActivityContextProjection",
+    "ConcordAcademicResultManifestDecodeError",
+    "ConcordAcademicResultManifestError",
+    "ConcordAcademicResultManifestValidationError",
+    "CorePublicationReferenceProjection",
+    "CriterionProjection",
+    "CriterionSetProjection",
+    "CurrentState",
+    "EvidenceLocatorProjection",
+    "EvidenceReferenceProjection",
+    "JsonScalar",
+    "ManifestProjection",
+    "ManifestRecordSet",
+    "ModerationProjection",
+    "PROJECTION_DIGEST_ALGORITHM",
+    "PUBLICATION_KIND",
+    "PrivacyProjection",
+    "PublicActor",
+    "RecordReferenceProjection",
+    "RevisionReason",
+    "ScaleLevelProjection",
+    "ScoreBasis",
+    "ScoreDisposition",
+    "ScoreEvidenceLinkProjection",
+    "ScoreKind",
+    "ScoreProjection",
+    "ScoringScaleProjection",
+    "StandardsResultProjection",
+    "StatusReasonProjection",
+    "SubjectReferenceProjection",
+    "TargetReferenceProjection",
+    "academic_result_manifest_from_bytes",
+    "academic_result_manifest_from_dict",
+    "academic_result_manifest_to_bytes",
+    "academic_result_manifest_to_dict",
+    "calculate_semantic_projection_digest",
+    "derive_manifest_capabilities",
+    "validate_academic_result_manifest",
+    "with_semantic_projection_digest",
+]

--- a/concord/academic_result_manifest_generation.py
+++ b/concord/academic_result_manifest_generation.py
@@ -1,0 +1,2110 @@
+"""Immutable generation of Concord Academic Result Manifest v1."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal, TypeAlias, cast
+
+from pds_core.academic_work_registrations import AcademicWorkRegistration
+from pds_core.publication_records import validate_publication_manifest_path
+from pds_core.publication_storage import (
+    PublicationManifestError,
+    PublicationManifestIntegrityError,
+    PublicationManifestNotFoundError,
+    verify_publication_manifest,
+)
+from pds_core.registry_services import (
+    RegistryServiceError,
+    RegistryServiceNotFoundError,
+    get_canonical_publication_record,
+)
+from pds_core.routes import safe_module_work_descendant
+from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef
+from pds_core.standards import StandardsLibrary
+
+from concord.academic_result_manifest import (
+    ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+    ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+    AcademicResultManifest,
+    ActivityContextProjection,
+    ConcordAcademicResultManifestValidationError,
+    CorePublicationReferenceProjection,
+    CriterionProjection,
+    CriterionSetProjection,
+    EvidenceLocatorProjection,
+    EvidenceReferenceProjection,
+    ManifestProjection,
+    ManifestRecordSet,
+    ModerationProjection,
+    PrivacyProjection,
+    PublicActor,
+    RecordReferenceProjection,
+    RevisionReason,
+    ScaleLevelProjection,
+    ScoreEvidenceLinkProjection,
+    ScoreProjection,
+    ScoringScaleProjection,
+    StandardsResultProjection,
+    StatusReasonProjection,
+    SubjectReferenceProjection,
+    TargetReferenceProjection,
+    academic_result_manifest_from_bytes,
+    academic_result_manifest_to_bytes,
+    derive_manifest_capabilities,
+    with_semantic_projection_digest,
+)
+from concord.academic_work_registration import (
+    ConcordAcademicWorkRegistrationError,
+    ConcordAcademicWorkRegistrationIntegrityError,
+    ConcordAcademicWorkRegistrationNotFoundError,
+    ConcordAcademicWorkRegistrationValidationError,
+    load_current_concord_academic_work_registration,
+)
+from concord.model_validation import ConcordRecordGraph
+from concord.models import (
+    ActorReference,
+    ConcordRecordReference,
+    Criterion,
+    CriterionSet,
+    EvidenceLocator,
+    EvidenceReference,
+    ModerationRecord,
+    PrivacyPolicy,
+    ScoreEvidenceLink,
+    ScoreRecord,
+    ScoreTargetReference,
+    ScoringScale,
+    StatusReason,
+    SubjectReference,
+)
+from concord.pds_contract import (
+    CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+    CONCORD_ACADEMIC_WORK_CONTRACT_VERSION,
+    CONCORD_ACADEMIC_WORK_KIND,
+    CONCORD_ACTIVITY_CONTRACT_VERSION,
+    CONCORD_ACTIVITY_RECORD_KIND,
+    CONCORD_MODULE_ID,
+)
+from concord.storage import (
+    load_current_record_graph,
+    load_current_snapshot,
+)
+from concord.storage_errors import (
+    ConcordStorageConflictError,
+    ConcordStorageError,
+    ConcordStorageIntegrityError,
+    ConcordStorageNotFoundError,
+    ConcordStorageReadError,
+    ConcordStorageValidationError,
+)
+from concord.workflows.context import require_core_class, resolve_read_workspace_root
+from concord.workflows.errors import (
+    ConcordWorkflowNotFoundError,
+    ConcordWorkflowValidationError,
+)
+from concord.workflows.models import WorkflowActor
+
+ManifestGenerationDisposition: TypeAlias = Literal["created", "existing"]
+ManifestPreviewDisposition: TypeAlias = Literal["would_create", "would_reuse"]
+
+_RECORD_SET_RELATIVE_DIR = "exports/manifests/academic_results"
+_LOCK_NAME = ".write.lock"
+
+
+class ConcordManifestGenerationError(Exception):
+    """Base error for Concord manifest generation and immutable storage."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self._lock_cleanup_failure: ManifestGenerationCleanupFailure | None = None
+
+    @property
+    def lock_cleanup_failure(self) -> ManifestGenerationCleanupFailure | None:
+        return self._lock_cleanup_failure
+
+    def _record_lock_cleanup_failure(
+        self, failure: ManifestGenerationCleanupFailure
+    ) -> None:
+        self._lock_cleanup_failure = failure
+
+
+class ConcordManifestGenerationValidationError(
+    ConcordManifestGenerationError, ValueError
+):
+    """Generation input or native Concord state is not publishable."""
+
+
+class ConcordManifestGenerationNotFoundError(ConcordManifestGenerationError):
+    """Required managed native/Core state does not exist."""
+
+
+class ConcordManifestGenerationConflictError(ConcordManifestGenerationError):
+    """Expected native state or immutable producer storage has moved."""
+
+
+class ConcordManifestGenerationIntegrityError(ConcordManifestGenerationError):
+    """Canonical native, registry, or manifest state is contradictory."""
+
+
+class ConcordManifestGenerationWriteError(ConcordManifestGenerationError):
+    """Producer-owned immutable storage could not be completed safely."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.incomplete_target_cleanup_failure: OSError | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestGenerationCleanupFailure:
+    path: Path
+    relative_path: str
+    message: str
+    error: OSError
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, Path):
+            raise TypeError("cleanup failure path must be a Path.")
+        if not isinstance(self.relative_path, str) or not self.relative_path:
+            raise ValueError("cleanup failure relative_path must be nonempty.")
+        if not isinstance(self.message, str) or not self.message:
+            raise ValueError("cleanup failure message must be nonempty.")
+        if not isinstance(self.error, OSError):
+            raise TypeError("cleanup failure error must be an OSError.")
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestGenerationPartialState:
+    operation: str
+    work: ModuleWorkRef
+    revision: int
+    path: Path
+    relative_path: str
+    expected_sha256: str | None
+    durable_file_exists: bool
+    lock_cleanup_failure: ManifestGenerationCleanupFailure | None = None
+
+
+class ConcordManifestGenerationPartialSuccessError(
+    ConcordManifestGenerationWriteError
+):
+    """Manifest bytes are durable but completion/verification is uncertain."""
+
+    def __init__(
+        self,
+        message: str,
+        state: ManifestGenerationPartialState,
+    ) -> None:
+        super().__init__(message)
+        self.state = state
+        if state.lock_cleanup_failure is not None:
+            self._record_lock_cleanup_failure(state.lock_cleanup_failure)
+
+
+class _DurableRevisionWriteError(Exception):
+    pass
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class GenerateAcademicResultManifestRequest:
+    class_id: str
+    activity_id: str
+    expected_snapshot_revision: int
+    actor: WorkflowActor
+    revision_reason: RevisionReason
+
+    def __post_init__(self) -> None:
+        try:
+            ModuleWorkRef(
+                module_id=CONCORD_MODULE_ID,
+                class_id=self.class_id,
+                work_id=self.activity_id,
+            )
+        except Exception as error:
+            raise ConcordManifestGenerationValidationError(
+                "class_id and activity_id must be safe identifiers."
+            ) from error
+        if (
+            isinstance(self.expected_snapshot_revision, bool)
+            or not isinstance(self.expected_snapshot_revision, int)
+            or self.expected_snapshot_revision < 1
+        ):
+            raise ConcordManifestGenerationValidationError(
+                "expected_snapshot_revision must be a positive integer."
+            )
+        if not isinstance(self.actor, WorkflowActor):
+            raise ConcordManifestGenerationValidationError(
+                "actor must be a WorkflowActor."
+            )
+        try:
+            ManifestProjection(
+                source_snapshot_revision=1,
+                projection_digest_algorithm="sha256",
+                projection_digest="0" * 64,
+                generated_by=_workflow_actor(self.actor),
+                revision_reason=self.revision_reason,
+            )
+        except Exception as error:
+            raise ConcordManifestGenerationValidationError(
+                "revision_reason is not a supported manifest revision reason."
+            ) from error
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestGenerationContext:
+    work: ModuleWorkRef
+    graph: ConcordRecordGraph
+    snapshot_revision: int
+    snapshot_sha256: str
+    registration: AcademicWorkRegistration
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.work, ModuleWorkRef):
+            raise ConcordManifestGenerationValidationError(
+                "context work must be a ModuleWorkRef."
+            )
+        if self.work.module_id != CONCORD_MODULE_ID:
+            raise ConcordManifestGenerationValidationError(
+                'context work.module_id must be "concord".'
+            )
+        if not isinstance(self.graph, ConcordRecordGraph):
+            raise ConcordManifestGenerationValidationError(
+                "context graph must be a ConcordRecordGraph."
+            )
+        if (
+            isinstance(self.snapshot_revision, bool)
+            or not isinstance(self.snapshot_revision, int)
+            or self.snapshot_revision < 1
+        ):
+            raise ConcordManifestGenerationValidationError(
+                "context snapshot_revision must be positive."
+            )
+        if (
+            not isinstance(self.snapshot_sha256, str)
+            or len(self.snapshot_sha256) != 64
+        ):
+            raise ConcordManifestGenerationValidationError(
+                "context snapshot_sha256 must be a SHA-256 digest."
+            )
+        if not isinstance(self.registration, AcademicWorkRegistration):
+            raise ConcordManifestGenerationValidationError(
+                "context registration is invalid."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class StoredAcademicResultManifest:
+    manifest: AcademicResultManifest
+    revision: int
+    path: Path
+    relative_path: str
+    content: bytes
+    sha256: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.manifest, AcademicResultManifest):
+            raise ConcordManifestGenerationValidationError(
+                "stored manifest has an invalid manifest value."
+            )
+        if (
+            isinstance(self.revision, bool)
+            or not isinstance(self.revision, int)
+            or self.revision < 1
+        ):
+            raise ConcordManifestGenerationValidationError(
+                "stored manifest revision must be positive."
+            )
+        if not isinstance(self.path, Path):
+            raise ConcordManifestGenerationValidationError(
+                "stored manifest path must be a Path."
+            )
+        if not isinstance(self.relative_path, str) or not self.relative_path:
+            raise ConcordManifestGenerationValidationError(
+                "stored manifest relative_path must be nonempty."
+            )
+        if not isinstance(self.content, bytes):
+            raise ConcordManifestGenerationValidationError(
+                "stored manifest content must be bytes."
+            )
+        expected_digest = hashlib.sha256(self.content).hexdigest()
+        if self.sha256 != expected_digest:
+            raise ConcordManifestGenerationIntegrityError(
+                "stored manifest digest disagrees with its bytes."
+            )
+        decoded = academic_result_manifest_from_bytes(self.content)
+        if decoded != self.manifest:
+            raise ConcordManifestGenerationIntegrityError(
+                "stored manifest bytes disagree with the typed manifest."
+            )
+        if decoded.record_set.revision != self.revision:
+            raise ConcordManifestGenerationIntegrityError(
+                "stored manifest revision disagrees with its record-set revision."
+            )
+        expected_relative = academic_result_manifest_relative_path(
+            decoded.work, self.revision
+        )
+        if self.relative_path != expected_relative:
+            raise ConcordManifestGenerationIntegrityError(
+                "stored manifest relative path disagrees with its identity."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultManifestPreview:
+    """Read-only projection of what manifest generation would do."""
+
+    disposition: ManifestPreviewDisposition
+    manifest: AcademicResultManifest
+    revision: int
+    path: Path
+    relative_path: str
+    content: bytes
+    sha256: str
+    registration_revision: int
+    source_snapshot_revision: int
+
+    def __post_init__(self) -> None:
+        if self.disposition not in {"would_create", "would_reuse"}:
+            raise ConcordManifestGenerationValidationError(
+                "preview disposition is invalid."
+            )
+        if not isinstance(self.manifest, AcademicResultManifest):
+            raise ConcordManifestGenerationValidationError(
+                "preview manifest is invalid."
+            )
+        if (
+            isinstance(self.revision, bool)
+            or not isinstance(self.revision, int)
+            or self.revision < 1
+        ):
+            raise ConcordManifestGenerationValidationError(
+                "preview revision must be positive."
+            )
+        if not isinstance(self.path, Path):
+            raise ConcordManifestGenerationValidationError(
+                "preview path must be a Path."
+            )
+        if not isinstance(self.relative_path, str) or not self.relative_path:
+            raise ConcordManifestGenerationValidationError(
+                "preview relative_path must be nonempty."
+            )
+        if not isinstance(self.content, bytes):
+            raise ConcordManifestGenerationValidationError(
+                "preview content must be bytes."
+            )
+        if self.sha256 != hashlib.sha256(self.content).hexdigest():
+            raise ConcordManifestGenerationIntegrityError(
+                "preview SHA-256 disagrees with its bytes."
+            )
+        stored = StoredAcademicResultManifest(
+            manifest=self.manifest,
+            revision=self.revision,
+            path=self.path,
+            relative_path=self.relative_path,
+            content=self.content,
+            sha256=self.sha256,
+        )
+        del stored
+        if (
+            isinstance(self.registration_revision, bool)
+            or not isinstance(self.registration_revision, int)
+            or self.registration_revision < 1
+        ):
+            raise ConcordManifestGenerationValidationError(
+                "preview registration_revision must be positive."
+            )
+        if (
+            isinstance(self.source_snapshot_revision, bool)
+            or not isinstance(self.source_snapshot_revision, int)
+            or self.source_snapshot_revision < 1
+        ):
+            raise ConcordManifestGenerationValidationError(
+                "preview source_snapshot_revision must be positive."
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultManifestGenerationResult:
+    disposition: ManifestGenerationDisposition
+    manifest: AcademicResultManifest
+    revision: int
+    path: Path
+    relative_path: str
+    content: bytes
+    sha256: str
+    registration_revision: int
+    source_snapshot_revision: int
+
+    def __post_init__(self) -> None:
+        if self.disposition not in {"created", "existing"}:
+            raise ConcordManifestGenerationValidationError(
+                "generation disposition is invalid."
+            )
+        stored = StoredAcademicResultManifest(
+            manifest=self.manifest,
+            revision=self.revision,
+            path=self.path,
+            relative_path=self.relative_path,
+            content=self.content,
+            sha256=self.sha256,
+        )
+        del stored
+        if (
+            isinstance(self.registration_revision, bool)
+            or not isinstance(self.registration_revision, int)
+            or self.registration_revision < 1
+        ):
+            raise ConcordManifestGenerationValidationError(
+                "registration_revision must be positive."
+            )
+        if (
+            isinstance(self.source_snapshot_revision, bool)
+            or not isinstance(self.source_snapshot_revision, int)
+            or self.source_snapshot_revision < 1
+        ):
+            raise ConcordManifestGenerationValidationError(
+                "source_snapshot_revision must be positive."
+            )
+
+
+def _workflow_actor(value: WorkflowActor) -> PublicActor:
+    return PublicActor(
+        actor_kind=value.actor_kind,
+        actor_id=value.actor_id,
+        owning_system=value.owning_system,
+    )
+
+
+def _actor(value: ActorReference) -> PublicActor:
+    return PublicActor(
+        actor_kind=value.actor_kind,
+        actor_id=value.actor_id,
+        owning_system=value.owning_system,
+    )
+
+
+def _subject(value: SubjectReference) -> SubjectReferenceProjection:
+    return SubjectReferenceProjection(
+        subject_kind=value.subject_kind,
+        subject_id=value.subject_id,
+        owning_system=value.owning_system,
+        contract_version=value.contract_version,
+    )
+
+
+def _target(value: ScoreTargetReference) -> TargetReferenceProjection:
+    return TargetReferenceProjection(
+        target_kind=value.target_kind,
+        target_id=value.target_id,
+        owning_system=value.owning_system,
+        contract_version=value.contract_version,
+    )
+
+
+def _record_reference(
+    value: ModuleRecordRef | ConcordRecordReference,
+) -> RecordReferenceProjection:
+    if isinstance(value, ModuleRecordRef):
+        return RecordReferenceProjection(
+            module_id=value.module_id,
+            record_kind=value.record_kind,
+            record_id=value.record_id,
+            contract_version=value.contract_version,
+        )
+    return RecordReferenceProjection(
+        module_id=CONCORD_MODULE_ID,
+        record_kind=value.record_kind,
+        record_id=value.record_id,
+        contract_version=value.contract_version,
+    )
+
+
+def _locator(value: EvidenceLocator | None) -> EvidenceLocatorProjection | None:
+    if value is None:
+        return None
+    return EvidenceLocatorProjection(
+        page_number=value.page_number,
+        source_page_index=value.source_page_index,
+        section_label=value.section_label,
+        row_label=value.row_label,
+        column_label=value.column_label,
+        participant_label=value.participant_label,
+        session_id=value.session_id,
+    )
+
+
+def _evidence_reference(
+    value: EvidenceReference,
+) -> EvidenceReferenceProjection:
+    publication = value.source_publication_reference
+    return EvidenceReferenceProjection(
+        evidence_kind=value.evidence_kind,
+        owning_system=value.owning_system,
+        record_id=value.record_id,
+        contract_version=value.contract_version,
+        source_publication_reference=(
+            CorePublicationReferenceProjection(
+                publication_id=publication.publication_id,
+                publication_schema_version=publication.publication_schema_version,
+            )
+            if publication is not None
+            else None
+        ),
+        immutable_source_version=value.immutable_source_version,
+        locator=_locator(value.locator),
+        subject_context=tuple(_subject(item) for item in value.subject_context),
+        moderation_requirement=value.moderation_requirement,
+    )
+
+
+def _status_reason(
+    value: StatusReason | None,
+) -> StatusReasonProjection | None:
+    if value is None:
+        return None
+    return StatusReasonProjection(
+        reason_code=value.reason_code,
+        recorded_by=_actor(value.recorded_by),
+        recorded_at=_native_timestamp(value.recorded_at, "status_reason.recorded_at"),
+        related_record=(
+            _record_reference(value.related_record)
+            if value.related_record is not None
+            else None
+        ),
+    )
+
+
+def _native_timestamp(value: str, field: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ConcordManifestGenerationIntegrityError(
+            f"{field} is not a valid native timestamp."
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ConcordManifestGenerationIntegrityError(
+            f"{field} must be timezone-aware."
+        )
+    return parsed
+
+
+def _criterion_set(value: CriterionSet) -> CriterionSetProjection:
+    return CriterionSetProjection(
+        criterion_set_id=value.criterion_set_id,
+        lineage_id=value.lineage_id,
+        revision=value.revision,
+        criterion_set_kind=value.criterion_set_kind,
+        scope=value.scope,
+        criterion_ids=value.criterion_ids,
+        status=value.status,
+        supersedes_criterion_set_id=value.supersedes_criterion_set_id,
+        standards_profile_id=value.standards_profile_id,
+    )
+
+
+def _criterion(value: Criterion) -> CriterionProjection:
+    return CriterionProjection(
+        criterion_id=value.criterion_id,
+        criterion_set_id=value.criterion_set_id,
+        key=value.key,
+        label=value.label,
+        definition=value.definition,
+        criterion_kind=value.criterion_kind,
+        supported_target_kinds=value.supported_target_kinds,
+        status=value.status,
+        standard_id=value.standard_id,
+        alignment_standard_ids=value.alignment_standard_ids,
+        default_scoring_scale_id=value.default_scoring_scale_id,
+    )
+
+
+def _scale(value: ScoringScale) -> ScoringScaleProjection:
+    return ScoringScaleProjection(
+        scoring_scale_id=value.scoring_scale_id,
+        lineage_id=value.lineage_id,
+        name=value.name,
+        revision=value.revision,
+        scale_type=value.scale_type,
+        levels=tuple(
+            ScaleLevelProjection(
+                value=item.value,
+                label=item.label,
+                meaning=item.meaning,
+                position=item.position,
+                description=item.description,
+            )
+            for item in value.levels
+        ),
+        status=value.status,
+        supersedes_scoring_scale_id=value.supersedes_scoring_scale_id,
+    )
+
+
+def _score_current_states(
+    values: tuple[ScoreRecord, ...],
+) -> dict[str, Literal["current", "superseded"]]:
+    predecessor_ids = {
+        value.supersedes_score_record_id
+        for value in values
+        if value.supersedes_score_record_id is not None
+    }
+    return {
+        value.score_record_id: (
+            "superseded"
+            if value.score_record_id in predecessor_ids
+            else "current"
+        )
+        for value in values
+    }
+
+
+def _moderation_current_states(
+    values: tuple[ModerationRecord, ...],
+) -> dict[str, Literal["current", "superseded"]]:
+    predecessor_ids = {
+        value.supersedes_moderation_record_id
+        for value in values
+        if value.supersedes_moderation_record_id is not None
+    }
+    return {
+        value.moderation_record_id: (
+            "superseded"
+            if value.moderation_record_id in predecessor_ids
+            else "current"
+        )
+        for value in values
+    }
+
+
+def _score(
+    value: ScoreRecord,
+    states: dict[str, Literal["current", "superseded"]],
+) -> ScoreProjection:
+    return ScoreProjection(
+        score_record_id=value.score_record_id,
+        activity_id=value.activity_id,
+        session_id=value.session_id,
+        target_reference=_target(value.target_reference),
+        criterion_id=value.criterion_id,
+        score_kind=cast(Literal["standard_backed", "local"], value.score_kind),
+        standard_id=value.standard_id,
+        scoring_scale_id=value.scoring_scale_id,
+        disposition=cast(
+            Literal[
+                "scored",
+                "insufficient_evidence",
+                "absent",
+                "excused",
+                "not_observed",
+                "not_applicable",
+                "deferred",
+            ],
+            value.disposition,
+        ),
+        value=value.value,
+        basis=cast(
+            Literal[
+                "linked_evidence",
+                "professional_judgment",
+                "mixed_basis",
+            ],
+            value.basis,
+        ),
+        scorer=_actor(value.scorer),
+        scored_at=_native_timestamp(value.scored_at, "score.scored_at"),
+        moderation_complete=value.moderation_complete,
+        status_reason=_status_reason(value.status_reason),
+        supersedes_score_record_id=value.supersedes_score_record_id,
+        current_state=states[value.score_record_id],
+    )
+
+
+def _score_link(value: ScoreEvidenceLink) -> ScoreEvidenceLinkProjection:
+    return ScoreEvidenceLinkProjection(
+        score_evidence_link_id=value.score_evidence_link_id,
+        score_record_id=value.score_record_id,
+        evidence_reference=_evidence_reference(value.evidence_reference),
+        evidence_locator=_locator(value.evidence_locator),
+        subject_context=tuple(_subject(item) for item in value.subject_context),
+        relevance_description=value.relevance_description,
+        significance=value.significance,
+        moderation_record_id=value.moderation_record_id,
+        status=value.status,
+        supersedes_score_evidence_link_id=value.supersedes_score_evidence_link_id,
+    )
+
+
+def _moderation(
+    value: ModerationRecord,
+    states: dict[str, Literal["current", "superseded"]],
+) -> ModerationProjection:
+    return ModerationProjection(
+        moderation_record_id=value.moderation_record_id,
+        target_evidence_reference=_evidence_reference(
+            value.target_evidence_reference
+        ),
+        target_subject_references=tuple(
+            _subject(item) for item in value.target_subject_references
+        ),
+        status=value.status,
+        permitted_use=value.permitted_use,
+        qualification=value.qualification,
+        supersedes_moderation_record_id=value.supersedes_moderation_record_id,
+        current_state=states[value.moderation_record_id],
+    )
+
+
+def _public_privacy(value: PrivacyPolicy) -> PrivacyProjection:
+    return PrivacyProjection(
+        classification=value.classification,
+        audience_references=tuple(
+            _subject(item) for item in value.audience_references
+        ),
+        policy_reference=(
+            _record_reference(value.policy_reference)
+            if value.policy_reference is not None
+            else None
+        ),
+        inherited_from=(
+            _record_reference(value.inherited_from)
+            if value.inherited_from is not None
+            else None
+        ),
+    )
+
+
+def _resolve_effective_privacy(
+    values: Iterable[PrivacyPolicy],
+) -> PrivacyProjection:
+    projected = tuple(_public_privacy(value) for value in values)
+    restricted = PrivacyProjection(
+        classification="teacher_restricted",
+        audience_references=(),
+        policy_reference=None,
+        inherited_from=None,
+    )
+    if not projected:
+        return restricted
+
+    first = projected[0]
+    if all(item == first for item in projected):
+        return first
+
+    if any(
+        value.classification == "teacher_restricted"
+        for value in projected
+    ):
+        return restricted
+
+    if any(
+        value.classification in {"external_policy", "inherited"}
+        for value in projected
+    ):
+        return restricted
+
+    narrower_classes = {
+        value.classification
+        for value in projected
+        if value.classification != "classroom_shared"
+    }
+    if len(narrower_classes) != 1:
+        return restricted
+
+    classification = next(iter(narrower_classes))
+    narrower = tuple(
+        value
+        for value in projected
+        if value.classification == classification
+    )
+    narrowest = narrower[0]
+    if all(item == narrowest for item in narrower):
+        return narrowest
+    return restricted
+
+def _verify_external_publication_reference(
+    root: Path,
+    reference: EvidenceReference,
+) -> None:
+    source = reference.source_publication_reference
+    if source is None:
+        return
+    try:
+        publication = get_canonical_publication_record(
+            root, source.publication_id
+        )
+    except RegistryServiceNotFoundError as error:
+        raise ConcordManifestGenerationNotFoundError(
+            "Referenced Core Publication Record is unavailable: "
+            f"{source.publication_id}"
+        ) from error
+    except RegistryServiceError as error:
+        raise ConcordManifestGenerationIntegrityError(
+            "Referenced Core Publication Record could not be verified."
+        ) from error
+
+    expected_schema = source.publication_schema_version
+    if (
+        expected_schema is not None
+        and publication.schema_version != expected_schema
+    ):
+        raise ConcordManifestGenerationIntegrityError(
+            "Referenced Core Publication schema version does not match "
+            "the Concord evidence reference."
+        )
+    if publication.work.module_id != reference.owning_system:
+        raise ConcordManifestGenerationIntegrityError(
+            "Referenced Core Publication producer module does not match "
+            "the Concord evidence owner."
+        )
+    try:
+        verify_publication_manifest(root, publication)
+    except PublicationManifestNotFoundError as error:
+        raise ConcordManifestGenerationNotFoundError(
+            "Referenced external publication manifest is unavailable."
+        ) from error
+    except PublicationManifestIntegrityError as error:
+        raise ConcordManifestGenerationIntegrityError(
+            "Referenced external publication manifest failed digest or "
+            "containment verification."
+        ) from error
+    except PublicationManifestError as error:
+        raise ConcordManifestGenerationIntegrityError(
+            "Referenced external publication manifest could not be verified."
+        ) from error
+
+
+def _verify_external_lineage(root: Path, graph: ConcordRecordGraph) -> None:
+    references: list[EvidenceReference] = []
+    references.extend(
+        item.evidence_reference for item in graph.score_evidence_links
+    )
+    references.extend(
+        item.target_evidence_reference for item in graph.moderation_records
+    )
+    seen: set[EvidenceReference] = set()
+    for reference in references:
+        if reference in seen:
+            continue
+        seen.add(reference)
+        if (
+            reference.source_publication_reference is not None
+        ):
+            _verify_external_publication_reference(root, reference)
+        if (
+            reference.owning_system != CONCORD_MODULE_ID
+            and reference.source_publication_reference is None
+            and reference.immutable_source_version is None
+        ):
+            raise ConcordManifestGenerationIntegrityError(
+                "External evidence lacks exact immutable lineage."
+            )
+
+
+def _registration_for_generation(
+    root: Path,
+    class_id: str,
+    activity_id: str,
+) -> AcademicWorkRegistration:
+    try:
+        registration = load_current_concord_academic_work_registration(
+            root, class_id, activity_id
+        )
+    except ConcordAcademicWorkRegistrationNotFoundError as error:
+        raise ConcordManifestGenerationNotFoundError(str(error)) from error
+    except ConcordAcademicWorkRegistrationValidationError as error:
+        raise ConcordManifestGenerationValidationError(str(error)) from error
+    except ConcordAcademicWorkRegistrationIntegrityError as error:
+        raise ConcordManifestGenerationIntegrityError(str(error)) from error
+    except ConcordAcademicWorkRegistrationError as error:
+        raise ConcordManifestGenerationIntegrityError(str(error)) from error
+    if registration is None:
+        raise ConcordManifestGenerationValidationError(
+            "Concord Activity must have an explicit current Academic Work "
+            "Registration before manifest generation."
+        )
+    return registration
+
+
+def _validate_registration_for_activity(
+    registration: AcademicWorkRegistration,
+    *,
+    work: ModuleWorkRef,
+    title: str,
+) -> None:
+    expected_source = ModuleRecordRef(
+        module_id=CONCORD_MODULE_ID,
+        record_kind=CONCORD_ACTIVITY_RECORD_KIND,
+        record_id=work.work_id,
+        contract_version=CONCORD_ACTIVITY_CONTRACT_VERSION,
+    )
+    if (
+        registration.work != work
+        or registration.producer_contract_version
+        != CONCORD_ACADEMIC_WORK_CONTRACT_VERSION
+        or registration.work_kind != CONCORD_ACADEMIC_WORK_KIND
+        or registration.source_records != (expected_source,)
+    ):
+        raise ConcordManifestGenerationIntegrityError(
+            "Current Academic Work Registration does not match the exact "
+            "Concord Activity publication contract."
+        )
+    if registration.title != title:
+        raise ConcordManifestGenerationValidationError(
+            "Activity title differs from the current Academic Work "
+            "Registration; explicitly update the registration first."
+        )
+
+
+def _load_generation_context(
+    root: Path,
+    request: GenerateAcademicResultManifestRequest,
+    *,
+    standards_library: StandardsLibrary | None,
+) -> ManifestGenerationContext:
+    try:
+        require_core_class(root, request.class_id)
+    except ConcordWorkflowValidationError as error:
+        raise ConcordManifestGenerationValidationError(str(error)) from error
+    except ConcordWorkflowNotFoundError as error:
+        raise ConcordManifestGenerationNotFoundError(str(error)) from error
+
+    work = ModuleWorkRef(
+        module_id=CONCORD_MODULE_ID,
+        class_id=request.class_id,
+        work_id=request.activity_id,
+    )
+    try:
+        loaded = load_current_record_graph(
+            root,
+            work,
+            standards_library=standards_library,
+        )
+    except ConcordStorageNotFoundError as error:
+        raise ConcordManifestGenerationNotFoundError(
+            f"Concord Activity is unavailable: {request.activity_id}"
+        ) from error
+    except ConcordStorageConflictError as error:
+        raise ConcordManifestGenerationConflictError(str(error)) from error
+    except ConcordStorageValidationError as error:
+        raise ConcordManifestGenerationValidationError(str(error)) from error
+    except (ConcordStorageIntegrityError, ConcordStorageReadError) as error:
+        raise ConcordManifestGenerationIntegrityError(str(error)) from error
+    except ConcordStorageError as error:
+        raise ConcordManifestGenerationIntegrityError(str(error)) from error
+
+    if loaded.snapshot_revision != request.expected_snapshot_revision:
+        raise ConcordManifestGenerationConflictError(
+            "The expected Concord snapshot revision is stale or in the future."
+        )
+    if len(loaded.graph.activities) != 1:
+        raise ConcordManifestGenerationIntegrityError(
+            "Concord snapshot must contain exactly one Activity."
+        )
+    activity = loaded.graph.activities[0]
+    if activity.work_reference != work:
+        raise ConcordManifestGenerationIntegrityError(
+            "Concord Activity identity disagrees with its work."
+        )
+    registration = _registration_for_generation(
+        root, request.class_id, request.activity_id
+    )
+    try:
+        current_after_registration = load_current_snapshot(root, work)
+    except ConcordStorageError as error:
+        raise ConcordManifestGenerationIntegrityError(str(error)) from error
+    if (
+        current_after_registration.snapshot_revision
+        != loaded.snapshot_revision
+        or current_after_registration.snapshot_sha256
+        != loaded.snapshot_sha256
+    ):
+        raise ConcordManifestGenerationConflictError(
+            "Concord native snapshot changed while registration was loaded."
+        )
+    _validate_registration_for_activity(
+        registration,
+        work=work,
+        title=activity.title,
+    )
+
+    if activity.scoring_orientation == "evidence_only":
+        raise ConcordManifestGenerationValidationError(
+            "evidence_only Activity cannot generate an academic-result manifest."
+        )
+    if not loaded.graph.score_records:
+        raise ConcordManifestGenerationValidationError(
+            "Academic-result manifest requires at least one Score Record."
+        )
+
+    _verify_external_lineage(root, loaded.graph)
+    return ManifestGenerationContext(
+        work=work,
+        graph=loaded.graph,
+        snapshot_revision=loaded.snapshot_revision,
+        snapshot_sha256=loaded.snapshot_sha256,
+        registration=registration,
+    )
+
+
+def _required_moderation_records(
+    graph: ConcordRecordGraph,
+) -> tuple[ModerationRecord, ...]:
+    referenced = {
+        item.moderation_record_id
+        for item in graph.score_evidence_links
+        if item.moderation_record_id is not None
+    }
+    if not referenced:
+        return ()
+
+    by_id = {
+        item.moderation_record_id: item
+        for item in graph.moderation_records
+    }
+    predecessor_to_successors: dict[str, set[str]] = {}
+    for item in graph.moderation_records:
+        predecessor = item.supersedes_moderation_record_id
+        if predecessor is not None:
+            predecessor_to_successors.setdefault(predecessor, set()).add(
+                item.moderation_record_id
+            )
+
+    selected: set[str] = set(referenced)
+    changed = True
+    while changed:
+        changed = False
+        for record_id in tuple(selected):
+            record = by_id.get(record_id)
+            if record is None:
+                raise ConcordManifestGenerationIntegrityError(
+                    "Score Evidence Link references a missing Moderation Record."
+                )
+            predecessor = record.supersedes_moderation_record_id
+            if predecessor is not None and predecessor not in selected:
+                selected.add(predecessor)
+                changed = True
+            for successor in predecessor_to_successors.get(record_id, ()):
+                if successor not in selected:
+                    selected.add(successor)
+                    changed = True
+
+    return tuple(
+        sorted(
+            (by_id[record_id] for record_id in selected),
+            key=lambda item: item.moderation_record_id,
+        )
+    )
+
+
+def _build_manifest(
+    context: ManifestGenerationContext,
+    request: GenerateAcademicResultManifestRequest,
+    *,
+    revision: int,
+    generated_at: datetime,
+) -> AcademicResultManifest:
+    graph = context.graph
+    activity = graph.activities[0]
+
+    set_by_id = {
+        item.criterion_set_id: item for item in graph.criterion_sets
+    }
+    criterion_by_id = {
+        item.criterion_id: item for item in graph.criteria
+    }
+    scale_by_id = {
+        item.scoring_scale_id: item for item in graph.scoring_scales
+    }
+
+    required_set_ids = set(activity.criterion_set_ids)
+    for score_record in graph.score_records:
+        criterion = criterion_by_id.get(score_record.criterion_id)
+        if criterion is None:
+            raise ConcordManifestGenerationIntegrityError(
+                "Score references a missing Criterion."
+            )
+        required_set_ids.add(criterion.criterion_set_id)
+
+    projected_sets_native: list[CriterionSet] = []
+    for set_id in required_set_ids:
+        criterion_set = set_by_id.get(set_id)
+        if criterion_set is None:
+            raise ConcordManifestGenerationIntegrityError(
+                "Activity/Score references a missing Criterion Set."
+            )
+        projected_sets_native.append(criterion_set)
+    projected_sets_native.sort(
+        key=lambda item: (
+            item.lineage_id,
+            item.revision,
+            item.criterion_set_id,
+        )
+    )
+
+    projected_criteria_native: list[Criterion] = []
+    for criterion_set in projected_sets_native:
+        for criterion_id in criterion_set.criterion_ids:
+            criterion = criterion_by_id.get(criterion_id)
+            if criterion is None:
+                raise ConcordManifestGenerationIntegrityError(
+                    "Criterion Set member is missing."
+                )
+            projected_criteria_native.append(criterion)
+
+    used_scale_ids = {
+        score_record.scoring_scale_id for score_record in graph.score_records
+    }
+    projected_scales_native: list[ScoringScale] = []
+    for scale_id in used_scale_ids:
+        scale = scale_by_id.get(scale_id)
+        if scale is None:
+            raise ConcordManifestGenerationIntegrityError(
+                "Score references a missing Scoring Scale."
+            )
+        projected_scales_native.append(scale)
+    projected_scales_native.sort(
+        key=lambda item: (
+            item.lineage_id,
+            item.revision,
+            item.scoring_scale_id,
+        )
+    )
+
+    native_scores = tuple(
+        sorted(graph.score_records, key=lambda item: item.score_record_id)
+    )
+    score_states = _score_current_states(native_scores)
+
+    native_links = tuple(
+        sorted(
+            graph.score_evidence_links,
+            key=lambda item: (
+                item.score_record_id,
+                item.score_evidence_link_id,
+            ),
+        )
+    )
+
+    native_moderation = _required_moderation_records(graph)
+    moderation_states = _moderation_current_states(native_moderation)
+
+    privacy_values: list[PrivacyPolicy] = []
+    if activity.privacy_policy is not None:
+        privacy_values.append(activity.privacy_policy)
+    privacy_values.extend(item.privacy_policy for item in native_scores)
+    privacy_values.extend(item.privacy_policy for item in native_moderation)
+
+    manifest = AcademicResultManifest(
+        record_type=ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+        contract_version=ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+        producer_module_id=CONCORD_MODULE_ID,
+        generated_at=generated_at,
+        record_set=ManifestRecordSet(
+            CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+            revision,
+        ),
+        work=context.work,
+        source_activity=ModuleRecordRef(
+            module_id=CONCORD_MODULE_ID,
+            record_kind=CONCORD_ACTIVITY_RECORD_KIND,
+            record_id=context.work.work_id,
+            contract_version=CONCORD_ACTIVITY_CONTRACT_VERSION,
+        ),
+        projection=ManifestProjection(
+            source_snapshot_revision=context.snapshot_revision,
+            projection_digest_algorithm="sha256",
+            projection_digest="0" * 64,
+            generated_by=_workflow_actor(request.actor),
+            revision_reason=request.revision_reason,
+        ),
+        activity_context=ActivityContextProjection(
+            activity_id=activity.activity_id,
+            class_id=context.work.class_id,
+            title=activity.title,
+            scoring_orientation=activity.scoring_orientation,
+            standards_profile_id=activity.standards_profile_id,
+            focus_standard_ids=activity.focus_standard_ids,
+            criterion_set_ids=activity.criterion_set_ids,
+        ),
+        criterion_sets=tuple(
+            _criterion_set(item) for item in projected_sets_native
+        ),
+        criteria=tuple(
+            _criterion(item) for item in projected_criteria_native
+        ),
+        scoring_scales=tuple(
+            _scale(item) for item in projected_scales_native
+        ),
+        scores=tuple(
+            _score(item, score_states) for item in native_scores
+        ),
+        score_evidence_links=tuple(
+            _score_link(item) for item in native_links
+        ),
+        moderation_records=tuple(
+            _moderation(item, moderation_states)
+            for item in native_moderation
+        ),
+        standards_result_projection=tuple(
+            StandardsResultProjection(
+                score_record_id=item.score_record_id,
+                standard_id=cast(str, item.standard_id),
+            )
+            for item in native_scores
+            if item.score_kind == "standard_backed"
+        ),
+        privacy=_resolve_effective_privacy(privacy_values),
+    )
+    return with_semantic_projection_digest(manifest)
+
+
+def build_academic_result_manifest(
+    context: ManifestGenerationContext,
+    request: GenerateAcademicResultManifestRequest,
+    *,
+    revision: int,
+    generated_at: datetime,
+) -> AcademicResultManifest:
+    """Purely build one validated manifest from an immutable loaded context."""
+    if not isinstance(context, ManifestGenerationContext):
+        raise ConcordManifestGenerationValidationError(
+            "context must be a ManifestGenerationContext."
+        )
+    if not isinstance(request, GenerateAcademicResultManifestRequest):
+        raise ConcordManifestGenerationValidationError(
+            "request must be a GenerateAcademicResultManifestRequest."
+        )
+    if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
+        raise ConcordManifestGenerationValidationError(
+            "revision must be a positive integer."
+        )
+    if (
+        not isinstance(generated_at, datetime)
+        or generated_at.tzinfo is None
+        or generated_at.utcoffset() is None
+    ):
+        raise ConcordManifestGenerationValidationError(
+            "generated_at must be timezone-aware."
+        )
+    try:
+        return _build_manifest(
+            context,
+            request,
+            revision=revision,
+            generated_at=generated_at,
+        )
+    except ConcordAcademicResultManifestValidationError as error:
+        raise ConcordManifestGenerationValidationError(str(error)) from error
+
+
+def academic_result_manifest_relative_path(
+    work: ModuleWorkRef,
+    revision: int,
+) -> str:
+    if not isinstance(work, ModuleWorkRef) or work.module_id != CONCORD_MODULE_ID:
+        raise ConcordManifestGenerationValidationError(
+            "work must identify Concord."
+        )
+    if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
+        raise ConcordManifestGenerationValidationError(
+            "revision must be positive."
+        )
+    relative = (
+        f"classes/{work.class_id}/modules/{work.module_id}/work/"
+        f"{work.work_id}/{_RECORD_SET_RELATIVE_DIR}/{revision}.json"
+    )
+    try:
+        return validate_publication_manifest_path(work, relative)
+    except Exception as error:
+        raise ConcordManifestGenerationValidationError(
+            "manifest relative path is invalid."
+        ) from error
+
+
+def _manifest_directory(root: Path, work: ModuleWorkRef) -> Path:
+    try:
+        return safe_module_work_descendant(
+            root,
+            work,
+            _RECORD_SET_RELATIVE_DIR,
+        )
+    except Exception as error:
+        raise ConcordManifestGenerationValidationError(
+            "manifest directory is outside the exact Concord work root."
+        ) from error
+
+
+def _canonical_revision_name(name: str) -> int | None:
+    if not name.endswith(".json"):
+        return None
+    stem = name[:-5]
+    if (
+        not stem.isdecimal()
+        or stem == "0"
+        or str(int(stem)) != stem
+    ):
+        return None
+    return int(stem)
+
+
+def _stored_from_bytes(
+    root: Path,
+    work: ModuleWorkRef,
+    revision: int,
+    path: Path,
+    content: bytes,
+) -> StoredAcademicResultManifest:
+    try:
+        manifest = academic_result_manifest_from_bytes(content)
+    except Exception as error:
+        raise ConcordManifestGenerationIntegrityError(
+            f"Manifest revision {revision} is invalid."
+        ) from error
+    relative = academic_result_manifest_relative_path(work, revision)
+    if (
+        manifest.work != work
+        or manifest.record_set.record_set_id
+        != CONCORD_ACADEMIC_RESULT_RECORD_SET_ID
+        or manifest.record_set.revision != revision
+        or path.name != f"{revision}.json"
+    ):
+        raise ConcordManifestGenerationIntegrityError(
+            f"Manifest revision {revision} disagrees with its series/path."
+        )
+    expected_path = root.joinpath(*relative.split("/"))
+    try:
+        if path.resolve(strict=True) != expected_path.resolve(strict=True):
+            raise ConcordManifestGenerationIntegrityError(
+                "Manifest path resolves differently from its canonical path."
+            )
+    except FileNotFoundError as error:
+        raise ConcordManifestGenerationNotFoundError(
+            f"Manifest revision {revision} disappeared."
+        ) from error
+    except (OSError, RuntimeError) as error:
+        raise ConcordManifestGenerationIntegrityError(
+            "Manifest path could not be safely resolved."
+        ) from error
+    return StoredAcademicResultManifest(
+        manifest=manifest,
+        revision=revision,
+        path=path,
+        relative_path=relative,
+        content=content,
+        sha256=hashlib.sha256(content).hexdigest(),
+    )
+
+
+def _load_history(
+    root: Path,
+    work: ModuleWorkRef,
+    *,
+    allow_lock: bool,
+) -> tuple[StoredAcademicResultManifest, ...]:
+    directory = _manifest_directory(root, work)
+    if not directory.exists():
+        return ()
+    if directory.is_symlink() or not directory.is_dir():
+        raise ConcordManifestGenerationIntegrityError(
+            "manifest history must be a nonsymlink directory."
+        )
+    try:
+        work_root = directory.parents[2].resolve(strict=True)
+        directory.resolve(strict=True).relative_to(work_root)
+    except (OSError, RuntimeError, ValueError) as error:
+        raise ConcordManifestGenerationIntegrityError(
+            "manifest history escapes the Concord work root."
+        ) from error
+
+    stored: list[StoredAcademicResultManifest] = []
+    try:
+        entries = tuple(directory.iterdir())
+    except OSError as error:
+        raise ConcordManifestGenerationIntegrityError(
+            "manifest history could not be enumerated."
+        ) from error
+
+    revision_entries: list[tuple[int, Path]] = []
+    for entry in entries:
+        if entry.name == _LOCK_NAME:
+            if allow_lock:
+                continue
+            raise ConcordManifestGenerationConflictError(
+                "Manifest generation history is currently locked."
+            )
+        revision = _canonical_revision_name(entry.name)
+        if revision is None:
+            raise ConcordManifestGenerationIntegrityError(
+                "manifest history contains an unexpected entry."
+            )
+        revision_entries.append((revision, entry))
+
+    for revision, entry in sorted(
+        revision_entries, key=lambda item: item[0]
+    ):
+        if entry.is_symlink() or not entry.is_file():
+            raise ConcordManifestGenerationIntegrityError(
+                "manifest revision must be a nonsymlink regular file."
+            )
+        try:
+            content = entry.read_bytes()
+        except OSError as error:
+            raise ConcordManifestGenerationIntegrityError(
+                f"Manifest revision {revision} could not be read."
+            ) from error
+        stored.append(
+            _stored_from_bytes(root, work, revision, entry, content)
+        )
+
+    revisions = tuple(item.revision for item in stored)
+    if revisions:
+        if revisions[0] != 1:
+            raise ConcordManifestGenerationIntegrityError(
+                "manifest history must begin at revision 1."
+            )
+        if tuple(sorted(revisions)) != revisions:
+            raise ConcordManifestGenerationIntegrityError(
+                "manifest revisions must be numerically ordered."
+            )
+        if len(revisions) != len(set(revisions)):
+            raise ConcordManifestGenerationIntegrityError(
+                "manifest history contains duplicate revisions."
+            )
+        for previous, current in zip(revisions, revisions[1:]):
+            if current <= previous:
+                raise ConcordManifestGenerationIntegrityError(
+                    "manifest revisions must strictly increase."
+                )
+    return tuple(stored)
+
+
+def list_academic_result_manifest_revisions(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+) -> tuple[StoredAcademicResultManifest, ...]:
+    root = Path(workspace_root)
+    return _load_history(root, work, allow_lock=False)
+
+
+def load_academic_result_manifest_revision(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+    revision: int,
+) -> StoredAcademicResultManifest:
+    if isinstance(revision, bool) or not isinstance(revision, int) or revision < 1:
+        raise ConcordManifestGenerationValidationError(
+            "revision must be a positive integer."
+        )
+    for stored in list_academic_result_manifest_revisions(
+        workspace_root, work
+    ):
+        if stored.revision == revision:
+            return stored
+    raise ConcordManifestGenerationNotFoundError(
+        f"Academic-result manifest revision {revision} was not found."
+    )
+
+
+def load_academic_result_manifest_head(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+) -> StoredAcademicResultManifest | None:
+    history = list_academic_result_manifest_revisions(
+        workspace_root, work
+    )
+    return history[-1] if history else None
+
+
+def _acquire_lock(directory: Path) -> tuple[int, Path]:
+    try:
+        work_root = directory.parents[2]
+        for candidate in (
+            directory.parents[1],
+            directory.parent,
+            directory,
+        ):
+            if candidate.is_symlink() or (
+                candidate.exists() and not candidate.is_dir()
+            ):
+                raise ConcordManifestGenerationConflictError(
+                    "manifest generation path contains an unsafe entry."
+                )
+            candidate.mkdir(exist_ok=True)
+        directory.resolve(strict=True).relative_to(
+            work_root.resolve(strict=True)
+        )
+    except ConcordManifestGenerationError:
+        raise
+    except (OSError, RuntimeError, ValueError) as error:
+        raise ConcordManifestGenerationWriteError(
+            "Could not establish a contained manifest generation directory."
+        ) from error
+
+    lock_path = directory / _LOCK_NAME
+    try:
+        descriptor = os.open(
+            lock_path,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_BINARY", 0),
+            0o600,
+        )
+    except FileExistsError as error:
+        raise ConcordManifestGenerationConflictError(
+            "Another manifest generation operation holds .write.lock."
+        ) from error
+    except OSError as error:
+        raise ConcordManifestGenerationWriteError(
+            "Could not create the manifest generation lock."
+        ) from error
+    return descriptor, lock_path
+
+
+def _sync_directory(directory: Path) -> None:
+    if os.name == "nt":
+        return
+    descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_new_revision(path: Path, content: bytes) -> None:
+    descriptor: int | None = None
+    created = False
+    durable = False
+    try:
+        descriptor = os.open(
+            path,
+            os.O_WRONLY
+            | os.O_CREAT
+            | os.O_EXCL
+            | getattr(os, "O_BINARY", 0),
+            0o600,
+        )
+        created = True
+        with os.fdopen(descriptor, "wb", closefd=True) as stream:
+            descriptor = None
+            written = stream.write(content)
+            if written != len(content):
+                raise OSError("Manifest revision write was incomplete.")
+            stream.flush()
+            os.fsync(stream.fileno())
+        durable = True
+        _sync_directory(path.parent)
+    except FileExistsError as error:
+        raise ConcordManifestGenerationConflictError(
+            "The planned immutable manifest revision already exists."
+        ) from error
+    except Exception as error:
+        cleanup_error: OSError | None = None
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        if created and not durable:
+            try:
+                path.unlink()
+            except OSError as caught:
+                cleanup_error = caught
+        if durable:
+            raise _DurableRevisionWriteError(
+                "Manifest is durable but directory sync failed."
+            ) from error
+        write_error = ConcordManifestGenerationWriteError(
+            "Could not durably create immutable manifest revision"
+            + (
+                "; incomplete-file cleanup also failed."
+                if cleanup_error is not None
+                else "."
+            )
+        )
+        write_error.incomplete_target_cleanup_failure = cleanup_error
+        raise write_error from error
+
+
+def _prewrite_state_check(
+    root: Path,
+    context: ManifestGenerationContext,
+    request: GenerateAcademicResultManifestRequest,
+) -> None:
+    try:
+        current = load_current_snapshot(root, context.work)
+    except ConcordStorageNotFoundError as error:
+        raise ConcordManifestGenerationConflictError(
+            "Concord current snapshot disappeared before manifest completion."
+        ) from error
+    except ConcordStorageError as error:
+        raise ConcordManifestGenerationIntegrityError(str(error)) from error
+    if (
+        current.snapshot_revision != context.snapshot_revision
+        or current.snapshot_sha256 != context.snapshot_sha256
+        or current.snapshot_revision != request.expected_snapshot_revision
+    ):
+        raise ConcordManifestGenerationConflictError(
+            "Concord native snapshot changed during manifest generation."
+        )
+
+    registration = _registration_for_generation(
+        root, request.class_id, request.activity_id
+    )
+    if registration != context.registration:
+        raise ConcordManifestGenerationConflictError(
+            "Academic Work Registration changed during manifest generation."
+        )
+
+
+def _clock_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def preview_academic_result_manifest(
+    request: GenerateAcademicResultManifestRequest,
+    *,
+    workspace_root: str | Path | None = None,
+    standards_library: StandardsLibrary | None = None,
+    clock: Callable[[], datetime] = _clock_now,
+) -> AcademicResultManifestPreview:
+    """Project generation read-only without acquiring a write lock or writing bytes."""
+    if not isinstance(request, GenerateAcademicResultManifestRequest):
+        raise ConcordManifestGenerationValidationError(
+            "request must be GenerateAcademicResultManifestRequest."
+        )
+    if not callable(clock):
+        raise ConcordManifestGenerationValidationError("clock must be callable.")
+    try:
+        resolved = resolve_read_workspace_root(workspace_root)
+    except Exception as error:
+        raise ConcordManifestGenerationValidationError(str(error)) from error
+    if resolved is None:
+        raise ConcordManifestGenerationNotFoundError(
+            "Paper Data Suite workspace does not exist."
+        )
+    root = Path(resolved)
+    work = ModuleWorkRef(
+        module_id=CONCORD_MODULE_ID,
+        class_id=request.class_id,
+        work_id=request.activity_id,
+    )
+    history = _load_history(root, work, allow_lock=False)
+    context = _load_generation_context(
+        root,
+        request,
+        standards_library=standards_library,
+    )
+    next_revision = 1 if not history else history[-1].revision + 1
+    if not history and request.revision_reason != "initial":
+        raise ConcordManifestGenerationValidationError(
+            "The first producer manifest revision requires "
+            'revision_reason="initial".'
+        )
+    generated_at = clock()
+    if (
+        not isinstance(generated_at, datetime)
+        or generated_at.tzinfo is None
+        or generated_at.utcoffset() is None
+    ):
+        raise ConcordManifestGenerationValidationError(
+            "clock must return a timezone-aware datetime."
+        )
+    candidate = build_academic_result_manifest(
+        context,
+        request,
+        revision=next_revision,
+        generated_at=generated_at,
+    )
+    predecessor = history[-1] if history else None
+    _prewrite_state_check(root, context, request)
+    if (
+        predecessor is not None
+        and predecessor.manifest.projection.projection_digest
+        == candidate.projection.projection_digest
+    ):
+        return AcademicResultManifestPreview(
+            disposition="would_reuse",
+            manifest=predecessor.manifest,
+            revision=predecessor.revision,
+            path=predecessor.path,
+            relative_path=predecessor.relative_path,
+            content=predecessor.content,
+            sha256=predecessor.sha256,
+            registration_revision=context.registration.registration_revision,
+            source_snapshot_revision=context.snapshot_revision,
+        )
+    if history and request.revision_reason == "initial":
+        raise ConcordManifestGenerationValidationError(
+            "A materially changed successor manifest cannot use "
+            'revision_reason="initial".'
+        )
+    content = academic_result_manifest_to_bytes(candidate)
+    relative_path = academic_result_manifest_relative_path(work, next_revision)
+    path = root.joinpath(*relative_path.split("/"))
+    return AcademicResultManifestPreview(
+        disposition="would_create",
+        manifest=candidate,
+        revision=next_revision,
+        path=path,
+        relative_path=relative_path,
+        content=content,
+        sha256=hashlib.sha256(content).hexdigest(),
+        registration_revision=context.registration.registration_revision,
+        source_snapshot_revision=context.snapshot_revision,
+    )
+
+
+def generate_academic_result_manifest(
+    request: GenerateAcademicResultManifestRequest,
+    *,
+    workspace_root: str | Path | None = None,
+    standards_library: StandardsLibrary | None = None,
+    clock: Callable[[], datetime] = _clock_now,
+) -> AcademicResultManifestGenerationResult:
+    """Generate or reuse one immutable producer manifest revision."""
+    if not isinstance(request, GenerateAcademicResultManifestRequest):
+        raise ConcordManifestGenerationValidationError(
+            "request must be GenerateAcademicResultManifestRequest."
+        )
+    if not callable(clock):
+        raise ConcordManifestGenerationValidationError(
+            "clock must be callable."
+        )
+    try:
+        resolved = resolve_read_workspace_root(workspace_root)
+    except Exception as error:
+        raise ConcordManifestGenerationValidationError(str(error)) from error
+    if resolved is None:
+        raise ConcordManifestGenerationNotFoundError(
+            "Paper Data Suite workspace does not exist."
+        )
+    root = Path(resolved)
+    work = ModuleWorkRef(
+        module_id=CONCORD_MODULE_ID,
+        class_id=request.class_id,
+        work_id=request.activity_id,
+    )
+    directory = _manifest_directory(root, work)
+    lock_descriptor, lock_path = _acquire_lock(directory)
+
+    operation_error: BaseException | None = None
+    durable_path: Path | None = None
+    durable_revision: int | None = None
+    expected_digest: str | None = None
+    result_value: AcademicResultManifestGenerationResult | None = None
+    try:
+        os.close(lock_descriptor)
+        history = _load_history(root, work, allow_lock=True)
+        context = _load_generation_context(
+            root,
+            request,
+            standards_library=standards_library,
+        )
+        next_revision = (
+            1 if not history else history[-1].revision + 1
+        )
+        if not history and request.revision_reason != "initial":
+            raise ConcordManifestGenerationValidationError(
+                "The first producer manifest revision requires "
+                'revision_reason="initial".'
+            )
+        generated_at = clock()
+        if (
+            not isinstance(generated_at, datetime)
+            or generated_at.tzinfo is None
+            or generated_at.utcoffset() is None
+        ):
+            raise ConcordManifestGenerationValidationError(
+                "clock must return a timezone-aware datetime."
+            )
+
+        candidate = build_academic_result_manifest(
+            context,
+            request,
+            revision=next_revision,
+            generated_at=generated_at,
+        )
+        predecessor = history[-1] if history else None
+
+        _prewrite_state_check(root, context, request)
+
+        if (
+            predecessor is not None
+            and predecessor.manifest.projection.projection_digest
+            == candidate.projection.projection_digest
+        ):
+            expected_digest = predecessor.sha256
+            durable_path = predecessor.path
+            durable_revision = predecessor.revision
+            result_value = AcademicResultManifestGenerationResult(
+                disposition="existing",
+                manifest=predecessor.manifest,
+                revision=predecessor.revision,
+                path=predecessor.path,
+                relative_path=predecessor.relative_path,
+                content=predecessor.content,
+                sha256=predecessor.sha256,
+                registration_revision=(
+                    context.registration.registration_revision
+                ),
+                source_snapshot_revision=(
+                    predecessor.manifest.projection.source_snapshot_revision
+                ),
+            )
+        else:
+            if history and request.revision_reason == "initial":
+                raise ConcordManifestGenerationValidationError(
+                    "A materially changed successor manifest cannot use "
+                    'revision_reason="initial".'
+                )
+            content = academic_result_manifest_to_bytes(candidate)
+            target = directory / f"{next_revision}.json"
+            relative = academic_result_manifest_relative_path(
+                work, next_revision
+            )
+            expected_digest = hashlib.sha256(content).hexdigest()
+            try:
+                _write_new_revision(target, content)
+            except _DurableRevisionWriteError as error:
+                durable_path = target
+                durable_revision = next_revision
+                state = ManifestGenerationPartialState(
+                    operation="directory_sync",
+                    work=work,
+                    revision=next_revision,
+                    path=target,
+                    relative_path=relative,
+                    expected_sha256=expected_digest,
+                    durable_file_exists=target.exists(),
+                )
+                raise ConcordManifestGenerationPartialSuccessError(
+                    "Manifest revision is durable but directory sync failed.",
+                    state,
+                ) from error
+
+            durable_path = target
+            durable_revision = next_revision
+            try:
+                stored_history = _load_history(
+                    root, work, allow_lock=True
+                )
+                stored = next(
+                    item
+                    for item in stored_history
+                    if item.revision == next_revision
+                )
+                if (
+                    stored.content != content
+                    or stored.manifest != candidate
+                    or stored.sha256 != expected_digest
+                ):
+                    raise ConcordManifestGenerationIntegrityError(
+                        "Durable manifest contradicts generated candidate."
+                    )
+                _prewrite_state_check(root, context, request)
+                result_value = AcademicResultManifestGenerationResult(
+                    disposition="created",
+                    manifest=stored.manifest,
+                    revision=stored.revision,
+                    path=stored.path,
+                    relative_path=stored.relative_path,
+                    content=stored.content,
+                    sha256=stored.sha256,
+                    registration_revision=(
+                        context.registration.registration_revision
+                    ),
+                    source_snapshot_revision=context.snapshot_revision,
+                )
+            except ConcordManifestGenerationError:
+                raise
+            except Exception as error:
+                state = ManifestGenerationPartialState(
+                    operation="generate",
+                    work=work,
+                    revision=next_revision,
+                    path=target,
+                    relative_path=relative,
+                    expected_sha256=expected_digest,
+                    durable_file_exists=target.exists(),
+                )
+                raise ConcordManifestGenerationPartialSuccessError(
+                    "Manifest is durable but final verification failed.",
+                    state,
+                ) from error
+        assert result_value is not None
+        return result_value
+    except ConcordManifestGenerationError as error:
+        operation_error = error
+        raise
+    except Exception as error:
+        normalized = ConcordManifestGenerationIntegrityError(
+            "Manifest generation failed during validation or projection."
+        )
+        operation_error = normalized
+        raise normalized from error
+    except BaseException as error:
+        operation_error = error
+        raise
+    finally:
+        try:
+            lock_path.unlink()
+        except OSError as cleanup_error:
+            cleanup_failure = ManifestGenerationCleanupFailure(
+                path=lock_path,
+                relative_path=(
+                    academic_result_manifest_relative_path(work, 1)
+                    .rsplit("/", 1)[0]
+                    + f"/{_LOCK_NAME}"
+                ),
+                message=str(cleanup_error),
+                error=cleanup_error,
+            )
+            if operation_error is None:
+                if durable_path is not None and durable_revision is not None:
+                    state = ManifestGenerationPartialState(
+                        operation="lock_cleanup",
+                        work=work,
+                        revision=durable_revision,
+                        path=durable_path,
+                        relative_path=academic_result_manifest_relative_path(
+                            work, durable_revision
+                        ),
+                        expected_sha256=expected_digest,
+                        durable_file_exists=durable_path.exists(),
+                        lock_cleanup_failure=cleanup_failure,
+                    )
+                    raise ConcordManifestGenerationPartialSuccessError(
+                        "Manifest is durable but generation lock cleanup failed.",
+                        state,
+                    ) from cleanup_error
+                write_error = ConcordManifestGenerationWriteError(
+                    "Manifest generation lock cleanup failed."
+                )
+                write_error._record_lock_cleanup_failure(cleanup_failure)
+                raise write_error from cleanup_error
+            if isinstance(operation_error, ConcordManifestGenerationError):
+                operation_error._record_lock_cleanup_failure(cleanup_failure)
+                if isinstance(
+                    operation_error,
+                    ConcordManifestGenerationPartialSuccessError,
+                ):
+                    object.__setattr__(
+                        operation_error.state,
+                        "lock_cleanup_failure",
+                        cleanup_failure,
+                    )
+
+
+def _manifest_summary(
+    *,
+    manifest: AcademicResultManifest,
+    revision: int,
+    registration_revision: int,
+    source_snapshot_revision: int,
+    relative_path: str,
+    sha256: str,
+) -> dict[str, object]:
+    scores = manifest.scores
+    current_count = sum(item.current_state == "current" for item in scores)
+    standard_count = sum(item.score_kind == "standard_backed" for item in scores)
+    non_score_count = sum(item.disposition != "scored" for item in scores)
+    score_by_id = {score.score_record_id: score for score in scores}
+    moderated_score_ids = {
+        item.score_record_id
+        for item in manifest.score_evidence_links
+        if (
+            item.moderation_record_id is not None
+            and score_by_id[item.score_record_id].disposition == "scored"
+        )
+    }
+    return {
+        "work": manifest.work,
+        "registration_revision": registration_revision,
+        "source_snapshot_revision": source_snapshot_revision,
+        "record_set_id": manifest.record_set.record_set_id,
+        "record_set_revision": revision,
+        "manifest_contract_version": manifest.contract_version,
+        "score_count": len(scores),
+        "current_score_count": current_count,
+        "historical_score_count": len(scores) - current_count,
+        "standard_backed_score_count": standard_count,
+        "local_score_count": len(scores) - standard_count,
+        "non_score_count": non_score_count,
+        "moderation_dependent_count": len(moderated_score_ids),
+        "capabilities": derive_manifest_capabilities(manifest),
+        "manifest_path": relative_path,
+        "manifest_sha256": sha256,
+        "privacy_classification": manifest.privacy.classification,
+    }
+
+
+def manifest_preview_summary(
+    preview: AcademicResultManifestPreview,
+) -> dict[str, object]:
+    """Return the compact publication-safe summary of a read-only preview."""
+    if not isinstance(preview, AcademicResultManifestPreview):
+        raise ConcordManifestGenerationValidationError(
+            "preview must be AcademicResultManifestPreview."
+        )
+    result = _manifest_summary(
+        manifest=preview.manifest,
+        revision=preview.revision,
+        registration_revision=preview.registration_revision,
+        source_snapshot_revision=preview.source_snapshot_revision,
+        relative_path=preview.relative_path,
+        sha256=preview.sha256,
+    )
+    return {"disposition": preview.disposition, **result}
+
+
+def manifest_generation_summary(
+    result: AcademicResultManifestGenerationResult,
+) -> dict[str, object]:
+    """Return a compact privacy-safe summary of a generated/reused manifest."""
+    if not isinstance(result, AcademicResultManifestGenerationResult):
+        raise ConcordManifestGenerationValidationError(
+            "result must be AcademicResultManifestGenerationResult."
+        )
+    summary = _manifest_summary(
+        manifest=result.manifest,
+        revision=result.revision,
+        registration_revision=result.registration_revision,
+        source_snapshot_revision=result.source_snapshot_revision,
+        relative_path=result.relative_path,
+        sha256=result.sha256,
+    )
+    return {"disposition": result.disposition, **summary}
+
+
+__all__ = [
+    "AcademicResultManifestGenerationResult",
+    "AcademicResultManifestPreview",
+    "ConcordManifestGenerationConflictError",
+    "ConcordManifestGenerationError",
+    "ConcordManifestGenerationIntegrityError",
+    "ConcordManifestGenerationNotFoundError",
+    "ConcordManifestGenerationPartialSuccessError",
+    "ConcordManifestGenerationValidationError",
+    "ConcordManifestGenerationWriteError",
+    "GenerateAcademicResultManifestRequest",
+    "ManifestGenerationCleanupFailure",
+    "ManifestGenerationContext",
+    "ManifestGenerationDisposition",
+    "ManifestGenerationPartialState",
+    "ManifestPreviewDisposition",
+    "StoredAcademicResultManifest",
+    "academic_result_manifest_relative_path",
+    "build_academic_result_manifest",
+    "generate_academic_result_manifest",
+    "list_academic_result_manifest_revisions",
+    "load_academic_result_manifest_head",
+    "load_academic_result_manifest_revision",
+    "manifest_generation_summary",
+    "manifest_preview_summary",
+    "preview_academic_result_manifest",
+]

--- a/concord/academic_result_publication.py
+++ b/concord/academic_result_publication.py
@@ -1,0 +1,2092 @@
+"""Explicit Core publication workflows for Concord academic-result manifests.
+
+Concord owns manifest generation, producer revision policy, and educational
+semantics. Core owns canonical Publication Records, identifiers, timestamps,
+registry persistence, and idempotency reconciliation. This module deliberately
+writes no Core registry JSON and no catalog rows directly.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Final, Literal, NoReturn
+
+from pds_core.academic_catalog import (
+    AcademicCatalogBuildError,
+    AcademicCatalogBuildResult,
+    AcademicCatalogCompatibilityError,
+    AcademicCatalogConflictError,
+    AcademicCatalogError,
+    AcademicCatalogIntegrityError,
+    AcademicCatalogNotFoundError,
+    AcademicCatalogReadError,
+    AcademicCatalogSourceError,
+    AcademicCatalogValidationError,
+    CatalogPublication,
+    PublicationCatalogQuery,
+    PublicationCatalogState,
+    load_academic_catalog_metadata,
+    query_publication_catalog,
+    rebuild_academic_catalog,
+)
+from pds_core.academic_work_registration_storage import (
+    AcademicWorkRegistrationIntegrityError,
+    AcademicWorkRegistrationNotFoundError,
+    AcademicWorkRegistrationReadError,
+    AcademicWorkRegistrationStorageError,
+    load_academic_work_registration_revision,
+)
+from pds_core.academic_work_registrations import AcademicWorkRegistration
+from pds_core.publication_compatibility import (
+    PublicationCompatibilityError,
+    PublicationCompatibilityResult,
+    evaluate_publication_compatibility,
+)
+from pds_core.publication_records import (
+    PublicationCapability,
+    PublicationRecord,
+    PublicationRecordError,
+    PublicationWithdrawal,
+    validate_publication_record_series,
+)
+from pds_core.publication_storage import (
+    PublicationManifestError,
+    PublicationManifestIntegrityError,
+    PublicationManifestNotFoundError,
+    PublicationStorageError,
+    get_current_publication_record,
+    list_publication_record_set,
+    verify_publication_manifest,
+)
+from pds_core.registry_services import (
+    PublicationManifestRequest,
+    PublicationServiceResult,
+    PublicationWithdrawalRequest,
+    PublicationWithdrawalServiceResult,
+    RegistryServiceConflictError,
+    RegistryServiceError,
+    RegistryServiceIntegrityError,
+    RegistryServiceNotFoundError,
+    RegistryServicePartialSuccessError,
+    RegistryServiceValidationError,
+    RegistryServiceWriteError,
+    get_canonical_publication_record,
+    get_canonical_publication_withdrawal,
+    publish_manifest_revision,
+    supersede_manifest_revision,
+    withdraw_publication,
+)
+from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef
+from pds_core.standards import StandardsLibrary
+
+from concord.academic_result_manifest import (
+    ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+    AcademicResultManifest,
+    derive_manifest_capabilities,
+)
+from concord.academic_result_manifest_generation import (
+    AcademicResultManifestGenerationResult,
+    ConcordManifestGenerationConflictError,
+    ConcordManifestGenerationError,
+    ConcordManifestGenerationIntegrityError,
+    ConcordManifestGenerationNotFoundError,
+    ConcordManifestGenerationPartialSuccessError,
+    ConcordManifestGenerationValidationError,
+    ConcordManifestGenerationWriteError,
+    GenerateAcademicResultManifestRequest,
+    ManifestGenerationPartialState,
+    StoredAcademicResultManifest,
+    academic_result_manifest_relative_path,
+    generate_academic_result_manifest,
+    list_academic_result_manifest_revisions,
+    load_academic_result_manifest_revision,
+)
+from concord.academic_work_registration import (
+    ConcordAcademicWorkRegistrationError,
+    ConcordAcademicWorkRegistrationIntegrityError,
+    ConcordAcademicWorkRegistrationNotFoundError,
+    ConcordAcademicWorkRegistrationValidationError,
+    load_current_concord_academic_work_registration,
+)
+from concord.pds_contract import (
+    CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+    CONCORD_ACADEMIC_WORK_CONTRACT_VERSION,
+    CONCORD_ACADEMIC_WORK_KIND,
+    CONCORD_ACTIVITY_CONTRACT_VERSION,
+    CONCORD_ACTIVITY_RECORD_KIND,
+    CONCORD_MODULE_ID,
+)
+from concord.pds_publication import get_publication_producer_profile
+from concord.workflows.context import resolve_read_workspace_root
+
+CONCORD_ACADEMIC_RESULT_PUBLICATION_KIND: Final[Literal["academic_result_set"]] = (
+    "academic_result_set"
+)
+
+PublicationDisposition = Literal["created", "existing"]
+PublicationOperation = Literal[
+    "publish",
+    "supersede",
+    "withdraw",
+    "republish_after_withdrawal",
+]
+WithdrawalManifestVerification = Literal[
+    "verified",
+    "missing",
+    "digest_mismatch_or_unsafe",
+    "unreadable",
+]
+PublicationCanonicalState = Literal[
+    "producer_only",
+    "uncertain",
+    "confirmed",
+]
+
+
+class ConcordAcademicResultPublicationError(Exception):
+    """Base error for Concord's Core publication boundary."""
+
+
+class ConcordAcademicResultPublicationValidationError(
+    ConcordAcademicResultPublicationError, ValueError
+):
+    """The requested publication operation is malformed or inapplicable."""
+
+
+class ConcordAcademicResultPublicationNotFoundError(
+    ConcordAcademicResultPublicationError
+):
+    """Required producer or canonical state does not exist."""
+
+
+class ConcordAcademicResultPublicationConflictError(
+    ConcordAcademicResultPublicationError
+):
+    """Caller expectations conflict with current immutable state."""
+
+
+class ConcordAcademicResultPublicationIntegrityError(
+    ConcordAcademicResultPublicationError
+):
+    """Producer, registration, or canonical state is contradictory."""
+
+
+class ConcordAcademicResultPublicationWriteError(
+    ConcordAcademicResultPublicationError
+):
+    """Core publication state could not be completed or read safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationPartialSuccessState:
+    """Durable state known when publication completion becomes uncertain."""
+
+    operation: PublicationOperation
+    canonical_state: PublicationCanonicalState
+    manifest_generation: AcademicResultManifestGenerationResult | None
+    generation_partial_state: ManifestGenerationPartialState | None
+    publication: PublicationRecord | None
+    recommended_next_action: str
+    withdrawal: PublicationWithdrawal | None = None
+    catalog_rebuild_attempted: bool = False
+    catalog_replacement_completed: bool = False
+    catalog_verification_completed: bool = False
+    catalog_build: AcademicCatalogBuildResult | None = None
+    catalog_error: Exception | None = None
+    withdrawal_manifest_verification: WithdrawalManifestVerification | None = None
+
+    def __post_init__(self) -> None:
+        if self.operation not in {
+            "publish",
+            "supersede",
+            "withdraw",
+            "republish_after_withdrawal",
+        }:
+            raise ValueError("operation is not a supported publication transition.")
+        if self.canonical_state not in {
+            "producer_only",
+            "uncertain",
+            "confirmed",
+        }:
+            raise ValueError("canonical_state is invalid.")
+        if self.manifest_generation is not None and not isinstance(
+            self.manifest_generation,
+            AcademicResultManifestGenerationResult,
+        ):
+            raise TypeError(
+                "manifest_generation must be an "
+                "AcademicResultManifestGenerationResult or None."
+            )
+        if self.generation_partial_state is not None and not isinstance(
+            self.generation_partial_state,
+            ManifestGenerationPartialState,
+        ):
+            raise TypeError(
+                "generation_partial_state must be a "
+                "ManifestGenerationPartialState or None."
+            )
+        if self.publication is not None and not isinstance(
+            self.publication, PublicationRecord
+        ):
+            raise TypeError("publication must be a PublicationRecord or None.")
+        if self.withdrawal is not None and not isinstance(
+            self.withdrawal, PublicationWithdrawal
+        ):
+            raise TypeError("withdrawal must be a PublicationWithdrawal or None.")
+        if (
+            not isinstance(self.recommended_next_action, str)
+            or not self.recommended_next_action
+        ):
+            raise ValueError("recommended_next_action must be nonempty.")
+        if self.canonical_state == "producer_only" and self.publication is not None:
+            raise ValueError(
+                "producer_only partial state must not claim a Core publication."
+            )
+        for name in (
+            "catalog_rebuild_attempted",
+            "catalog_replacement_completed",
+            "catalog_verification_completed",
+        ):
+            if not isinstance(getattr(self, name), bool):
+                raise TypeError(f"{name} must be Boolean.")
+        if self.catalog_replacement_completed and not self.catalog_rebuild_attempted:
+            raise ValueError("catalog replacement requires a rebuild attempt.")
+        if (
+            self.catalog_verification_completed
+            and not self.catalog_replacement_completed
+        ):
+            raise ValueError("catalog verification requires replacement completion.")
+        if self.catalog_replacement_completed and self.catalog_build is None:
+            raise ValueError("completed catalog replacement requires its build result.")
+        if self.catalog_build is not None and not isinstance(
+            self.catalog_build, AcademicCatalogBuildResult
+        ):
+            raise TypeError("catalog_build must be AcademicCatalogBuildResult or None.")
+        if self.catalog_error is not None and not isinstance(
+            self.catalog_error, Exception
+        ):
+            raise TypeError("catalog_error must be an Exception or None.")
+        if (
+            self.withdrawal_manifest_verification is not None
+            and self.withdrawal_manifest_verification
+            not in {
+                "verified",
+                "missing",
+                "digest_mismatch_or_unsafe",
+                "unreadable",
+            }
+        ):
+            raise ValueError("withdrawal_manifest_verification is invalid.")
+
+
+class ConcordAcademicResultPublicationPartialSuccessError(
+    ConcordAcademicResultPublicationError
+):
+    """Producer/Core state is durable but the operation needs reconciliation."""
+
+    def __init__(
+        self,
+        message: str,
+        state: PublicationPartialSuccessState,
+    ) -> None:
+        super().__init__(message)
+        self.state = state
+
+
+@dataclass(frozen=True, slots=True)
+class PublicationCatalogReconciliation:
+    """One rebuilt Core catalog plus the exact reconciled Concord row."""
+
+    build: AcademicCatalogBuildResult
+    publication: CatalogPublication
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.build, AcademicCatalogBuildResult):
+            raise TypeError("build must be an AcademicCatalogBuildResult.")
+        if not isinstance(self.publication, CatalogPublication):
+            raise TypeError("publication must be a CatalogPublication.")
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultPublicationResult:
+    """Verified Core publication of one exact Concord manifest revision."""
+
+    disposition: PublicationDisposition
+    publication: PublicationRecord
+    registration: AcademicWorkRegistration
+    compatibility: PublicationCompatibilityResult
+    catalog: PublicationCatalogReconciliation
+    manifest_generation: AcademicResultManifestGenerationResult
+
+    def __post_init__(self) -> None:
+        if self.disposition not in {"created", "existing"}:
+            raise ValueError("disposition must be created or existing.")
+        if not isinstance(self.publication, PublicationRecord):
+            raise TypeError("publication must be a PublicationRecord.")
+        if not isinstance(self.registration, AcademicWorkRegistration):
+            raise TypeError("registration must be an AcademicWorkRegistration.")
+        if not isinstance(self.compatibility, PublicationCompatibilityResult):
+            raise TypeError(
+                "compatibility must be a PublicationCompatibilityResult."
+            )
+        if not isinstance(self.catalog, PublicationCatalogReconciliation):
+            raise TypeError("catalog must be a PublicationCatalogReconciliation.")
+        if not isinstance(
+            self.manifest_generation,
+            AcademicResultManifestGenerationResult,
+        ):
+            raise TypeError(
+                "manifest_generation must be an "
+                "AcademicResultManifestGenerationResult."
+            )
+        if self.publication.record_set_revision != self.manifest_generation.revision:
+            raise ValueError(
+                "publication and manifest_generation revisions must agree."
+            )
+        if self.catalog.publication.publication_id != self.publication.publication_id:
+            raise ValueError("catalog row must belong to publication.")
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultWithdrawalResult:
+    """Verified explicit withdrawal of one Concord Core publication."""
+
+    disposition: PublicationDisposition
+    publication: PublicationRecord
+    withdrawal: PublicationWithdrawal
+    catalog: PublicationCatalogReconciliation
+    manifest_verification: WithdrawalManifestVerification
+
+    def __post_init__(self) -> None:
+        if self.disposition not in {"created", "existing"}:
+            raise ValueError("disposition must be created or existing.")
+        if not isinstance(self.publication, PublicationRecord):
+            raise TypeError("publication must be a PublicationRecord.")
+        if not isinstance(self.withdrawal, PublicationWithdrawal):
+            raise TypeError("withdrawal must be a PublicationWithdrawal.")
+        if not isinstance(self.catalog, PublicationCatalogReconciliation):
+            raise TypeError("catalog must be a PublicationCatalogReconciliation.")
+        if self.withdrawal.publication_id != self.publication.publication_id:
+            raise ValueError("withdrawal must belong to publication.")
+        if self.catalog.publication.publication_id != self.publication.publication_id:
+            raise ValueError("catalog row must belong to publication.")
+        if self.manifest_verification not in {
+            "verified",
+            "missing",
+            "digest_mismatch_or_unsafe",
+            "unreadable",
+        }:
+            raise ValueError("manifest_verification is invalid.")
+
+
+@dataclass(frozen=True, slots=True)
+class ConcordPublicationSeriesState:
+    """Presentation-neutral reconciliation of one Concord publication series."""
+
+    work: ModuleWorkRef
+    producer_revisions: tuple[int, ...]
+    producer_head: StoredAcademicResultManifest | None
+    publications: tuple[PublicationRecord, ...]
+    withdrawals: tuple[PublicationWithdrawal, ...]
+    core_head: PublicationRecord | None
+    core_head_withdrawal: PublicationWithdrawal | None
+    current_selectable_publication: PublicationRecord | None
+    current_registration: AcademicWorkRegistration | None
+    catalog_available: bool
+    catalog_rows: tuple[CatalogPublication, ...]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.work, ModuleWorkRef):
+            raise TypeError("work must be a ModuleWorkRef.")
+        object.__setattr__(self, "producer_revisions", tuple(self.producer_revisions))
+        object.__setattr__(self, "publications", tuple(self.publications))
+        object.__setattr__(self, "withdrawals", tuple(self.withdrawals))
+        object.__setattr__(self, "catalog_rows", tuple(self.catalog_rows))
+        if any(
+            isinstance(item, bool) or not isinstance(item, int) or item < 1
+            for item in self.producer_revisions
+        ):
+            raise TypeError("producer_revisions must contain positive integers.")
+        if tuple(sorted(set(self.producer_revisions))) != self.producer_revisions:
+            raise ValueError("producer_revisions must be unique and ascending.")
+        if (self.producer_head is None) != (not self.producer_revisions):
+            raise ValueError("producer_head presence must agree with revisions.")
+        if (
+            self.producer_head is not None
+            and self.producer_head.revision != self.producer_revisions[-1]
+        ):
+            raise ValueError("producer_head must be the greatest producer revision.")
+        if any(
+            not isinstance(item, PublicationRecord) for item in self.publications
+        ):
+            raise TypeError("publications must contain PublicationRecord values.")
+        if any(
+            not isinstance(item, PublicationWithdrawal)
+            for item in self.withdrawals
+        ):
+            raise TypeError("withdrawals must contain PublicationWithdrawal values.")
+        if any(not isinstance(item, CatalogPublication) for item in self.catalog_rows):
+            raise TypeError("catalog_rows must contain CatalogPublication values.")
+        publication_ids = {item.publication_id for item in self.publications}
+        withdrawal_ids = tuple(item.publication_id for item in self.withdrawals)
+        if len(set(withdrawal_ids)) != len(withdrawal_ids):
+            raise ValueError("withdrawals must not contain duplicate publication IDs.")
+        if not set(withdrawal_ids).issubset(publication_ids):
+            raise ValueError("withdrawals must belong to this publication series.")
+        expected_head = _series_head(self.publications)
+        if self.core_head != expected_head:
+            raise ValueError("core_head disagrees with the supersession chain.")
+        if self.core_head_withdrawal is not None and (
+            self.core_head is None
+            or self.core_head_withdrawal.publication_id
+            != self.core_head.publication_id
+        ):
+            raise ValueError("core_head_withdrawal must belong to core_head.")
+        expected_selectable = (
+            self.core_head
+            if self.core_head is not None and self.core_head_withdrawal is None
+            else None
+        )
+        if self.current_selectable_publication != expected_selectable:
+            raise ValueError("current selectable publication disagrees with Core.")
+        if self.current_registration is not None and (
+            not isinstance(self.current_registration, AcademicWorkRegistration)
+            or self.current_registration.work != self.work
+        ):
+            raise ValueError("current_registration must belong to work.")
+        if not isinstance(self.catalog_available, bool):
+            raise TypeError("catalog_available must be Boolean.")
+        if not self.catalog_available and self.catalog_rows:
+            raise ValueError("catalog rows require an available catalog.")
+
+    @property
+    def current_registration_revision(self) -> int | None:
+        return (
+            None
+            if self.current_registration is None
+            else self.current_registration.registration_revision
+        )
+
+    @property
+    def producer_head_revision(self) -> int | None:
+        return None if self.producer_head is None else self.producer_head.revision
+
+    @property
+    def producer_head_projection_digest(self) -> str | None:
+        return (
+            None
+            if self.producer_head is None
+            else self.producer_head.manifest.projection.projection_digest
+        )
+
+
+def _clock_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _work_identity(class_id: str, activity_id: str) -> ModuleWorkRef:
+    try:
+        return ModuleWorkRef(
+            module_id=CONCORD_MODULE_ID,
+            class_id=class_id,
+            work_id=activity_id,
+        )
+    except Exception as error:
+        raise ConcordAcademicResultPublicationValidationError(
+            "Publication request does not identify safe Concord work."
+        ) from error
+
+
+def _work(request: GenerateAcademicResultManifestRequest) -> ModuleWorkRef:
+    return _work_identity(request.class_id, request.activity_id)
+
+
+def _source_record(work: ModuleWorkRef) -> ModuleRecordRef:
+    try:
+        return ModuleRecordRef(
+            module_id=CONCORD_MODULE_ID,
+            record_kind=CONCORD_ACTIVITY_RECORD_KIND,
+            record_id=work.work_id,
+            contract_version=CONCORD_ACTIVITY_CONTRACT_VERSION,
+        )
+    except Exception as error:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Concord Activity source identity is invalid."
+        ) from error
+
+
+def _raise_generation_error(
+    error: ConcordManifestGenerationError,
+    *,
+    operation: PublicationOperation,
+) -> NoReturn:
+    if isinstance(error, ConcordManifestGenerationPartialSuccessError):
+        raise ConcordAcademicResultPublicationPartialSuccessError(
+            "Producer manifest state may be durable; reconcile manifest generation "
+            "before retrying publication.",
+            PublicationPartialSuccessState(
+                operation=operation,
+                canonical_state="producer_only",
+                manifest_generation=None,
+                generation_partial_state=error.state,
+                publication=None,
+                recommended_next_action=(
+                    "Reconcile the immutable Concord manifest revision, then retry "
+                    "the same publication request."
+                ),
+            ),
+        ) from error
+    if isinstance(error, ConcordManifestGenerationValidationError):
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    if isinstance(error, ConcordManifestGenerationNotFoundError):
+        raise ConcordAcademicResultPublicationNotFoundError(str(error)) from error
+    if isinstance(error, ConcordManifestGenerationConflictError):
+        raise ConcordAcademicResultPublicationConflictError(str(error)) from error
+    if isinstance(error, ConcordManifestGenerationIntegrityError):
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    if isinstance(error, ConcordManifestGenerationWriteError):
+        raise ConcordAcademicResultPublicationWriteError(str(error)) from error
+    raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+
+
+def _current_registration(
+    root: Path,
+    request: GenerateAcademicResultManifestRequest,
+    generation: AcademicResultManifestGenerationResult,
+) -> AcademicWorkRegistration:
+    try:
+        registration = load_current_concord_academic_work_registration(
+            root,
+            request.class_id,
+            request.activity_id,
+        )
+    except ConcordAcademicWorkRegistrationNotFoundError as error:
+        raise ConcordAcademicResultPublicationNotFoundError(str(error)) from error
+    except ConcordAcademicWorkRegistrationValidationError as error:
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    except ConcordAcademicWorkRegistrationIntegrityError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    except ConcordAcademicWorkRegistrationError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    if registration is None:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "The registration used by manifest generation disappeared before "
+            "publication."
+        )
+    expected_source = _source_record(generation.manifest.work)
+    if (
+        registration.registration_revision != generation.registration_revision
+        or registration.work != generation.manifest.work
+        or registration.producer_contract_version
+        != CONCORD_ACADEMIC_WORK_CONTRACT_VERSION
+        or registration.work_kind != CONCORD_ACADEMIC_WORK_KIND
+        or registration.source_records != (expected_source,)
+        or registration.title != generation.manifest.activity_context.title
+    ):
+        raise ConcordAcademicResultPublicationConflictError(
+            "Current Academic Work Registration changed after manifest generation; "
+            "regenerate/reconcile before publication."
+        )
+    return registration
+
+
+def _validate_manifest_identity(
+    manifest: AcademicResultManifest,
+    *,
+    work: ModuleWorkRef,
+    source_record: ModuleRecordRef,
+) -> None:
+    source = manifest.source_activity
+    context = manifest.activity_context
+    if (
+        manifest.work != work
+        or manifest.contract_version != ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION
+        or manifest.record_set.record_set_id
+        != CONCORD_ACADEMIC_RESULT_RECORD_SET_ID
+        or source.module_id != source_record.module_id
+        or source.record_kind != source_record.record_kind
+        or source.record_id != source_record.record_id
+        or source.contract_version != source_record.contract_version
+        or context.activity_id != work.work_id
+        or context.class_id != work.class_id
+    ):
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Concord manifest identity does not agree across work, Activity source, "
+            "and Activity context."
+        )
+
+
+def _manifest_request(
+    generation: AcademicResultManifestGenerationResult,
+    registration: AcademicWorkRegistration,
+) -> PublicationManifestRequest:
+    work = generation.manifest.work
+    source_record = _source_record(work)
+    _validate_manifest_identity(
+        generation.manifest,
+        work=work,
+        source_record=source_record,
+    )
+    capabilities = derive_manifest_capabilities(generation.manifest)
+    try:
+        return PublicationManifestRequest(
+            work=work,
+            source_record=source_record,
+            publication_kind=CONCORD_ACADEMIC_RESULT_PUBLICATION_KIND,
+            capabilities=capabilities,
+            record_set_id=CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+            record_set_revision=generation.revision,
+            manifest_contract_version=ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+            manifest_path=generation.relative_path,
+            academic_work_registration_revision=(
+                registration.registration_revision
+            ),
+            expected_manifest_digest=generation.sha256,
+        )
+    except RegistryServiceValidationError as error:
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    except Exception as error:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Could not construct the exact Core Publication Manifest request."
+        ) from error
+
+
+def _raise_core_error(
+    error: RegistryServiceError,
+    generation: AcademicResultManifestGenerationResult,
+    *,
+    operation: PublicationOperation,
+) -> NoReturn:
+    if isinstance(error, RegistryServicePartialSuccessError):
+        raise ConcordAcademicResultPublicationPartialSuccessError(
+            "Core publication may be durable but canonical completion is uncertain.",
+            PublicationPartialSuccessState(
+                operation=operation,
+                canonical_state="uncertain",
+                manifest_generation=generation,
+                generation_partial_state=None,
+                publication=error.state.publication,
+                recommended_next_action=(
+                    "Reload Core canonical publication state and reconcile the same "
+                    "logical producer revision before attempting a different action."
+                ),
+            ),
+        ) from error
+    if isinstance(error, RegistryServiceValidationError):
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    if isinstance(error, RegistryServiceNotFoundError):
+        raise ConcordAcademicResultPublicationNotFoundError(str(error)) from error
+    if isinstance(error, RegistryServiceConflictError):
+        raise ConcordAcademicResultPublicationConflictError(str(error)) from error
+    if isinstance(error, RegistryServiceIntegrityError):
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    if isinstance(error, RegistryServiceWriteError):
+        raise ConcordAcademicResultPublicationWriteError(str(error)) from error
+    raise ConcordAcademicResultPublicationWriteError(str(error)) from error
+
+
+def _referenced_registration(
+    root: Path,
+    publication: PublicationRecord,
+) -> AcademicWorkRegistration:
+    revision = publication.academic_work_registration_revision
+    if revision is None:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Concord academic-result publication is missing its registration revision."
+        )
+    try:
+        return load_academic_work_registration_revision(
+            root,
+            publication.work,
+            revision,
+        )
+    except AcademicWorkRegistrationNotFoundError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Publication references a missing Academic Work Registration revision."
+        ) from error
+    except AcademicWorkRegistrationIntegrityError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    except AcademicWorkRegistrationReadError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    except AcademicWorkRegistrationStorageError as error:
+        raise ConcordAcademicResultPublicationWriteError(str(error)) from error
+
+
+def _verify_publication(
+    root: Path,
+    service: PublicationServiceResult,
+    generation: AcademicResultManifestGenerationResult,
+    *,
+    expected_supersedes_publication_id: str | None,
+) -> tuple[
+    PublicationRecord,
+    AcademicWorkRegistration,
+    PublicationCompatibilityResult,
+]:
+    publication = service.publication
+    if service.withdrawal is not None:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Core publication unexpectedly returned a withdrawal."
+        )
+    try:
+        canonical = get_canonical_publication_record(
+            root, publication.publication_id
+        )
+    except RegistryServiceError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Core publication exists but could not be reloaded canonically."
+        ) from error
+    if canonical != publication:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Core canonical Publication Record differs from the service result."
+        )
+
+    expected_source = _source_record(generation.manifest.work)
+    expected_capabilities = derive_manifest_capabilities(generation.manifest)
+    _validate_manifest_identity(
+        generation.manifest,
+        work=canonical.work,
+        source_record=expected_source,
+    )
+    if (
+        canonical.work != generation.manifest.work
+        or canonical.source_record != expected_source
+        or canonical.publication_kind
+        != CONCORD_ACADEMIC_RESULT_PUBLICATION_KIND
+        or canonical.capabilities != expected_capabilities
+        or canonical.record_set_id != CONCORD_ACADEMIC_RESULT_RECORD_SET_ID
+        or canonical.record_set_revision != generation.revision
+        or canonical.manifest_contract_version
+        != ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION
+        or canonical.manifest_path != generation.relative_path
+        or canonical.manifest_digest_algorithm != "sha256"
+        or canonical.manifest_digest != generation.sha256
+        or canonical.academic_work_registration_revision
+        != generation.registration_revision
+        or canonical.supersedes_publication_id
+        != expected_supersedes_publication_id
+    ):
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Core Publication Record does not exactly bind the Concord producer "
+            "manifest and Activity registration."
+        )
+
+    try:
+        verify_publication_manifest(root, canonical)
+    except PublicationManifestNotFoundError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Published Concord manifest disappeared after Core publication."
+        ) from error
+    except PublicationManifestIntegrityError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    except PublicationManifestError as error:
+        raise ConcordAcademicResultPublicationWriteError(str(error)) from error
+
+    registration = _referenced_registration(root, canonical)
+    if (
+        registration.registration_revision != generation.registration_revision
+        or registration.work != canonical.work
+        or registration.producer_contract_version
+        != CONCORD_ACADEMIC_WORK_CONTRACT_VERSION
+        or registration.work_kind != CONCORD_ACADEMIC_WORK_KIND
+        or registration.source_records != (expected_source,)
+        or registration.title != generation.manifest.activity_context.title
+    ):
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Referenced Academic Work Registration does not match the exact "
+            "Concord publication contract."
+        )
+
+    try:
+        compatibility = evaluate_publication_compatibility(
+            canonical,
+            get_publication_producer_profile(),
+            registration,
+        )
+    except PublicationCompatibilityError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    if not compatibility.compatible:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Core reports the Concord publication as "
+            "contract-incompatible: " + ", ".join(compatibility.codes)
+        )
+    return canonical, registration, compatibility
+
+
+def _post_core_partial(
+    error: ConcordAcademicResultPublicationError,
+    generation: AcademicResultManifestGenerationResult,
+    publication: PublicationRecord,
+    *,
+    operation: PublicationOperation,
+) -> NoReturn:
+    raise ConcordAcademicResultPublicationPartialSuccessError(
+        "Core publication is durable but Concord post-write verification failed.",
+        PublicationPartialSuccessState(
+            operation=operation,
+            canonical_state="confirmed",
+            manifest_generation=generation,
+            generation_partial_state=None,
+            publication=publication,
+            recommended_next_action=(
+                "Reconcile this exact Core publication and producer manifest before "
+                "creating, superseding, or withdrawing another publication."
+            ),
+        ),
+    ) from error
+
+
+def _validate_canonical_publication_record(
+    publication: PublicationRecord,
+    *,
+    expected_work: ModuleWorkRef,
+) -> PublicationRecord:
+    if not isinstance(publication, PublicationRecord):
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Canonical publication has the wrong model type."
+        )
+    source_record = _source_record(expected_work)
+    try:
+        expected_path = academic_result_manifest_relative_path(
+            expected_work,
+            publication.record_set_revision,
+        )
+    except ConcordManifestGenerationError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Canonical publication has an invalid producer revision."
+        ) from error
+    if (
+        publication.work != expected_work
+        or publication.source_record != source_record
+        or publication.publication_kind
+        != CONCORD_ACADEMIC_RESULT_PUBLICATION_KIND
+        or publication.record_set_id != CONCORD_ACADEMIC_RESULT_RECORD_SET_ID
+        or publication.manifest_contract_version
+        != ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION
+        or publication.manifest_path != expected_path
+    ):
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Canonical publication contradicts Concord's exact producer contract."
+        )
+    supported = get_publication_producer_profile().publication_contracts[0]
+    if not set(publication.capabilities).issubset(
+        supported.supported_capabilities
+    ):
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Canonical publication advertises a capability outside Concord's profile."
+        )
+    return publication
+
+
+def _load_series(
+    root: Path,
+    work: ModuleWorkRef,
+) -> tuple[PublicationRecord, ...]:
+    try:
+        records = list_publication_record_set(
+            root,
+            work,
+            CONCORD_ACADEMIC_RESULT_PUBLICATION_KIND,
+            CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+        )
+    except PublicationStorageError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    for publication in records:
+        _validate_canonical_publication_record(
+            publication,
+            expected_work=work,
+        )
+    try:
+        return validate_publication_record_series(records)
+    except PublicationRecordError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+
+
+def _series_head(
+    records: tuple[PublicationRecord, ...],
+) -> PublicationRecord | None:
+    if not records:
+        return None
+    superseded = {
+        item.supersedes_publication_id
+        for item in records
+        if item.supersedes_publication_id is not None
+    }
+    heads = tuple(
+        item for item in records if item.publication_id not in superseded
+    )
+    if len(heads) != 1:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Canonical Concord publication series does not have exactly one head."
+        )
+    return heads[0]
+
+
+class _CatalogReconciliationFailure(Exception):
+    def __init__(
+        self,
+        error: Exception,
+        *,
+        build: AcademicCatalogBuildResult | None,
+    ) -> None:
+        super().__init__(str(error))
+        self.error = error
+        self.build = build
+
+
+def _catalog_query(
+    work: ModuleWorkRef,
+    *,
+    required_capabilities: tuple[PublicationCapability, ...] = (),
+    state: PublicationCatalogState = "all",
+) -> PublicationCatalogQuery:
+    try:
+        return PublicationCatalogQuery(
+            class_id=work.class_id,
+            module_id=work.module_id,
+            work_id=work.work_id,
+            publication_kind=CONCORD_ACADEMIC_RESULT_PUBLICATION_KIND,
+            required_capabilities=required_capabilities,
+            record_set_id=CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+            state=state,
+        )
+    except AcademicCatalogValidationError as error:
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+
+
+def _raise_catalog_error(error: AcademicCatalogError) -> NoReturn:
+    if isinstance(error, AcademicCatalogValidationError):
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    if isinstance(error, AcademicCatalogNotFoundError):
+        raise ConcordAcademicResultPublicationNotFoundError(str(error)) from error
+    if isinstance(error, AcademicCatalogConflictError):
+        raise ConcordAcademicResultPublicationConflictError(str(error)) from error
+    if isinstance(
+        error,
+        (
+            AcademicCatalogSourceError,
+            AcademicCatalogIntegrityError,
+            AcademicCatalogCompatibilityError,
+            AcademicCatalogReadError,
+        ),
+    ):
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    if isinstance(error, AcademicCatalogBuildError):
+        raise ConcordAcademicResultPublicationWriteError(str(error)) from error
+    raise ConcordAcademicResultPublicationWriteError(str(error)) from error
+
+
+def _status_current_registration(
+    root: Path,
+    work: ModuleWorkRef,
+) -> AcademicWorkRegistration | None:
+    try:
+        registration = load_current_concord_academic_work_registration(
+            root,
+            work.class_id,
+            work.work_id,
+        )
+    except ConcordAcademicWorkRegistrationNotFoundError:
+        return None
+    except ConcordAcademicWorkRegistrationValidationError as error:
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    except ConcordAcademicWorkRegistrationIntegrityError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    except ConcordAcademicWorkRegistrationError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    if registration is None:
+        return None
+    expected_source = _source_record(work)
+    if (
+        registration.work != work
+        or registration.producer_contract_version
+        != CONCORD_ACADEMIC_WORK_CONTRACT_VERSION
+        or registration.work_kind != CONCORD_ACADEMIC_WORK_KIND
+        or registration.source_records != (expected_source,)
+    ):
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Current Academic Work Registration contradicts Concord's contract."
+        )
+    return registration
+
+
+def _load_withdrawals(
+    root: Path,
+    records: tuple[PublicationRecord, ...],
+) -> tuple[PublicationWithdrawal, ...]:
+    withdrawals: list[PublicationWithdrawal] = []
+    for publication in records:
+        try:
+            withdrawal = get_canonical_publication_withdrawal(
+                root,
+                publication.publication_id,
+            )
+        except RegistryServiceError as error:
+            raise ConcordAcademicResultPublicationIntegrityError(
+                "Could not load canonical Concord withdrawal state."
+            ) from error
+        if withdrawal is not None:
+            withdrawals.append(withdrawal)
+    return tuple(withdrawals)
+
+
+def _catalog_record_values(row: CatalogPublication) -> tuple[object, ...]:
+    return (
+        row.work,
+        row.source_record,
+        row.publication_kind,
+        row.capabilities,
+        row.record_set_id,
+        row.record_set_revision,
+        row.manifest_contract_version,
+        row.manifest_path,
+        row.manifest_digest_algorithm,
+        row.manifest_digest,
+        row.published_at,
+        row.academic_work_registration_revision,
+        row.supersedes_publication_id,
+    )
+
+
+def _canonical_record_values(publication: PublicationRecord) -> tuple[object, ...]:
+    return (
+        publication.work,
+        publication.source_record,
+        publication.publication_kind,
+        publication.capabilities,
+        publication.record_set_id,
+        publication.record_set_revision,
+        publication.manifest_contract_version,
+        publication.manifest_path,
+        publication.manifest_digest_algorithm,
+        publication.manifest_digest,
+        publication.published_at,
+        publication.academic_work_registration_revision,
+        publication.supersedes_publication_id,
+    )
+
+
+def _validate_catalog_rows_against_canonical(
+    root: Path,
+    records: tuple[PublicationRecord, ...],
+    withdrawals: tuple[PublicationWithdrawal, ...],
+    rows: tuple[CatalogPublication, ...],
+    current_registration: AcademicWorkRegistration | None,
+) -> None:
+    publication_by_id = {item.publication_id: item for item in records}
+    row_by_id = {item.publication_id: item for item in rows}
+    if len(row_by_id) != len(rows):
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Core academic catalog contains duplicate Concord publication rows."
+        )
+    if set(row_by_id) != set(publication_by_id):
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Core academic catalog does not cover the exact canonical Concord series."
+        )
+    withdrawal_by_id = {item.publication_id: item for item in withdrawals}
+    head = _series_head(records)
+    for publication_id, publication in publication_by_id.items():
+        row = row_by_id[publication_id]
+        withdrawal = withdrawal_by_id.get(publication_id)
+        referenced_registration = _referenced_registration(root, publication)
+        expected_head = head is not None and head.publication_id == publication_id
+        expected_withdrawn = withdrawal is not None
+        expected_current_revision = (
+            None
+            if current_registration is None
+            else current_registration.registration_revision
+        )
+        expected_current_lifecycle = (
+            None if current_registration is None else current_registration.lifecycle
+        )
+        if (
+            _catalog_record_values(row) != _canonical_record_values(publication)
+            or row.referenced_registration_lifecycle
+            != referenced_registration.lifecycle
+            or row.current_registration_revision != expected_current_revision
+            or row.current_registration_lifecycle != expected_current_lifecycle
+            or row.is_series_head != expected_head
+            or row.is_withdrawn != expected_withdrawn
+            or row.withdrawn_at
+            != (None if withdrawal is None else withdrawal.withdrawn_at)
+            or row.is_current_selectable
+            != (expected_head and not expected_withdrawn)
+        ):
+            raise ConcordAcademicResultPublicationIntegrityError(
+                "Core academic catalog row disagrees with canonical Concord state."
+            )
+
+
+def _reconcile_publication_catalog(
+    root: Path,
+    work: ModuleWorkRef,
+    publication: PublicationRecord,
+) -> PublicationCatalogReconciliation:
+    try:
+        build = rebuild_academic_catalog(root)
+    except AcademicCatalogError as error:
+        raise _CatalogReconciliationFailure(error, build=None) from error
+    try:
+        rows = query_publication_catalog(root, _catalog_query(work, state="all"))
+        records = _load_series(root, work)
+        withdrawals = _load_withdrawals(root, records)
+        current_registration = _status_current_registration(root, work)
+        _validate_catalog_rows_against_canonical(
+            root,
+            records,
+            withdrawals,
+            rows,
+            current_registration,
+        )
+        matches = tuple(
+            row for row in rows if row.publication_id == publication.publication_id
+        )
+        if len(matches) != 1:
+            raise ConcordAcademicResultPublicationIntegrityError(
+                "Rebuilt catalog does not contain exactly one target publication row."
+            )
+        return PublicationCatalogReconciliation(
+            build=build,
+            publication=matches[0],
+        )
+    except Exception as error:
+        raise _CatalogReconciliationFailure(error, build=build) from error
+
+
+def _raise_catalog_partial(
+    failure: _CatalogReconciliationFailure,
+    *,
+    operation: PublicationOperation,
+    generation: AcademicResultManifestGenerationResult | None,
+    publication: PublicationRecord,
+    withdrawal: PublicationWithdrawal | None = None,
+    withdrawal_manifest_verification: WithdrawalManifestVerification | None = None,
+) -> NoReturn:
+    raise ConcordAcademicResultPublicationPartialSuccessError(
+        "Canonical Core state is durable but catalog reconciliation failed.",
+        PublicationPartialSuccessState(
+            operation=operation,
+            canonical_state="confirmed",
+            manifest_generation=generation,
+            generation_partial_state=None,
+            publication=publication,
+            withdrawal=withdrawal,
+            recommended_next_action=(
+                "Replay the exact operation or rebuild the Core academic catalog; "
+                "do not create a duplicate publication."
+            ),
+            catalog_rebuild_attempted=True,
+            catalog_replacement_completed=failure.build is not None,
+            catalog_verification_completed=False,
+            catalog_build=failure.build,
+            catalog_error=failure.error,
+            withdrawal_manifest_verification=(
+                withdrawal_manifest_verification
+            ),
+        ),
+    ) from failure.error
+
+
+def _stored_manifest_for_publication(
+    root: Path,
+    publication: PublicationRecord,
+) -> StoredAcademicResultManifest:
+    try:
+        stored = load_academic_result_manifest_revision(
+            root,
+            publication.work,
+            publication.record_set_revision,
+        )
+    except ConcordManifestGenerationNotFoundError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Canonical publication references a missing Concord manifest revision."
+        ) from error
+    except ConcordManifestGenerationError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    source_record = _source_record(publication.work)
+    _validate_manifest_identity(
+        stored.manifest,
+        work=publication.work,
+        source_record=source_record,
+    )
+    if (
+        publication.source_record != source_record
+        or publication.capabilities
+        != derive_manifest_capabilities(stored.manifest)
+        or publication.record_set_revision != stored.revision
+        or publication.manifest_path != stored.relative_path
+        or publication.manifest_digest != stored.sha256
+        or publication.manifest_digest_algorithm != "sha256"
+    ):
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Canonical publication does not exactly bind its Concord manifest."
+        )
+    try:
+        resolved = verify_publication_manifest(root, publication)
+        expected = stored.path.resolve(strict=True)
+    except PublicationManifestNotFoundError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Canonical publication's Concord manifest is missing."
+        ) from error
+    except PublicationManifestIntegrityError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    except PublicationManifestError as error:
+        raise ConcordAcademicResultPublicationWriteError(str(error)) from error
+    except OSError as error:
+        raise ConcordAcademicResultPublicationWriteError(
+            "Could not resolve the immutable Concord manifest path."
+        ) from error
+    if resolved != expected:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Core resolved a different Concord manifest path than producer history."
+        )
+    registration = _referenced_registration(root, publication)
+    if (
+        registration.work != publication.work
+        or registration.producer_contract_version
+        != CONCORD_ACADEMIC_WORK_CONTRACT_VERSION
+        or registration.work_kind != CONCORD_ACADEMIC_WORK_KIND
+        or registration.source_records != (source_record,)
+        or registration.title != stored.manifest.activity_context.title
+    ):
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Canonical publication's referenced registration contradicts its "
+            "Concord manifest."
+        )
+    try:
+        compatibility = evaluate_publication_compatibility(
+            publication,
+            get_publication_producer_profile(),
+            registration,
+        )
+    except PublicationCompatibilityError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    if not compatibility.compatible:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Canonical predecessor is incompatible with Concord's producer profile: "
+            + ", ".join(compatibility.codes)
+        )
+    return stored
+
+
+def _validate_supersession_pair(
+    predecessor: StoredAcademicResultManifest,
+    successor: AcademicResultManifestGenerationResult,
+) -> None:
+    if (
+        predecessor.manifest.work != successor.manifest.work
+        or predecessor.manifest.record_set.record_set_id
+        != CONCORD_ACADEMIC_RESULT_RECORD_SET_ID
+        or successor.manifest.record_set.record_set_id
+        != CONCORD_ACADEMIC_RESULT_RECORD_SET_ID
+    ):
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Producer manifests do not share one Concord publication series."
+        )
+    if successor.revision <= predecessor.revision:
+        raise ConcordAcademicResultPublicationConflictError(
+            "Successor producer revision must be greater than the predecessor revision."
+        )
+    if (
+        successor.manifest.projection.projection_digest
+        == predecessor.manifest.projection.projection_digest
+    ):
+        raise ConcordAcademicResultPublicationConflictError(
+            "Concord's semantic public projection did not materially change."
+        )
+
+
+def query_concord_publication_catalog(
+    class_id: str,
+    activity_id: str,
+    *,
+    required_capabilities: tuple[PublicationCapability, ...] = (),
+    state: PublicationCatalogState = "current",
+    workspace_root: str | Path | None = None,
+) -> tuple[CatalogPublication, ...]:
+    """Query Core's derived catalog for one exact Concord Activity series."""
+    try:
+        resolved = resolve_read_workspace_root(workspace_root)
+    except Exception as error:
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    if resolved is None:
+        raise ConcordAcademicResultPublicationNotFoundError(
+            "Paper Data Suite workspace does not exist."
+        )
+    work = _work_identity(class_id, activity_id)
+    query = _catalog_query(
+        work,
+        required_capabilities=required_capabilities,
+        state=state,
+    )
+    try:
+        return query_publication_catalog(Path(resolved), query)
+    except AcademicCatalogError as error:
+        _raise_catalog_error(error)
+
+
+def load_concord_publication_series_status(
+    class_id: str,
+    activity_id: str,
+    *,
+    workspace_root: str | Path | None = None,
+) -> ConcordPublicationSeriesState:
+    """Reconcile producer, canonical Core, registration, and optional catalog state."""
+    try:
+        resolved = resolve_read_workspace_root(workspace_root)
+    except Exception as error:
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    if resolved is None:
+        raise ConcordAcademicResultPublicationNotFoundError(
+            "Paper Data Suite workspace does not exist."
+        )
+    root = Path(resolved)
+    work = _work_identity(class_id, activity_id)
+    try:
+        history = list_academic_result_manifest_revisions(root, work)
+    except ConcordManifestGenerationValidationError as error:
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    except ConcordManifestGenerationNotFoundError as error:
+        raise ConcordAcademicResultPublicationNotFoundError(str(error)) from error
+    except ConcordManifestGenerationError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+
+    records = _load_series(root, work)
+    for publication in records:
+        _stored_manifest_for_publication(root, publication)
+    withdrawals = _load_withdrawals(root, records)
+    head = _series_head(records)
+    withdrawal_by_id = {item.publication_id: item for item in withdrawals}
+    head_withdrawal = (
+        None if head is None else withdrawal_by_id.get(head.publication_id)
+    )
+    expected_selectable = (
+        head if head is not None and head_withdrawal is None else None
+    )
+    try:
+        selectable = get_current_publication_record(
+            root,
+            work,
+            CONCORD_ACADEMIC_RESULT_PUBLICATION_KIND,
+            CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+        )
+    except PublicationStorageError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    if selectable != expected_selectable:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Core current-selectable publication disagrees with structural head state."
+        )
+    current_registration = _status_current_registration(root, work)
+
+    catalog_available = False
+    rows: tuple[CatalogPublication, ...] = ()
+    try:
+        load_academic_catalog_metadata(root)
+    except AcademicCatalogNotFoundError:
+        pass
+    except AcademicCatalogError as error:
+        _raise_catalog_error(error)
+    else:
+        try:
+            rows = query_publication_catalog(root, _catalog_query(work, state="all"))
+        except AcademicCatalogError as error:
+            _raise_catalog_error(error)
+        _validate_catalog_rows_against_canonical(
+            root,
+            records,
+            withdrawals,
+            rows,
+            current_registration,
+        )
+        catalog_available = True
+
+    return ConcordPublicationSeriesState(
+        work=work,
+        producer_revisions=tuple(item.revision for item in history),
+        producer_head=history[-1] if history else None,
+        publications=records,
+        withdrawals=withdrawals,
+        core_head=head,
+        core_head_withdrawal=head_withdrawal,
+        current_selectable_publication=selectable,
+        current_registration=current_registration,
+        catalog_available=catalog_available,
+        catalog_rows=rows,
+    )
+
+
+def rebuild_concord_publication_catalog(
+    class_id: str,
+    activity_id: str,
+    *,
+    publication_id: str,
+    workspace_root: str | Path | None = None,
+) -> PublicationCatalogReconciliation:
+    """Rebuild Core's full catalog and reconcile one exact Concord publication."""
+    try:
+        resolved = resolve_read_workspace_root(workspace_root)
+    except Exception as error:
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    if resolved is None:
+        raise ConcordAcademicResultPublicationNotFoundError(
+            "Paper Data Suite workspace does not exist."
+        )
+    root = Path(resolved)
+    work = _work_identity(class_id, activity_id)
+    records = _load_series(root, work)
+    publication = next(
+        (item for item in records if item.publication_id == publication_id),
+        None,
+    )
+    if publication is None:
+        raise ConcordAcademicResultPublicationNotFoundError(
+            "Publication ID was not found in the exact Concord series."
+        )
+    try:
+        return _reconcile_publication_catalog(root, work, publication)
+    except _CatalogReconciliationFailure as failure:
+        if isinstance(failure.error, AcademicCatalogError):
+            _raise_catalog_error(failure.error)
+        if isinstance(failure.error, ConcordAcademicResultPublicationError):
+            raise failure.error from failure
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Catalog reconciliation failed after Core rebuilt the catalog."
+        ) from failure.error
+
+
+def rebuild_full_academic_catalog(
+    workspace_root: str | Path,
+) -> AcademicCatalogBuildResult:
+    """Explicitly rebuild Core's complete disposable academic catalog."""
+    try:
+        return rebuild_academic_catalog(workspace_root)
+    except AcademicCatalogError as error:
+        _raise_catalog_error(error)
+
+
+def _withdrawal_manifest_verification(
+    root: Path,
+    publication: PublicationRecord,
+) -> WithdrawalManifestVerification:
+    try:
+        verify_publication_manifest(root, publication)
+    except PublicationManifestNotFoundError:
+        return "missing"
+    except PublicationManifestIntegrityError:
+        return "digest_mismatch_or_unsafe"
+    except (PublicationManifestError, OSError):
+        return "unreadable"
+    return "verified"
+
+
+def _raise_withdrawal_core_error(
+    error: RegistryServiceError,
+    *,
+    publication: PublicationRecord | None,
+) -> NoReturn:
+    if isinstance(error, RegistryServicePartialSuccessError):
+        raise ConcordAcademicResultPublicationPartialSuccessError(
+            "Core withdrawal may be durable but canonical completion is uncertain.",
+            PublicationPartialSuccessState(
+                operation="withdraw",
+                canonical_state="uncertain",
+                manifest_generation=None,
+                generation_partial_state=None,
+                publication=error.state.publication or publication,
+                withdrawal=error.state.withdrawal,
+                recommended_next_action=(
+                    "Reload the exact Core publication and withdrawal before "
+                    "retrying or publishing a successor."
+                ),
+            ),
+        ) from error
+    if isinstance(error, RegistryServiceValidationError):
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    if isinstance(error, RegistryServiceNotFoundError):
+        raise ConcordAcademicResultPublicationNotFoundError(str(error)) from error
+    if isinstance(error, RegistryServiceConflictError):
+        raise ConcordAcademicResultPublicationConflictError(str(error)) from error
+    if isinstance(error, RegistryServiceIntegrityError):
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    if isinstance(error, RegistryServiceWriteError):
+        raise ConcordAcademicResultPublicationWriteError(str(error)) from error
+    raise ConcordAcademicResultPublicationWriteError(str(error)) from error
+
+
+def _verify_withdrawal_result(
+    root: Path,
+    work: ModuleWorkRef,
+    service: PublicationWithdrawalServiceResult,
+) -> tuple[PublicationRecord, PublicationWithdrawal, WithdrawalManifestVerification]:
+    try:
+        publication = get_canonical_publication_record(
+            root,
+            service.publication.publication_id,
+        )
+        withdrawal = get_canonical_publication_withdrawal(
+            root,
+            service.publication.publication_id,
+        )
+    except RegistryServiceError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Core withdrawal exists but could not be reloaded canonically."
+        ) from error
+    if publication != service.publication or withdrawal != service.withdrawal:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Canonical withdrawal state differs from Core's service result."
+        )
+    _validate_canonical_publication_record(publication, expected_work=work)
+    series = _load_series(root, work)
+    head = _series_head(series)
+    if head is None or head.publication_id != publication.publication_id:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Withdrawal target is no longer the structural Concord series head."
+        )
+    try:
+        selectable = get_current_publication_record(
+            root,
+            work,
+            CONCORD_ACADEMIC_RESULT_PUBLICATION_KIND,
+            CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+        )
+    except PublicationStorageError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    if selectable is not None:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Withdrawing the Concord head unexpectedly selected a predecessor."
+        )
+    return (
+        publication,
+        service.withdrawal,
+        _withdrawal_manifest_verification(root, publication),
+    )
+
+
+def _post_withdrawal_partial(
+    error: ConcordAcademicResultPublicationError,
+    service: PublicationWithdrawalServiceResult,
+) -> NoReturn:
+    raise ConcordAcademicResultPublicationPartialSuccessError(
+        "Core withdrawal is durable but Concord post-write verification failed.",
+        PublicationPartialSuccessState(
+            operation="withdraw",
+            canonical_state="confirmed",
+            manifest_generation=None,
+            generation_partial_state=None,
+            publication=service.publication,
+            withdrawal=service.withdrawal,
+            recommended_next_action=(
+                "Reload this exact Core publication and withdrawal before "
+                "publishing any successor."
+            ),
+        ),
+    ) from error
+
+
+def withdraw_concord_academic_result_publication(
+    class_id: str,
+    activity_id: str,
+    *,
+    publication_id: str,
+    reason: str,
+    workspace_root: str | Path | None = None,
+) -> AcademicResultWithdrawalResult:
+    """Explicitly withdraw the unique structural head of one Concord series."""
+    try:
+        resolved = resolve_read_workspace_root(workspace_root)
+    except Exception as error:
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    if resolved is None:
+        raise ConcordAcademicResultPublicationNotFoundError(
+            "Paper Data Suite workspace does not exist."
+        )
+    root = Path(resolved)
+    work = _work_identity(class_id, activity_id)
+    records = _load_series(root, work)
+    if not records:
+        raise ConcordAcademicResultPublicationNotFoundError(
+            "Concord publication series does not exist."
+        )
+    publication = next(
+        (item for item in records if item.publication_id == publication_id),
+        None,
+    )
+    if publication is None:
+        raise ConcordAcademicResultPublicationConflictError(
+            "Publication ID does not belong to the exact Concord series."
+        )
+    head = _series_head(records)
+    if head is None or head.publication_id != publication.publication_id:
+        raise ConcordAcademicResultPublicationConflictError(
+            "Only the structural Concord series head may be withdrawn here."
+        )
+    try:
+        request = PublicationWithdrawalRequest(
+            publication_id=publication.publication_id,
+            reason=reason,
+        )
+    except (RegistryServiceValidationError, TypeError, ValueError) as error:
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    try:
+        service = withdraw_publication(root, request)
+    except RegistryServiceError as error:
+        _raise_withdrawal_core_error(error, publication=publication)
+    try:
+        publication, withdrawal, manifest_verification = _verify_withdrawal_result(
+            root, work, service
+        )
+    except ConcordAcademicResultPublicationError as error:
+        _post_withdrawal_partial(error, service)
+    try:
+        catalog = _reconcile_publication_catalog(root, work, publication)
+    except _CatalogReconciliationFailure as failure:
+        _raise_catalog_partial(
+            failure,
+            operation="withdraw",
+            generation=None,
+            publication=publication,
+            withdrawal=withdrawal,
+            withdrawal_manifest_verification=manifest_verification,
+        )
+    return AcademicResultWithdrawalResult(
+        disposition=service.disposition,
+        publication=publication,
+        withdrawal=withdrawal,
+        catalog=catalog,
+        manifest_verification=manifest_verification,
+    )
+
+
+def republish_concord_academic_results_after_withdrawal(
+    request: GenerateAcademicResultManifestRequest,
+    *,
+    expected_withdrawn_head_publication_id: str,
+    workspace_root: str | Path | None = None,
+    standards_library: StandardsLibrary | None = None,
+    clock: Callable[[], datetime] = _clock_now,
+) -> AcademicResultPublicationResult:
+    """Publish a corrected successor that explicitly supersedes a withdrawn head."""
+    if not isinstance(request, GenerateAcademicResultManifestRequest):
+        raise ConcordAcademicResultPublicationValidationError(
+            "request must be GenerateAcademicResultManifestRequest."
+        )
+    if (
+        not isinstance(expected_withdrawn_head_publication_id, str)
+        or not expected_withdrawn_head_publication_id
+    ):
+        raise ConcordAcademicResultPublicationValidationError(
+            "expected_withdrawn_head_publication_id must be a nonempty string."
+        )
+    try:
+        resolved = resolve_read_workspace_root(workspace_root)
+    except Exception as error:
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    if resolved is None:
+        raise ConcordAcademicResultPublicationNotFoundError(
+            "Paper Data Suite workspace does not exist."
+        )
+    root = Path(resolved)
+    work = _work(request)
+    records = _load_series(root, work)
+    if not records:
+        raise ConcordAcademicResultPublicationNotFoundError(
+            "Concord publication series does not exist."
+        )
+    withdrawn_record = next(
+        (
+            item
+            for item in records
+            if item.publication_id == expected_withdrawn_head_publication_id
+        ),
+        None,
+    )
+    if withdrawn_record is None:
+        raise ConcordAcademicResultPublicationConflictError(
+            "Expected withdrawn publication does not belong to the Concord series."
+        )
+    try:
+        withdrawal = get_canonical_publication_withdrawal(
+            root,
+            withdrawn_record.publication_id,
+        )
+    except RegistryServiceError as error:
+        _raise_withdrawal_core_error(error, publication=withdrawn_record)
+    if withdrawal is None:
+        raise ConcordAcademicResultPublicationConflictError(
+            "Expected Concord publication is not withdrawn."
+        )
+    head = _series_head(records)
+    if head is None:
+        raise ConcordAcademicResultPublicationNotFoundError(
+            "Concord publication series does not have a structural head."
+        )
+    exact_replay = (
+        head.publication_id != withdrawn_record.publication_id
+        and head.supersedes_publication_id == withdrawn_record.publication_id
+    )
+    if head.publication_id != withdrawn_record.publication_id and not exact_replay:
+        raise ConcordAcademicResultPublicationConflictError(
+            "Expected withdrawn publication is not the current structural head "
+            "or the predecessor of an exact republication replay."
+        )
+    if head.publication_id == withdrawn_record.publication_id:
+        try:
+            selectable = get_current_publication_record(
+                root,
+                work,
+                CONCORD_ACADEMIC_RESULT_PUBLICATION_KIND,
+                CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+            )
+        except PublicationStorageError as error:
+            raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+        if selectable is not None:
+            raise ConcordAcademicResultPublicationIntegrityError(
+                "Withdrawn Concord structural head is unexpectedly selectable."
+            )
+    try:
+        result = supersede_concord_academic_results(
+            request,
+            expected_current_publication_id=withdrawn_record.publication_id,
+            workspace_root=root,
+            standards_library=standards_library,
+            clock=clock,
+        )
+    except ConcordAcademicResultPublicationPartialSuccessError as error:
+        state = error.state
+        raise ConcordAcademicResultPublicationPartialSuccessError(
+            "Corrected republication after withdrawal needs reconciliation.",
+            PublicationPartialSuccessState(
+                operation="republish_after_withdrawal",
+                canonical_state=state.canonical_state,
+                manifest_generation=state.manifest_generation,
+                generation_partial_state=state.generation_partial_state,
+                publication=state.publication,
+                withdrawal=withdrawal,
+                recommended_next_action=state.recommended_next_action,
+                catalog_rebuild_attempted=state.catalog_rebuild_attempted,
+                catalog_replacement_completed=(
+                    state.catalog_replacement_completed
+                ),
+                catalog_verification_completed=(
+                    state.catalog_verification_completed
+                ),
+                catalog_build=state.catalog_build,
+                catalog_error=state.catalog_error,
+                withdrawal_manifest_verification=(
+                    state.withdrawal_manifest_verification
+                ),
+            ),
+        ) from error
+    if (
+        result.publication.record_set_revision
+        <= withdrawn_record.record_set_revision
+        or result.publication.supersedes_publication_id
+        != withdrawn_record.publication_id
+    ):
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Corrected republication did not advance and supersede the withdrawn head."
+        )
+    try:
+        persisted_withdrawal = get_canonical_publication_withdrawal(
+            root,
+            withdrawn_record.publication_id,
+        )
+        selectable = get_current_publication_record(
+            root,
+            work,
+            CONCORD_ACADEMIC_RESULT_PUBLICATION_KIND,
+            CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+        )
+    except RegistryServiceError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    except PublicationStorageError as error:
+        raise ConcordAcademicResultPublicationIntegrityError(str(error)) from error
+    if persisted_withdrawal != withdrawal:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Republication altered the predecessor's immutable withdrawal."
+        )
+    if selectable != result.publication:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Corrected Concord republication is not the current selectable head."
+        )
+    return result
+
+
+def publish_concord_academic_results(
+    request: GenerateAcademicResultManifestRequest,
+    *,
+    workspace_root: str | Path | None = None,
+    standards_library: StandardsLibrary | None = None,
+    clock: Callable[[], datetime] = _clock_now,
+) -> AcademicResultPublicationResult:
+    """Generate/reuse the current producer manifest and publish it first in Core.
+
+    This service intentionally implements only the initial publication transition.
+    A nonempty Core series that requires a successor is a conflict; callers must
+    use supersede_concord_academic_results with the exact expected Core head.
+    """
+    if not isinstance(request, GenerateAcademicResultManifestRequest):
+        raise ConcordAcademicResultPublicationValidationError(
+            "request must be GenerateAcademicResultManifestRequest."
+        )
+    if not callable(clock):
+        raise ConcordAcademicResultPublicationValidationError(
+            "clock must be callable."
+        )
+    try:
+        resolved = resolve_read_workspace_root(workspace_root)
+    except Exception as error:
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    if resolved is None:
+        raise ConcordAcademicResultPublicationNotFoundError(
+            "Paper Data Suite workspace does not exist."
+        )
+    root = Path(resolved)
+    work = _work(request)
+
+    try:
+        generation = generate_academic_result_manifest(
+            request,
+            workspace_root=root,
+            standards_library=standards_library,
+            clock=clock,
+        )
+    except ConcordManifestGenerationError as error:
+        _raise_generation_error(error, operation="publish")
+
+    if generation.manifest.work != work:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Manifest generation returned a different Concord work identity."
+        )
+    registration = _current_registration(root, request, generation)
+    manifest_request = _manifest_request(generation, registration)
+
+    try:
+        service = publish_manifest_revision(root, manifest_request)
+    except RegistryServiceError as error:
+        _raise_core_error(error, generation, operation="publish")
+
+    try:
+        canonical, referenced_registration, compatibility = _verify_publication(
+            root,
+            service,
+            generation,
+            expected_supersedes_publication_id=None,
+        )
+    except ConcordAcademicResultPublicationError as error:
+        _post_core_partial(
+            error,
+            generation,
+            service.publication,
+            operation="publish",
+        )
+
+    try:
+        catalog = _reconcile_publication_catalog(root, work, canonical)
+    except _CatalogReconciliationFailure as failure:
+        _raise_catalog_partial(
+            failure,
+            operation="publish",
+            generation=generation,
+            publication=canonical,
+        )
+
+    return AcademicResultPublicationResult(
+        disposition=service.disposition,
+        publication=canonical,
+        registration=referenced_registration,
+        compatibility=compatibility,
+        catalog=catalog,
+        manifest_generation=generation,
+    )
+
+
+def supersede_concord_academic_results(
+    request: GenerateAcademicResultManifestRequest,
+    *,
+    expected_current_publication_id: str,
+    workspace_root: str | Path | None = None,
+    standards_library: StandardsLibrary | None = None,
+    clock: Callable[[], datetime] = _clock_now,
+) -> AcademicResultPublicationResult:
+    """Explicitly supersede one expected canonical Concord series head.
+
+    The caller must name the exact predecessor Publication Record. An exact replay
+    of a previously completed successor is reconciled idempotently; otherwise a
+    stale or non-head predecessor is rejected before Core is asked to write.
+    """
+    if not isinstance(request, GenerateAcademicResultManifestRequest):
+        raise ConcordAcademicResultPublicationValidationError(
+            "request must be GenerateAcademicResultManifestRequest."
+        )
+    if (
+        not isinstance(expected_current_publication_id, str)
+        or not expected_current_publication_id
+    ):
+        raise ConcordAcademicResultPublicationValidationError(
+            "expected_current_publication_id must be a nonempty string."
+        )
+    if not callable(clock):
+        raise ConcordAcademicResultPublicationValidationError(
+            "clock must be callable."
+        )
+    try:
+        resolved = resolve_read_workspace_root(workspace_root)
+    except Exception as error:
+        raise ConcordAcademicResultPublicationValidationError(str(error)) from error
+    if resolved is None:
+        raise ConcordAcademicResultPublicationNotFoundError(
+            "Paper Data Suite workspace does not exist."
+        )
+    root = Path(resolved)
+    work = _work(request)
+
+    try:
+        generation = generate_academic_result_manifest(
+            request,
+            workspace_root=root,
+            standards_library=standards_library,
+            clock=clock,
+        )
+    except ConcordManifestGenerationError as error:
+        _raise_generation_error(error, operation="supersede")
+    if generation.manifest.work != work:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Manifest generation returned a different Concord work identity."
+        )
+    registration = _current_registration(root, request, generation)
+
+    records = _load_series(root, work)
+    if not records:
+        raise ConcordAcademicResultPublicationNotFoundError(
+            "Publication series does not exist; use first publication."
+        )
+    predecessor_record = next(
+        (
+            item
+            for item in records
+            if item.publication_id == expected_current_publication_id
+        ),
+        None,
+    )
+    if predecessor_record is None:
+        raise ConcordAcademicResultPublicationConflictError(
+            "Expected publication ID does not belong to the Concord series."
+        )
+
+    logical = tuple(
+        item
+        for item in records
+        if item.record_set_revision == generation.revision
+    )
+    if len(logical) > 1:
+        raise ConcordAcademicResultPublicationIntegrityError(
+            "Canonical Concord logical publication revision is duplicated."
+        )
+    if generation.revision <= predecessor_record.record_set_revision:
+        raise ConcordAcademicResultPublicationConflictError(
+            "Concord has no later material producer revision to supersede the "
+            "expected publication."
+        )
+    if logical:
+        replay = logical[0]
+        if replay.supersedes_publication_id != expected_current_publication_id:
+            raise ConcordAcademicResultPublicationIntegrityError(
+                "Existing logical Concord revision has a contradictory predecessor."
+            )
+    else:
+        head = _series_head(records)
+        if head is None:
+            raise ConcordAcademicResultPublicationNotFoundError(
+                "Publication series does not have a canonical head."
+            )
+        if head.publication_id != expected_current_publication_id:
+            raise ConcordAcademicResultPublicationConflictError(
+                "Expected publication ID is not the canonical Concord series head."
+            )
+
+    predecessor = _stored_manifest_for_publication(root, predecessor_record)
+    _validate_supersession_pair(predecessor, generation)
+    manifest_request = _manifest_request(generation, registration)
+
+    try:
+        service = supersede_manifest_revision(
+            root,
+            manifest_request,
+            expected_current_publication_id=expected_current_publication_id,
+        )
+    except RegistryServiceError as error:
+        _raise_core_error(error, generation, operation="supersede")
+
+    try:
+        canonical, referenced_registration, compatibility = _verify_publication(
+            root,
+            service,
+            generation,
+            expected_supersedes_publication_id=(
+                expected_current_publication_id
+            ),
+        )
+        series = _load_series(root, work)
+        if canonical not in series:
+            raise ConcordAcademicResultPublicationIntegrityError(
+                "Superseding publication is absent from its revalidated Core series."
+            )
+    except ConcordAcademicResultPublicationError as error:
+        _post_core_partial(
+            error,
+            generation,
+            service.publication,
+            operation="supersede",
+        )
+
+    try:
+        catalog = _reconcile_publication_catalog(root, work, canonical)
+    except _CatalogReconciliationFailure as failure:
+        _raise_catalog_partial(
+            failure,
+            operation="supersede",
+            generation=generation,
+            publication=canonical,
+        )
+
+    return AcademicResultPublicationResult(
+        disposition=service.disposition,
+        publication=canonical,
+        registration=referenced_registration,
+        compatibility=compatibility,
+        catalog=catalog,
+        manifest_generation=generation,
+    )
+
+
+__all__ = [
+    "AcademicResultPublicationResult",
+    "AcademicResultWithdrawalResult",
+    "CONCORD_ACADEMIC_RESULT_PUBLICATION_KIND",
+    "ConcordAcademicResultPublicationConflictError",
+    "ConcordAcademicResultPublicationError",
+    "ConcordAcademicResultPublicationIntegrityError",
+    "ConcordAcademicResultPublicationNotFoundError",
+    "ConcordAcademicResultPublicationPartialSuccessError",
+    "ConcordAcademicResultPublicationValidationError",
+    "ConcordAcademicResultPublicationWriteError",
+    "ConcordPublicationSeriesState",
+    "PublicationCanonicalState",
+    "PublicationCatalogReconciliation",
+    "PublicationDisposition",
+    "PublicationOperation",
+    "PublicationPartialSuccessState",
+    "WithdrawalManifestVerification",
+    "load_concord_publication_series_status",
+    "publish_concord_academic_results",
+    "query_concord_publication_catalog",
+    "rebuild_concord_publication_catalog",
+    "rebuild_full_academic_catalog",
+    "republish_concord_academic_results_after_withdrawal",
+    "supersede_concord_academic_results",
+    "withdraw_concord_academic_result_publication",
+]

--- a/concord/academic_work_registration.py
+++ b/concord/academic_work_registration.py
@@ -1,0 +1,600 @@
+"""Concord-owned Core Academic Work Registration workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import NoReturn
+
+from pds_core.academic_work_registration_storage import (
+    AcademicWorkRegistrationConflictError as CoreStorageConflictError,
+)
+from pds_core.academic_work_registration_storage import (
+    AcademicWorkRegistrationIntegrityError as CoreStorageIntegrityError,
+)
+from pds_core.academic_work_registration_storage import (
+    AcademicWorkRegistrationNotFoundError as CoreStorageNotFoundError,
+)
+from pds_core.academic_work_registration_storage import (
+    AcademicWorkRegistrationReadError as CoreStorageReadError,
+)
+from pds_core.academic_work_registration_storage import (
+    AcademicWorkRegistrationWriteError as CoreStorageWriteError,
+)
+from pds_core.academic_work_registration_storage import (
+    list_academic_work_registration_revisions,
+    load_academic_work_registration_revision,
+    load_current_academic_work_registration,
+)
+from pds_core.academic_work_registrations import (
+    ACADEMIC_WORK_INTENTS,
+    ACADEMIC_WORK_REGISTRATION_LIFECYCLES,
+    AcademicWorkIntent,
+    AcademicWorkRegistration,
+    AcademicWorkRegistrationLifecycle,
+)
+from pds_core.academic_work_registrations import (
+    AcademicWorkRegistrationValidationError as CoreStorageValidationError,
+)
+from pds_core.registry_services import (
+    AcademicWorkRegistrationRequest,
+    AcademicWorkRegistrationServiceResult,
+    RegistryServiceConflictError,
+    RegistryServiceIntegrityError,
+    RegistryServiceNotFoundError,
+    RegistryServicePartialState,
+    RegistryServicePartialSuccessError,
+    RegistryServiceValidationError,
+    RegistryServiceWriteError,
+    register_academic_work,
+    update_academic_work_registration,
+)
+from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef, RoutingModelError
+from pds_core.workspace import WorkspaceRootError
+
+from concord.models import Activity
+from concord.pds_contract import (
+    CONCORD_ACADEMIC_WORK_CONTRACT_VERSION,
+    CONCORD_ACADEMIC_WORK_KIND,
+    CONCORD_ACTIVITY_CONTRACT_VERSION,
+    CONCORD_ACTIVITY_RECORD_KIND,
+    CONCORD_MODULE_ID,
+)
+from concord.storage import load_current_record, load_current_snapshot
+from concord.storage_errors import (
+    ConcordStorageIntegrityError,
+    ConcordStorageNotFoundError,
+    ConcordStorageReadError,
+    ConcordStorageValidationError,
+)
+from concord.workflows.context import require_core_class, resolve_read_workspace_root
+from concord.workflows.errors import (
+    ConcordWorkflowNotFoundError,
+    ConcordWorkflowValidationError,
+)
+
+SUPPORTED_ACADEMIC_INTENTS: tuple[AcademicWorkIntent, ...] = (
+    "formative",
+    "summative",
+    "diagnostic",
+    "practice",
+    "feedback_only",
+    "reporting_only",
+)
+SUPPORTED_ACADEMIC_WORK_LIFECYCLES: tuple[
+    AcademicWorkRegistrationLifecycle, ...
+] = ("planned", "active", "closed", "cancelled")
+
+
+class ConcordAcademicWorkRegistrationError(Exception):
+    """Base error for Concord's Academic Work Registration boundary."""
+
+
+class ConcordAcademicWorkRegistrationValidationError(
+    ConcordAcademicWorkRegistrationError, ValueError
+):
+    """Caller input or the managed Concord Activity is invalid."""
+
+
+class ConcordAcademicWorkRegistrationNotFoundError(
+    ConcordAcademicWorkRegistrationError
+):
+    """The requested managed Activity or registration does not exist."""
+
+
+class ConcordAcademicWorkRegistrationConflictError(
+    ConcordAcademicWorkRegistrationError
+):
+    """Existing canonical state conflicts with the requested operation."""
+
+
+class ConcordAcademicWorkRegistrationIntegrityError(
+    ConcordAcademicWorkRegistrationError
+):
+    """Concord or Core registration state cannot be reconciled safely."""
+
+
+class ConcordAcademicWorkRegistrationWriteError(
+    ConcordAcademicWorkRegistrationError
+):
+    """Core could not durably complete the requested registration write."""
+
+
+class ConcordAcademicWorkRegistrationPartialSuccessError(
+    ConcordAcademicWorkRegistrationError
+):
+    """Core left durable registration state while completion remained uncertain."""
+
+    def __init__(self, message: str, state: RegistryServicePartialState) -> None:
+        super().__init__(message)
+        self.state = state
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedActivityRegistrationContext:
+    """Validated minimal native Activity snapshot used for Core registration."""
+
+    work: ModuleWorkRef
+    source_record: ModuleRecordRef
+    title: str
+    snapshot_revision: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.work, ModuleWorkRef):
+            raise ConcordAcademicWorkRegistrationValidationError(
+                "work must be a ModuleWorkRef."
+            )
+        if self.work.module_id != CONCORD_MODULE_ID:
+            raise ConcordAcademicWorkRegistrationValidationError(
+                'work.module_id must be exactly "concord".'
+            )
+        if not isinstance(self.source_record, ModuleRecordRef):
+            raise ConcordAcademicWorkRegistrationValidationError(
+                "source_record must be a ModuleRecordRef."
+            )
+        expected_source = _activity_source_record(self.work)
+        if self.source_record != expected_source:
+            raise ConcordAcademicWorkRegistrationValidationError(
+                "source_record must identify the exact versioned Concord Activity."
+            )
+        if not isinstance(self.title, str) or not self.title.strip():
+            raise ConcordAcademicWorkRegistrationValidationError(
+                "title must be nonempty."
+            )
+        if self.title != self.title.strip():
+            raise ConcordAcademicWorkRegistrationValidationError(
+                "title must not contain leading or trailing whitespace."
+            )
+        if (
+            isinstance(self.snapshot_revision, bool)
+            or not isinstance(self.snapshot_revision, int)
+            or self.snapshot_revision < 1
+        ):
+            raise ConcordAcademicWorkRegistrationValidationError(
+                "snapshot_revision must be a positive integer."
+            )
+
+
+def _activity_work(class_id: str, activity_id: str) -> ModuleWorkRef:
+    try:
+        return ModuleWorkRef(
+            module_id=CONCORD_MODULE_ID,
+            class_id=class_id,
+            work_id=activity_id,
+        )
+    except (RoutingModelError, TypeError, ValueError) as error:
+        raise ConcordAcademicWorkRegistrationValidationError(str(error)) from error
+
+
+def _activity_source_record(work: ModuleWorkRef) -> ModuleRecordRef:
+    try:
+        return ModuleRecordRef(
+            module_id=CONCORD_MODULE_ID,
+            record_kind=CONCORD_ACTIVITY_RECORD_KIND,
+            record_id=work.work_id,
+            contract_version=CONCORD_ACTIVITY_CONTRACT_VERSION,
+        )
+    except (RoutingModelError, TypeError, ValueError) as error:
+        raise ConcordAcademicWorkRegistrationValidationError(str(error)) from error
+
+
+def load_managed_activity_registration_context(
+    workspace_root: str | Path,
+    class_id: str,
+    activity_id: str,
+) -> ManagedActivityRegistrationContext:
+    """Load one exact current native Activity without mutating the workspace."""
+    try:
+        root = resolve_read_workspace_root(workspace_root)
+    except WorkspaceRootError as error:
+        raise ConcordAcademicWorkRegistrationValidationError(str(error)) from error
+    if root is None:
+        raise ConcordAcademicWorkRegistrationNotFoundError(
+            "Paper Data Suite workspace does not exist."
+        )
+    try:
+        require_core_class(root, class_id)
+    except ConcordWorkflowValidationError as error:
+        raise ConcordAcademicWorkRegistrationValidationError(str(error)) from error
+    except ConcordWorkflowNotFoundError as error:
+        raise ConcordAcademicWorkRegistrationNotFoundError(str(error)) from error
+
+    work = _activity_work(class_id, activity_id)
+    try:
+        current = load_current_snapshot(root, work)
+        record, _ = load_current_record(
+            root,
+            work,
+            CONCORD_ACTIVITY_RECORD_KIND,
+            activity_id,
+        )
+    except ConcordStorageNotFoundError as error:
+        raise ConcordAcademicWorkRegistrationNotFoundError(
+            f"Concord Activity is not available: {activity_id}"
+        ) from error
+    except ConcordStorageValidationError as error:
+        raise ConcordAcademicWorkRegistrationValidationError(str(error)) from error
+    except (ConcordStorageIntegrityError, ConcordStorageReadError) as error:
+        raise ConcordAcademicWorkRegistrationIntegrityError(str(error)) from error
+
+    if not isinstance(record, Activity):
+        raise ConcordAcademicWorkRegistrationIntegrityError(
+            f"Current Activity record is invalid: {activity_id}"
+        )
+    if record.work_reference != work:
+        raise ConcordAcademicWorkRegistrationIntegrityError(
+            "Current Activity identity disagrees with its canonical work."
+        )
+
+    return ManagedActivityRegistrationContext(
+        work=work,
+        source_record=_activity_source_record(work),
+        title=record.title,
+        snapshot_revision=current.snapshot_revision,
+    )
+
+
+def build_concord_academic_work_registration_request(
+    context: ManagedActivityRegistrationContext,
+    *,
+    academic_intent: AcademicWorkIntent,
+    lifecycle: AcademicWorkRegistrationLifecycle,
+) -> AcademicWorkRegistrationRequest:
+    """Map one validated current Activity snapshot to Core's stable request."""
+    if not isinstance(context, ManagedActivityRegistrationContext):
+        raise ConcordAcademicWorkRegistrationValidationError(
+            "context must be a ManagedActivityRegistrationContext."
+        )
+    if academic_intent not in ACADEMIC_WORK_INTENTS:
+        raise ConcordAcademicWorkRegistrationValidationError(
+            "academic_intent must be one of: "
+            + ", ".join(SUPPORTED_ACADEMIC_INTENTS)
+            + "."
+        )
+    if lifecycle not in ACADEMIC_WORK_REGISTRATION_LIFECYCLES:
+        raise ConcordAcademicWorkRegistrationValidationError(
+            "lifecycle must be one of: "
+            + ", ".join(SUPPORTED_ACADEMIC_WORK_LIFECYCLES)
+            + "."
+        )
+    try:
+        return AcademicWorkRegistrationRequest(
+            work=context.work,
+            producer_contract_version=CONCORD_ACADEMIC_WORK_CONTRACT_VERSION,
+            title=context.title,
+            work_kind=CONCORD_ACADEMIC_WORK_KIND,
+            academic_intent=academic_intent,
+            lifecycle=lifecycle,
+            source_records=(context.source_record,),
+        )
+    except (RegistryServiceValidationError, TypeError, ValueError) as error:
+        raise ConcordAcademicWorkRegistrationValidationError(str(error)) from error
+
+
+def load_current_concord_academic_work_registration(
+    workspace_root: str | Path,
+    class_id: str,
+    activity_id: str,
+) -> AcademicWorkRegistration | None:
+    """Load Core's explicit current registration for one managed Activity."""
+    context = load_managed_activity_registration_context(
+        workspace_root, class_id, activity_id
+    )
+    try:
+        registration = load_current_academic_work_registration(
+            workspace_root, context.work
+        )
+    except Exception as error:
+        _raise_normalized_storage_error(error)
+    if registration is not None:
+        _verify_registration_identity(context, registration)
+    return registration
+
+
+def list_concord_academic_work_registration_revisions(
+    workspace_root: str | Path,
+    class_id: str,
+    activity_id: str,
+) -> tuple[int, ...]:
+    """List exact immutable Core registration revisions for one Activity."""
+    context = load_managed_activity_registration_context(
+        workspace_root, class_id, activity_id
+    )
+    try:
+        revisions = list_academic_work_registration_revisions(
+            workspace_root, context.work
+        )
+    except Exception as error:
+        _raise_normalized_storage_error(error)
+    for revision in revisions:
+        registration = load_concord_academic_work_registration_revision(
+            workspace_root,
+            class_id,
+            activity_id,
+            revision,
+        )
+        _verify_registration_identity(context, registration)
+    return revisions
+
+
+def load_concord_academic_work_registration_revision(
+    workspace_root: str | Path,
+    class_id: str,
+    activity_id: str,
+    registration_revision: int,
+) -> AcademicWorkRegistration:
+    """Load one exact immutable Core registration revision for an Activity."""
+    if (
+        isinstance(registration_revision, bool)
+        or not isinstance(registration_revision, int)
+        or registration_revision < 1
+    ):
+        raise ConcordAcademicWorkRegistrationValidationError(
+            "registration_revision must be a positive integer."
+        )
+    context = load_managed_activity_registration_context(
+        workspace_root, class_id, activity_id
+    )
+    try:
+        registration = load_academic_work_registration_revision(
+            workspace_root,
+            context.work,
+            registration_revision,
+        )
+    except Exception as error:
+        _raise_normalized_storage_error(error)
+    _verify_registration_identity(context, registration)
+    return registration
+
+
+def register_concord_academic_work(
+    workspace_root: str | Path,
+    class_id: str,
+    activity_id: str,
+    *,
+    academic_intent: AcademicWorkIntent,
+    lifecycle: AcademicWorkRegistrationLifecycle,
+) -> AcademicWorkRegistrationServiceResult:
+    """Create registration revision 1 or reconcile the exact existing value."""
+    context = load_managed_activity_registration_context(
+        workspace_root, class_id, activity_id
+    )
+    request = build_concord_academic_work_registration_request(
+        context,
+        academic_intent=academic_intent,
+        lifecycle=lifecycle,
+    )
+    try:
+        result = register_academic_work(workspace_root, request)
+    except Exception as error:
+        _raise_normalized_service_error(error)
+
+    if result.disposition not in {"created", "existing"}:
+        raise ConcordAcademicWorkRegistrationIntegrityError(
+            "Core returned an unexpected registration disposition: "
+            f"{result.disposition}."
+        )
+    if (
+        result.disposition == "created"
+        and result.registration.registration_revision != 1
+    ):
+        raise ConcordAcademicWorkRegistrationIntegrityError(
+            "Initial registration did not create revision 1."
+        )
+    _verify_registration_matches_request(context, request, result.registration)
+    _verify_current(workspace_root, context, result.registration)
+    return result
+
+
+def update_concord_academic_work_registration(
+    workspace_root: str | Path,
+    class_id: str,
+    activity_id: str,
+    *,
+    academic_intent: AcademicWorkIntent,
+    lifecycle: AcademicWorkRegistrationLifecycle,
+    expected_current_revision: int,
+) -> AcademicWorkRegistrationServiceResult:
+    """Explicitly update Core registration metadata with optimistic concurrency."""
+    if (
+        isinstance(expected_current_revision, bool)
+        or not isinstance(expected_current_revision, int)
+        or expected_current_revision < 1
+    ):
+        raise ConcordAcademicWorkRegistrationValidationError(
+            "expected_current_revision must be a positive integer."
+        )
+    context = load_managed_activity_registration_context(
+        workspace_root, class_id, activity_id
+    )
+    request = build_concord_academic_work_registration_request(
+        context,
+        academic_intent=academic_intent,
+        lifecycle=lifecycle,
+    )
+    try:
+        result = update_academic_work_registration(
+            workspace_root,
+            request,
+            expected_current_revision=expected_current_revision,
+        )
+    except Exception as error:
+        _raise_normalized_service_error(error)
+
+    if result.disposition not in {"updated", "existing"}:
+        raise ConcordAcademicWorkRegistrationIntegrityError(
+            "Core returned an unexpected update disposition: "
+            f"{result.disposition}."
+        )
+    _verify_registration_matches_request(context, request, result.registration)
+    _verify_current(workspace_root, context, result.registration)
+    return result
+
+
+def _verify_registration_identity(
+    context: ManagedActivityRegistrationContext,
+    registration: AcademicWorkRegistration,
+) -> None:
+    if not isinstance(registration, AcademicWorkRegistration):
+        raise ConcordAcademicWorkRegistrationIntegrityError(
+            "Core returned an invalid Academic Work Registration."
+        )
+    if registration.work != context.work:
+        raise ConcordAcademicWorkRegistrationIntegrityError(
+            "Registration work does not match the managed Concord Activity."
+        )
+    if (
+        registration.producer_contract_version
+        != CONCORD_ACADEMIC_WORK_CONTRACT_VERSION
+    ):
+        raise ConcordAcademicWorkRegistrationIntegrityError(
+            "Registration producer contract is not Concord academic work v1."
+        )
+    if registration.work_kind != CONCORD_ACADEMIC_WORK_KIND:
+        raise ConcordAcademicWorkRegistrationIntegrityError(
+            "Registration work_kind is not Concord collaborative_activity."
+        )
+    if registration.source_records != (context.source_record,):
+        raise ConcordAcademicWorkRegistrationIntegrityError(
+            "Registration source_records do not identify the exact Concord Activity."
+        )
+
+
+def _verify_registration_matches_request(
+    context: ManagedActivityRegistrationContext,
+    request: AcademicWorkRegistrationRequest,
+    registration: AcademicWorkRegistration,
+) -> None:
+    _verify_registration_identity(context, registration)
+    if (
+        registration.title != request.title
+        or registration.academic_intent != request.academic_intent
+        or registration.lifecycle != request.lifecycle
+    ):
+        raise ConcordAcademicWorkRegistrationIntegrityError(
+            "Core registration does not match the requested Activity metadata."
+        )
+
+
+def _verify_current(
+    workspace_root: str | Path,
+    context: ManagedActivityRegistrationContext,
+    expected: AcademicWorkRegistration,
+) -> None:
+    try:
+        current = load_current_academic_work_registration(
+            workspace_root, context.work
+        )
+    except Exception as error:
+        _raise_normalized_storage_error(error)
+    if current != expected:
+        raise ConcordAcademicWorkRegistrationIntegrityError(
+            "Core's current registration does not equal the service result."
+        )
+
+
+def _raise_normalized_service_error(error: Exception) -> NoReturn:
+    if isinstance(error, RegistryServicePartialSuccessError):
+        raise ConcordAcademicWorkRegistrationPartialSuccessError(
+            str(error), error.state
+        ) from error
+    mappings = (
+        (
+            RegistryServiceValidationError,
+            ConcordAcademicWorkRegistrationValidationError,
+        ),
+        (
+            RegistryServiceNotFoundError,
+            ConcordAcademicWorkRegistrationNotFoundError,
+        ),
+        (
+            RegistryServiceConflictError,
+            ConcordAcademicWorkRegistrationConflictError,
+        ),
+        (
+            RegistryServiceIntegrityError,
+            ConcordAcademicWorkRegistrationIntegrityError,
+        ),
+        (
+            RegistryServiceWriteError,
+            ConcordAcademicWorkRegistrationWriteError,
+        ),
+    )
+    for core_type, concord_type in mappings:
+        if isinstance(error, core_type):
+            raise concord_type(str(error)) from error
+    raise error
+
+
+def _raise_normalized_storage_error(error: Exception) -> NoReturn:
+    mappings = (
+        (
+            CoreStorageValidationError,
+            ConcordAcademicWorkRegistrationValidationError,
+        ),
+        (
+            CoreStorageNotFoundError,
+            ConcordAcademicWorkRegistrationNotFoundError,
+        ),
+        (
+            CoreStorageConflictError,
+            ConcordAcademicWorkRegistrationConflictError,
+        ),
+        (
+            CoreStorageIntegrityError,
+            ConcordAcademicWorkRegistrationIntegrityError,
+        ),
+        (
+            CoreStorageWriteError,
+            ConcordAcademicWorkRegistrationWriteError,
+        ),
+        (
+            CoreStorageReadError,
+            ConcordAcademicWorkRegistrationIntegrityError,
+        ),
+    )
+    for core_type, concord_type in mappings:
+        if isinstance(error, core_type):
+            raise concord_type(str(error)) from error
+    raise error
+
+
+__all__ = [
+    "ConcordAcademicWorkRegistrationConflictError",
+    "ConcordAcademicWorkRegistrationError",
+    "ConcordAcademicWorkRegistrationIntegrityError",
+    "ConcordAcademicWorkRegistrationNotFoundError",
+    "ConcordAcademicWorkRegistrationPartialSuccessError",
+    "ConcordAcademicWorkRegistrationValidationError",
+    "ConcordAcademicWorkRegistrationWriteError",
+    "ManagedActivityRegistrationContext",
+    "SUPPORTED_ACADEMIC_INTENTS",
+    "SUPPORTED_ACADEMIC_WORK_LIFECYCLES",
+    "build_concord_academic_work_registration_request",
+    "list_concord_academic_work_registration_revisions",
+    "load_concord_academic_work_registration_revision",
+    "load_current_concord_academic_work_registration",
+    "load_managed_activity_registration_context",
+    "register_concord_academic_work",
+    "update_concord_academic_work_registration",
+]

--- a/concord/cli_app/handlers/publication.py
+++ b/concord/cli_app/handlers/publication.py
@@ -1,0 +1,357 @@
+"""Direct Academic Publication commands for Concord Activities."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from pds_core.academic_work_registrations import AcademicWorkRegistration
+from pds_core.registry_services import (
+    AcademicWorkRegistrationRequest,
+    update_academic_work_registration,
+)
+from pds_core.routing_models import ModuleWorkRef
+
+from concord.academic_result_manifest_generation import (
+    GenerateAcademicResultManifestRequest,
+    generate_academic_result_manifest,
+    list_academic_result_manifest_revisions,
+    load_academic_result_manifest_revision,
+    manifest_generation_summary,
+    manifest_preview_summary,
+    preview_academic_result_manifest,
+)
+from concord.academic_result_publication import (
+    load_concord_publication_series_status,
+    publish_concord_academic_results,
+    query_concord_publication_catalog,
+    rebuild_concord_publication_catalog,
+    rebuild_full_academic_catalog,
+    republish_concord_academic_results_after_withdrawal,
+    supersede_concord_academic_results,
+    withdraw_concord_academic_result_publication,
+)
+from concord.academic_work_registration import (
+    load_current_concord_academic_work_registration,
+    register_concord_academic_work,
+)
+from concord.cli_app.common import (
+    load_command_standards_library,
+    workflow_actor,
+    workspace_arg,
+)
+from concord.pds_contract import CONCORD_MODULE_ID
+from concord.workflows import show_activity
+from concord.workflows.context import resolve_read_workspace_root
+
+
+def _root(args: argparse.Namespace) -> Path:
+    resolved = resolve_read_workspace_root(workspace_arg(args))
+    if resolved is None:
+        raise FileNotFoundError("Paper Data Suite workspace does not exist.")
+    return Path(resolved)
+
+
+def _work(args: argparse.Namespace) -> ModuleWorkRef:
+    return ModuleWorkRef(CONCORD_MODULE_ID, args.class_id, args.activity_id)
+
+
+def _request(args: argparse.Namespace) -> GenerateAcademicResultManifestRequest:
+    return GenerateAcademicResultManifestRequest(
+        class_id=args.class_id,
+        activity_id=args.activity_id,
+        expected_snapshot_revision=args.expected_snapshot,
+        actor=workflow_actor(args),
+        revision_reason=args.revision_reason,
+    )
+
+
+def _print_registration(registration: AcademicWorkRegistration) -> None:
+    print(f"Work: {registration.work.class_id}/{registration.work.work_id}")
+    print(f"Registration revision: {registration.registration_revision}")
+    print(f"Title: {registration.title}")
+    print(f"Academic intent: {registration.academic_intent}")
+    print(f"Lifecycle: {registration.lifecycle}")
+    print(f"Producer contract: {registration.producer_contract_version}")
+
+
+def _print_summary(summary: dict[str, object]) -> None:
+    work = summary["work"]
+    if isinstance(work, ModuleWorkRef):
+        print(f"Work: {work.class_id}/{work.work_id}")
+    for key, label in (
+        ("disposition", "Disposition"),
+        ("registration_revision", "Registration revision"),
+        ("source_snapshot_revision", "Source snapshot revision"),
+        ("record_set_id", "Record set"),
+        ("record_set_revision", "Record-set revision"),
+        ("manifest_contract_version", "Manifest contract"),
+        ("score_count", "Scores"),
+        ("current_score_count", "Current Scores"),
+        ("historical_score_count", "Historical Scores"),
+        ("standard_backed_score_count", "Standard-backed Scores"),
+        ("local_score_count", "Local Scores"),
+        ("non_score_count", "Non-score records"),
+        ("moderation_dependent_count", "Moderation-dependent Scores"),
+        ("manifest_path", "Manifest path"),
+        ("manifest_sha256", "Manifest SHA-256"),
+    ):
+        if key in summary:
+            print(f"{label}: {summary[key]}")
+    capabilities = summary.get("capabilities")
+    if capabilities is not None:
+        print("Capabilities: " + ", ".join(capabilities))  # type: ignore[arg-type]
+
+
+def handle_register(args: argparse.Namespace) -> int:
+    result = register_concord_academic_work(
+        _root(args),
+        args.class_id,
+        args.activity_id,
+        academic_intent=args.academic_intent,
+        lifecycle=args.lifecycle,
+    )
+    print(f"Disposition: {result.disposition}")
+    _print_registration(result.registration)
+    return 0
+
+
+def handle_registration_show(args: argparse.Namespace) -> int:
+    registration = load_current_concord_academic_work_registration(
+        _root(args), args.class_id, args.activity_id
+    )
+    if registration is None:
+        print("No current Academic Work Registration.")
+        return 0
+    _print_registration(registration)
+    return 0
+
+
+def handle_registration_update(args: argparse.Namespace) -> int:
+    root = _root(args)
+    current = load_current_concord_academic_work_registration(
+        root, args.class_id, args.activity_id
+    )
+    if current is None:
+        raise FileNotFoundError("Academic Work Registration does not exist.")
+    detail = show_activity(
+        args.class_id,
+        args.activity_id,
+        workspace_root=root,
+    )
+    request = AcademicWorkRegistrationRequest(
+        work=current.work,
+        producer_contract_version=current.producer_contract_version,
+        title=detail.summary.title,
+        work_kind=current.work_kind,
+        academic_intent=args.academic_intent,
+        lifecycle=args.lifecycle,
+        source_records=current.source_records,
+    )
+    result = update_academic_work_registration(
+        root,
+        request,
+        expected_current_revision=args.expected_registration_revision,
+    )
+    print(f"Disposition: {result.disposition}")
+    _print_registration(result.registration)
+    return 0
+
+
+def handle_manifest_preview(args: argparse.Namespace) -> int:
+    preview = preview_academic_result_manifest(
+        _request(args),
+        workspace_root=workspace_arg(args),
+        standards_library=load_command_standards_library(args),
+    )
+    _print_summary(manifest_preview_summary(preview))
+    return 0
+
+
+def handle_manifest_generate(args: argparse.Namespace) -> int:
+    result = generate_academic_result_manifest(
+        _request(args),
+        workspace_root=workspace_arg(args),
+        standards_library=load_command_standards_library(args),
+    )
+    _print_summary(manifest_generation_summary(result))
+    return 0
+
+
+def handle_manifest_list(args: argparse.Namespace) -> int:
+    items = list_academic_result_manifest_revisions(_root(args), _work(args))
+    if not items:
+        print("No Concord academic-result manifest revisions.")
+        return 0
+    for item in items:
+        print(
+            f"{item.revision}\t{item.sha256}\t"
+            f"{item.manifest.projection.projection_digest}\t{item.relative_path}"
+        )
+    return 0
+
+
+def handle_manifest_show(args: argparse.Namespace) -> int:
+    stored = load_academic_result_manifest_revision(
+        _root(args), _work(args), args.revision
+    )
+    text = stored.content.decode("utf-8")
+    print(text, end="" if text.endswith("\n") else "\n")
+    return 0
+
+
+def handle_publish(args: argparse.Namespace) -> int:
+    result = publish_concord_academic_results(
+        _request(args),
+        workspace_root=workspace_arg(args),
+        standards_library=load_command_standards_library(args),
+    )
+    print(f"Disposition: {result.disposition}")
+    print(f"Publication: {result.publication.publication_id}")
+    print(f"Record-set revision: {result.publication.record_set_revision}")
+    print(f"Manifest SHA-256: {result.publication.manifest_digest}")
+    return 0
+
+
+def handle_supersede(args: argparse.Namespace) -> int:
+    state = load_concord_publication_series_status(
+        args.class_id,
+        args.activity_id,
+        workspace_root=workspace_arg(args),
+    )
+    if (
+        state.core_head_withdrawal is not None
+        and state.core_head is not None
+        and state.core_head.publication_id == args.expected_current_publication_id
+    ):
+        result = republish_concord_academic_results_after_withdrawal(
+            _request(args),
+            expected_withdrawn_head_publication_id=(
+                args.expected_current_publication_id
+            ),
+            workspace_root=workspace_arg(args),
+            standards_library=load_command_standards_library(args),
+        )
+    else:
+        result = supersede_concord_academic_results(
+            _request(args),
+            expected_current_publication_id=args.expected_current_publication_id,
+            workspace_root=workspace_arg(args),
+            standards_library=load_command_standards_library(args),
+        )
+    print(f"Disposition: {result.disposition}")
+    print(f"Publication: {result.publication.publication_id}")
+    print(f"Supersedes: {result.publication.supersedes_publication_id}")
+    print(f"Record-set revision: {result.publication.record_set_revision}")
+    return 0
+
+
+def handle_withdraw(args: argparse.Namespace) -> int:
+    result = withdraw_concord_academic_result_publication(
+        args.class_id,
+        args.activity_id,
+        publication_id=args.publication_id,
+        reason=args.reason,
+        workspace_root=workspace_arg(args),
+    )
+    print(f"Disposition: {result.disposition}")
+    print(f"Publication: {result.publication.publication_id}")
+    print(f"Withdrawn at: {result.withdrawal.withdrawn_at.isoformat()}")
+    print(f"Manifest verification: {result.manifest_verification}")
+    return 0
+
+
+def handle_series_show(args: argparse.Namespace) -> int:
+    state = load_concord_publication_series_status(
+        args.class_id,
+        args.activity_id,
+        workspace_root=workspace_arg(args),
+    )
+    print(f"Work: {state.work.class_id}/{state.work.work_id}")
+    print(
+        "Producer head: "
+        + (str(state.producer_head.revision) if state.producer_head else "none")
+    )
+    print(
+        "Core structural head: "
+        + (state.core_head.publication_id if state.core_head else "none")
+    )
+    print(
+        "Core head withdrawn: "
+        + ("yes" if state.core_head_withdrawal is not None else "no")
+    )
+    print(
+        "Current selectable publication: "
+        + (
+            state.current_selectable_publication.publication_id
+            if state.current_selectable_publication is not None
+            else "none"
+        )
+    )
+    print(
+        "Current registration revision: "
+        + (
+            str(state.current_registration_revision)
+            if state.current_registration_revision is not None
+            else "none"
+        )
+    )
+    print(f"Catalog available: {'yes' if state.catalog_available else 'no'}")
+    print(f"Catalog rows: {len(state.catalog_rows)}")
+    for publication in state.publications:
+        withdrawal = next(
+            (
+                item
+                for item in state.withdrawals
+                if item.publication_id == publication.publication_id
+            ),
+            None,
+        )
+        print(
+            f"{publication.record_set_revision}\t{publication.publication_id}\t"
+            f"supersedes={publication.supersedes_publication_id or '-'}\t"
+            f"withdrawn={'yes' if withdrawal is not None else 'no'}"
+        )
+    return 0
+
+
+def handle_catalog_list(args: argparse.Namespace) -> int:
+    rows = query_concord_publication_catalog(
+        args.class_id,
+        args.activity_id,
+        required_capabilities=tuple(args.required_capability or ()),
+        state=args.state,
+        workspace_root=workspace_arg(args),
+    )
+    if not rows:
+        print("No matching Concord publication catalog rows.")
+        return 0
+    for row in rows:
+        print(
+            f"{row.record_set_revision}\t{row.publication_id}\t"
+            f"head={'yes' if row.is_series_head else 'no'}\t"
+            f"withdrawn={'yes' if row.is_withdrawn else 'no'}\t"
+            f"current={'yes' if row.is_current_selectable else 'no'}"
+        )
+    return 0
+
+
+def handle_catalog_rebuild(args: argparse.Namespace) -> int:
+    if args.publication_id is None:
+        result = rebuild_full_academic_catalog(_root(args))
+        print(f"Catalog: {result.catalog_path}")
+        print(
+            "Source snapshot SHA-256: "
+            f"{result.metadata.source_snapshot_sha256}"
+        )
+        print(f"Publications: {result.metadata.publication_count}")
+        return 0
+    reconciliation = rebuild_concord_publication_catalog(
+        args.class_id,
+        args.activity_id,
+        publication_id=args.publication_id,
+        workspace_root=workspace_arg(args),
+    )
+    print(f"Publication: {reconciliation.publication.publication_id}")
+    print("Catalog reconciliation: verified")
+    return 0

--- a/concord/cli_app/main.py
+++ b/concord/cli_app/main.py
@@ -9,6 +9,11 @@ from typing import cast
 
 from pds_core.module_dispatch import ModuleDispatchError
 from pds_core.module_profiles import ModuleDiscoveryError, ModuleRegistryError
+from pds_core.registry_services import (
+    RegistryServiceConflictError,
+    RegistryServiceError,
+    RegistryServicePartialSuccessError,
+)
 from pds_core.route_registrations import RouteRegistrationPersistenceError
 from pds_core.scan_failure_metadata import (
     RoutingFailureMetadataReadError,
@@ -20,6 +25,19 @@ from pds_core.scan_resolution_metadata import (
 )
 from pds_core.workspace import WorkspaceRootError
 
+from concord.academic_result_manifest_generation import (
+    ConcordManifestGenerationConflictError,
+    ConcordManifestGenerationError,
+    ConcordManifestGenerationPartialSuccessError,
+)
+from concord.academic_result_publication import (
+    ConcordAcademicResultPublicationConflictError,
+    ConcordAcademicResultPublicationError,
+    ConcordAcademicResultPublicationPartialSuccessError,
+)
+from concord.academic_work_registration import (
+    ConcordAcademicWorkRegistrationError,
+)
 from concord.cli_app.parser import build_parser
 from concord.routing.rendering import RenderPartialSuccessError
 from concord.routing.review import RoutingResolutionPartialSuccessError
@@ -71,6 +89,45 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     try:
         return cast(CommandHandler, handler)(args)
+    except ConcordAcademicResultPublicationPartialSuccessError as error:
+        print(f"Partial success: {error}", file=sys.stderr)
+        print(
+            f"Canonical state: {error.state.canonical_state}",
+            file=sys.stderr,
+        )
+        print(error.state.recommended_next_action, file=sys.stderr)
+        return EXIT_PARTIAL_SUCCESS
+    except ConcordManifestGenerationPartialSuccessError as error:
+        print(f"Partial success: {error}", file=sys.stderr)
+        print(f"Manifest revision: {error.state.revision}", file=sys.stderr)
+        return EXIT_PARTIAL_SUCCESS
+    except RegistryServicePartialSuccessError as error:
+        print(f"Partial success: {error}", file=sys.stderr)
+        return EXIT_PARTIAL_SUCCESS
+    except (
+        ConcordAcademicResultPublicationConflictError,
+        ConcordManifestGenerationConflictError,
+        RegistryServiceConflictError,
+    ) as error:
+        print(f"Conflict: {error}", file=sys.stderr)
+        return EXIT_CONFLICT
+    except ConcordAcademicWorkRegistrationError as error:
+        name = error.__class__.__name__
+        if name.endswith("PartialSuccessError"):
+            print(f"Partial success: {error}", file=sys.stderr)
+            return EXIT_PARTIAL_SUCCESS
+        if name.endswith("ConflictError"):
+            print(f"Conflict: {error}", file=sys.stderr)
+            return EXIT_CONFLICT
+        print(f"Error: {error}", file=sys.stderr)
+        return EXIT_ERROR
+    except (
+        ConcordAcademicResultPublicationError,
+        ConcordManifestGenerationError,
+        RegistryServiceError,
+    ) as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return EXIT_ERROR
     except ArtifactRoutePreparationPartialSuccessError as error:
         print(f"Partial success: {error}", file=sys.stderr)
         print(

--- a/concord/cli_app/parser.py
+++ b/concord/cli_app/parser.py
@@ -9,6 +9,7 @@ from concord.cli_app.handlers import (
     activity,
     artifact,
     group,
+    publication,
     responsibility,
     review_moderation,
     role,
@@ -1332,6 +1333,174 @@ def _scan_commands(
     resolve.set_defaults(handler=scan.handle_review_resolve, command_parser=resolve)
 
 
+def _publication_projection_options(parser: argparse.ArgumentParser) -> None:
+    _workspace_option(parser)
+    _standards_option(parser)
+    _expected_option(parser)
+    _actor_options(parser)
+    _class_activity(parser)
+    parser.add_argument(
+        "--revision-reason",
+        required=True,
+        choices=(
+            "initial",
+            "native_state_change",
+            "evidence_lineage_change",
+            "moderation_change",
+            "projection_correction",
+            "privacy_correction",
+            "contract_migration",
+        ),
+    )
+
+
+def _publication_commands(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    parent = subparsers.add_parser(
+        "publication",
+        help="Register and publish Concord academic-result manifests.",
+    )
+    actions = parent.add_subparsers(dest="publication_command", required=True)
+
+    register = actions.add_parser(
+        "register", help="Register one Activity as explicit Core academic work."
+    )
+    _workspace_option(register)
+    _class_activity(register)
+    register.add_argument(
+        "--academic-intent",
+        required=True,
+        choices=(
+            "formative",
+            "summative",
+            "diagnostic",
+            "practice",
+            "feedback_only",
+            "reporting_only",
+        ),
+    )
+    register.add_argument(
+        "--lifecycle",
+        required=True,
+        choices=("planned", "active", "closed", "cancelled"),
+    )
+    register.set_defaults(handler=publication.handle_register)
+
+    registration_show = actions.add_parser(
+        "registration-show", help="Show the current Core registration."
+    )
+    _workspace_option(registration_show)
+    _class_activity(registration_show)
+    registration_show.set_defaults(handler=publication.handle_registration_show)
+
+    registration_update = actions.add_parser(
+        "registration-update", help="Create an explicit registration revision."
+    )
+    _workspace_option(registration_update)
+    _class_activity(registration_update)
+    registration_update.add_argument(
+        "--expected-registration-revision", type=int, required=True
+    )
+    registration_update.add_argument(
+        "--academic-intent",
+        required=True,
+        choices=(
+            "formative",
+            "summative",
+            "diagnostic",
+            "practice",
+            "feedback_only",
+            "reporting_only",
+        ),
+    )
+    registration_update.add_argument(
+        "--lifecycle",
+        required=True,
+        choices=("planned", "active", "closed", "cancelled"),
+    )
+    registration_update.set_defaults(
+        handler=publication.handle_registration_update
+    )
+
+    preview = actions.add_parser(
+        "manifest-preview", help="Preview generation without writing a manifest."
+    )
+    _publication_projection_options(preview)
+    preview.set_defaults(handler=publication.handle_manifest_preview)
+
+    generate = actions.add_parser(
+        "manifest-generate", help="Generate or reuse the immutable producer head."
+    )
+    _publication_projection_options(generate)
+    generate.set_defaults(handler=publication.handle_manifest_generate)
+
+    manifest_list = actions.add_parser(
+        "manifest-list", help="List immutable producer manifest revisions."
+    )
+    _workspace_option(manifest_list)
+    _class_activity(manifest_list)
+    manifest_list.set_defaults(handler=publication.handle_manifest_list)
+
+    manifest_show = actions.add_parser(
+        "manifest-show", help="Show one exact publication-safe manifest revision."
+    )
+    _workspace_option(manifest_show)
+    _class_activity(manifest_show)
+    manifest_show.add_argument("--revision", type=int, required=True)
+    manifest_show.set_defaults(handler=publication.handle_manifest_show)
+
+    publish = actions.add_parser(
+        "publish", help="Create or reconcile the first Core Publication Record."
+    )
+    _publication_projection_options(publish)
+    publish.set_defaults(handler=publication.handle_publish)
+
+    supersede = actions.add_parser(
+        "supersede", help="Explicitly supersede the expected Core series head."
+    )
+    _publication_projection_options(supersede)
+    supersede.add_argument("--expected-current-publication-id", required=True)
+    supersede.set_defaults(handler=publication.handle_supersede)
+
+    withdraw = actions.add_parser(
+        "withdraw", help="Withdraw one exact Core Publication Record."
+    )
+    _workspace_option(withdraw)
+    _class_activity(withdraw)
+    withdraw.add_argument("--publication-id", required=True)
+    withdraw.add_argument("--reason", required=True)
+    withdraw.set_defaults(handler=publication.handle_withdraw)
+
+    series_show = actions.add_parser(
+        "series-show", help="Show canonical producer/Core publication state."
+    )
+    _workspace_option(series_show)
+    _class_activity(series_show)
+    series_show.set_defaults(handler=publication.handle_series_show)
+
+    catalog_list = actions.add_parser(
+        "catalog-list", help="List derived Core catalog rows for the Activity."
+    )
+    _workspace_option(catalog_list)
+    _class_activity(catalog_list)
+    catalog_list.add_argument(
+        "--state",
+        choices=("current", "series_heads", "historical", "withdrawn", "all"),
+        default="current",
+    )
+    catalog_list.add_argument("--required-capability", action="append")
+    catalog_list.set_defaults(handler=publication.handle_catalog_list)
+
+    catalog_rebuild = actions.add_parser(
+        "catalog-rebuild", help="Rebuild Core's full disposable academic catalog."
+    )
+    _workspace_option(catalog_rebuild)
+    _class_activity(catalog_rebuild)
+    catalog_rebuild.add_argument("--publication-id")
+    catalog_rebuild.set_defaults(handler=publication.handle_catalog_rebuild)
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Build the complete direct-command parser without touching workspace state."""
     parser = argparse.ArgumentParser(
@@ -1359,6 +1528,7 @@ def build_parser() -> argparse.ArgumentParser:
     _criterion_set_commands(subparsers)
     _scale_commands(subparsers)
     _score_commands(subparsers)
+    _publication_commands(subparsers)
     _artifact_commands(subparsers)
     _moderation_commands(subparsers)
     _scan_commands(subparsers)

--- a/concord/menu_activity.py
+++ b/concord/menu_activity.py
@@ -27,6 +27,7 @@ from concord.menu_prompts import (
     show_result,
     slug_identifier,
 )
+from concord.menu_publication import launch_publication_menu
 from concord.menu_responsibility import launch_responsibility_menu
 from concord.menu_role import launch_role_menu
 from concord.menu_scoring import launch_scoring_menu
@@ -476,7 +477,8 @@ def launch_activity_context_menu(
         print("6. Responsibilities")
         print("7. Artifact Pages")
         print("8. Scoring")
-        print("9. Edit Activity")
+        print("9. Publication")
+        print("10. Edit Activity")
         print_navigation()
         print()
         choice = input("Select an option: ").strip()
@@ -502,6 +504,8 @@ def launch_activity_context_menu(
         elif choice == "8":
             launch_scoring_menu(activity, session_state)
         elif choice == "9":
+            launch_publication_menu(activity, session_state)
+        elif choice == "10":
             _edit_activity(activity, session_state)
         else:
             print(navigation_hint_with_help())

--- a/concord/menu_publication.py
+++ b/concord/menu_publication.py
@@ -1,0 +1,665 @@
+"""Teacher-facing Academic Publication workflow for one Concord Activity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pds_core.academic_work_registrations import (
+    AcademicWorkIntent,
+    AcademicWorkRegistrationLifecycle,
+)
+from pds_core.registry_services import (
+    AcademicWorkRegistrationRequest,
+    RegistryServiceConflictError,
+    RegistryServicePartialSuccessError,
+    update_academic_work_registration,
+)
+
+from concord.academic_result_manifest import RevisionReason
+from concord.academic_result_manifest_generation import (
+    AcademicResultManifestPreview,
+    ConcordManifestGenerationConflictError,
+    ConcordManifestGenerationPartialSuccessError,
+    GenerateAcademicResultManifestRequest,
+    generate_academic_result_manifest,
+    manifest_generation_summary,
+    manifest_preview_summary,
+    preview_academic_result_manifest,
+)
+from concord.academic_result_publication import (
+    ConcordAcademicResultPublicationConflictError,
+    ConcordAcademicResultPublicationPartialSuccessError,
+    load_concord_publication_series_status,
+    publish_concord_academic_results,
+    query_concord_publication_catalog,
+    rebuild_full_academic_catalog,
+    republish_concord_academic_results_after_withdrawal,
+    supersede_concord_academic_results,
+    withdraw_concord_academic_result_publication,
+)
+from concord.academic_work_registration import (
+    load_current_concord_academic_work_registration,
+    register_concord_academic_work,
+)
+from concord.menu_context import CancelMenuAction, MenuSessionContext
+from concord.menu_navigation import (
+    ConcordMenuChoice,
+    NavigationChoice,
+    navigation_hint_with_help,
+    parse_menu_navigation,
+)
+from concord.menu_prompts import (
+    confirm_write,
+    load_menu_standards_library,
+    prompt_conflict_reload,
+    prompt_text,
+    select_one,
+    show_result,
+)
+from concord.menu_ui import (
+    clear_screen,
+    pause_for_user,
+    print_menu_header,
+    print_navigation,
+)
+from concord.workflows import ActivitySummary, show_activity
+from concord.workflows.context import resolve_read_workspace_root
+
+_ACADEMIC_INTENTS: tuple[AcademicWorkIntent, ...] = (
+    "formative",
+    "summative",
+    "diagnostic",
+    "practice",
+    "feedback_only",
+    "reporting_only",
+)
+_REGISTRATION_LIFECYCLES: tuple[
+    AcademicWorkRegistrationLifecycle, ...
+] = ("planned", "active", "closed", "cancelled")
+_REVISION_REASONS: tuple[RevisionReason, ...] = (
+    "native_state_change",
+    "evidence_lineage_change",
+    "moderation_change",
+    "projection_correction",
+    "privacy_correction",
+    "contract_migration",
+)
+
+
+def _root() -> Path:
+    resolved = resolve_read_workspace_root()
+    if resolved is None:
+        raise FileNotFoundError("Paper Data Suite workspace does not exist.")
+    return Path(resolved)
+
+
+def _registration_status(activity: ActivitySummary) -> None:
+    registration = load_current_concord_academic_work_registration(
+        _root(), activity.class_id, activity.activity_id
+    )
+    lines = [f"Activity: {activity.title}", f"Work: {activity.activity_id}"]
+    if registration is None:
+        lines.append("Registration: none")
+    else:
+        lines.extend(
+            (
+                f"Registration revision: {registration.registration_revision}",
+                f"Academic intent: {registration.academic_intent}",
+                f"Lifecycle: {registration.lifecycle}",
+                f"Registered title: {registration.title}",
+            )
+        )
+    show_result("Registration Status", tuple(lines))
+
+
+def _choose_registration_values() -> tuple[
+    AcademicWorkIntent, AcademicWorkRegistrationLifecycle
+]:
+    intent = select_one(
+        "Academic Intent",
+        _ACADEMIC_INTENTS,
+        tuple(item.replace("_", " ").title() for item in _ACADEMIC_INTENTS),
+        help_text="Choose the explicit Core academic intent for this Activity.",
+    )
+    lifecycle = select_one(
+        "Registration Lifecycle",
+        _REGISTRATION_LIFECYCLES,
+        tuple(item.title() for item in _REGISTRATION_LIFECYCLES),
+        help_text="Choose the explicit Core lifecycle for this registration.",
+    )
+    return intent, lifecycle
+
+
+def _register(activity: ActivitySummary) -> None:
+    intent, lifecycle = _choose_registration_values()
+    if not confirm_write(
+        "Register Activity",
+        "REGISTER",
+        (
+            f"Activity: {activity.title}",
+            f"Work: {activity.class_id}/{activity.activity_id}",
+            f"Academic intent: {intent}",
+            f"Lifecycle: {lifecycle}",
+        ),
+    ):
+        return
+    result = register_concord_academic_work(
+        _root(),
+        activity.class_id,
+        activity.activity_id,
+        academic_intent=intent,
+        lifecycle=lifecycle,
+    )
+    show_result(
+        "Registration Result",
+        (
+            f"Disposition: {result.disposition}",
+            f"Registration revision: {result.registration.registration_revision}",
+        ),
+    )
+
+
+def _update_registration(activity: ActivitySummary) -> None:
+    root = _root()
+    current = load_current_concord_academic_work_registration(
+        root, activity.class_id, activity.activity_id
+    )
+    if current is None:
+        show_result("Registration Update", ("Register the Activity first.",))
+        return
+    intent, lifecycle = _choose_registration_values()
+    detail = show_activity(
+        activity.class_id, activity.activity_id, workspace_root=root
+    )
+    if not confirm_write(
+        "Update Registration",
+        "REGISTER",
+        (
+            f"Activity: {detail.summary.title}",
+            f"Current registration revision: {current.registration_revision}",
+            f"Academic intent: {intent}",
+            f"Lifecycle: {lifecycle}",
+        ),
+    ):
+        return
+    request = AcademicWorkRegistrationRequest(
+        work=current.work,
+        producer_contract_version=current.producer_contract_version,
+        title=detail.summary.title,
+        work_kind=current.work_kind,
+        academic_intent=intent,
+        lifecycle=lifecycle,
+        source_records=current.source_records,
+    )
+    result = update_academic_work_registration(
+        root,
+        request,
+        expected_current_revision=current.registration_revision,
+    )
+    show_result(
+        "Registration Result",
+        (
+            f"Disposition: {result.disposition}",
+            f"Registration revision: {result.registration.registration_revision}",
+        ),
+    )
+
+
+def _revision_reason(activity: ActivitySummary) -> RevisionReason:
+    state = load_concord_publication_series_status(
+        activity.class_id, activity.activity_id, workspace_root=_root()
+    )
+    if not state.producer_revisions:
+        return "initial"
+    return select_one(
+        "Manifest Revision Reason",
+        _REVISION_REASONS,
+        tuple(item.replace("_", " ").title() for item in _REVISION_REASONS),
+        help_text=(
+            "Choose the controlled non-sensitive reason for this public projection."
+        ),
+    )
+
+
+def _manifest_request(
+    activity: ActivitySummary,
+    session: MenuSessionContext,
+) -> GenerateAcademicResultManifestRequest:
+    return GenerateAcademicResultManifestRequest(
+        class_id=activity.class_id,
+        activity_id=activity.activity_id,
+        expected_snapshot_revision=activity.snapshot_revision,
+        actor=session.require_actor(),
+        revision_reason=_revision_reason(activity),
+    )
+
+
+def _preview(
+    activity: ActivitySummary,
+    session: MenuSessionContext,
+) -> tuple[GenerateAcademicResultManifestRequest, AcademicResultManifestPreview]:
+    request = _manifest_request(activity, session)
+    preview = preview_academic_result_manifest(
+        request,
+        workspace_root=_root(),
+        standards_library=load_menu_standards_library(),
+    )
+    return request, preview
+
+
+def _review_lines(
+    preview: AcademicResultManifestPreview,
+    *,
+    academic_intent: str,
+    lifecycle: str,
+) -> tuple[str, ...]:
+    summary = manifest_preview_summary(preview)
+    work = preview.manifest.work
+    capabilities = ", ".join(summary["capabilities"])  # type: ignore[arg-type]
+    return (
+        f"Activity/work: {work.class_id}/{work.work_id}",
+        f"Registration revision: {summary['registration_revision']}",
+        f"Academic intent: {academic_intent}",
+        f"Registration lifecycle: {lifecycle}",
+        f"Concord source snapshot revision: {summary['source_snapshot_revision']}",
+        f"Record set: {summary['record_set_id']} @ {summary['record_set_revision']}",
+        f"Manifest contract: {summary['manifest_contract_version']}",
+        f"Scores: {summary['score_count']}",
+        (
+            "Current / historical Scores: "
+            f"{summary['current_score_count']} / {summary['historical_score_count']}"
+        ),
+        (
+            "Standard-backed / local Scores: "
+            f"{summary['standard_backed_score_count']} / "
+            f"{summary['local_score_count']}"
+        ),
+        f"Non-score records: {summary['non_score_count']}",
+        f"Moderation-dependent Scores: {summary['moderation_dependent_count']}",
+        f"Derived capabilities: {capabilities or '-'}",
+        f"Manifest path: {summary['manifest_path']}",
+        f"Manifest SHA-256: {summary['manifest_sha256']}",
+        f"Generation disposition: {summary['disposition']}",
+    )
+
+
+def _show_preview(activity: ActivitySummary, session: MenuSessionContext) -> None:
+    _request_value, preview = _preview(activity, session)
+    registration = load_current_concord_academic_work_registration(
+        _root(), activity.class_id, activity.activity_id
+    )
+    assert registration is not None
+    show_result(
+        "Publication Readiness / Preview",
+        _review_lines(
+            preview,
+            academic_intent=registration.academic_intent,
+            lifecycle=registration.lifecycle,
+        ),
+    )
+
+
+def _generate(activity: ActivitySummary, session: MenuSessionContext) -> None:
+    request, preview = _preview(activity, session)
+    registration = load_current_concord_academic_work_registration(
+        _root(), activity.class_id, activity.activity_id
+    )
+    assert registration is not None
+    review = _review_lines(
+        preview,
+        academic_intent=registration.academic_intent,
+        lifecycle=registration.lifecycle,
+    )
+    if not confirm_write("Generate Immutable Manifest", "GENERATE", review):
+        return
+    result = generate_academic_result_manifest(
+        request,
+        workspace_root=_root(),
+        standards_library=load_menu_standards_library(),
+        clock=lambda: preview.manifest.generated_at,
+    )
+    summary = manifest_generation_summary(result)
+    show_result(
+        "Manifest Result",
+        (
+            f"Disposition: {summary['disposition']}",
+            f"Record-set revision: {summary['record_set_revision']}",
+            f"Manifest path: {summary['manifest_path']}",
+            f"Manifest SHA-256: {summary['manifest_sha256']}",
+        ),
+    )
+
+
+def _publication_status(activity: ActivitySummary) -> None:
+    state = load_concord_publication_series_status(
+        activity.class_id, activity.activity_id, workspace_root=_root()
+    )
+    lines = [
+        (
+            "Producer manifest head: "
+            + (str(state.producer_head.revision) if state.producer_head else "none")
+        ),
+        (
+            "Core structural head: "
+            + (state.core_head.publication_id if state.core_head else "none")
+        ),
+        f"Core head withdrawn: {'yes' if state.core_head_withdrawal else 'no'}",
+        (
+            "Current selectable publication: "
+            + (
+                state.current_selectable_publication.publication_id
+                if state.current_selectable_publication
+                else "none"
+            )
+        ),
+        (
+            "Current registration revision: "
+            + (
+                str(state.current_registration_revision)
+                if state.current_registration_revision is not None
+                else "none"
+            )
+        ),
+        f"Catalog available: {'yes' if state.catalog_available else 'no'}",
+        f"Catalog rows: {len(state.catalog_rows)}",
+    ]
+    for publication in state.publications:
+        withdrawn = any(
+            item.publication_id == publication.publication_id
+            for item in state.withdrawals
+        )
+        lines.append(
+            f"Revision {publication.record_set_revision}: "
+            f"{publication.publication_id} "
+            f"({'withdrawn' if withdrawn else 'active history'})"
+        )
+    show_result("Publication History / Status", tuple(lines))
+
+
+def _publish(
+    activity: ActivitySummary,
+    session: MenuSessionContext,
+    *,
+    superseding: bool,
+) -> None:
+    state = load_concord_publication_series_status(
+        activity.class_id, activity.activity_id, workspace_root=_root()
+    )
+    if superseding and state.core_head is None:
+        show_result("Publish", ("There is no Core publication to supersede.",))
+        return
+    if not superseding and state.core_head is not None:
+        show_result(
+            "Publish",
+            ("A Core publication series already exists; use superseding publication.",),
+        )
+        return
+    request, preview = _preview(activity, session)
+    registration = load_current_concord_academic_work_registration(
+        _root(), activity.class_id, activity.activity_id
+    )
+    assert registration is not None
+    review = list(
+        _review_lines(
+            preview,
+            academic_intent=registration.academic_intent,
+            lifecycle=registration.lifecycle,
+        )
+    )
+    if state.core_head is not None:
+        review.append(f"Expected Core head: {state.core_head.publication_id}")
+        withdrawn_label = "yes" if state.core_head_withdrawal else "no"
+        review.append(f"Expected Core head withdrawn: {withdrawn_label}")
+    if not confirm_write("Publish Academic Results", "PUBLISH", tuple(review)):
+        return
+    if not superseding:
+        result = publish_concord_academic_results(
+            request,
+            workspace_root=_root(),
+            standards_library=load_menu_standards_library(),
+            clock=lambda: preview.manifest.generated_at,
+        )
+    else:
+        assert state.core_head is not None
+        if state.core_head_withdrawal is not None:
+            result = republish_concord_academic_results_after_withdrawal(
+                request,
+                expected_withdrawn_head_publication_id=state.core_head.publication_id,
+                workspace_root=_root(),
+                standards_library=load_menu_standards_library(),
+                clock=lambda: preview.manifest.generated_at,
+            )
+        else:
+            result = supersede_concord_academic_results(
+                request,
+                expected_current_publication_id=state.core_head.publication_id,
+                workspace_root=_root(),
+                standards_library=load_menu_standards_library(),
+                clock=lambda: preview.manifest.generated_at,
+            )
+    show_result(
+        "Publication Result",
+        (
+            f"Disposition: {result.disposition}",
+            f"Publication: {result.publication.publication_id}",
+            f"Record-set revision: {result.publication.record_set_revision}",
+        ),
+    )
+
+
+def _withdraw(activity: ActivitySummary) -> None:
+    state = load_concord_publication_series_status(
+        activity.class_id, activity.activity_id, workspace_root=_root()
+    )
+    if not state.publications:
+        show_result("Withdraw Publication", ("No Core publications exist.",))
+        return
+    publication_id = prompt_text(
+        "Withdraw Publication",
+        "Publication ID",
+        help_text="Enter the exact Core Publication Record ID to withdraw.",
+        default=(state.core_head.publication_id if state.core_head else None),
+    )
+    assert publication_id is not None
+    reason = prompt_text(
+        "Withdraw Publication",
+        "Publication-safe reason",
+        help_text=(
+            "Use deliberate operational text only; do not paste student or "
+            "moderation narrative."
+        ),
+    )
+    assert reason is not None
+    if not confirm_write(
+        "Withdraw Publication",
+        "WITHDRAW",
+        (
+            f"Activity: {activity.title}",
+            f"Publication: {publication_id}",
+            f"Reason: {reason}",
+        ),
+    ):
+        return
+    result = withdraw_concord_academic_result_publication(
+        activity.class_id,
+        activity.activity_id,
+        publication_id=publication_id,
+        reason=reason,
+        workspace_root=_root(),
+    )
+    show_result(
+        "Withdrawal Result",
+        (
+            f"Disposition: {result.disposition}",
+            f"Publication: {result.publication.publication_id}",
+            f"Manifest verification: {result.manifest_verification}",
+        ),
+    )
+
+
+def _catalog_status(activity: ActivitySummary) -> None:
+    state = load_concord_publication_series_status(
+        activity.class_id, activity.activity_id, workspace_root=_root()
+    )
+    lines = [
+        f"Catalog available: {'yes' if state.catalog_available else 'no'}",
+        f"Catalog rows for Activity: {len(state.catalog_rows)}",
+    ]
+    if state.catalog_available:
+        rows = query_concord_publication_catalog(
+            activity.class_id,
+            activity.activity_id,
+            state="all",
+            workspace_root=_root(),
+        )
+        for row in rows:
+            lines.append(
+                f"Revision {row.record_set_revision}: {row.publication_id}; "
+                f"head={'yes' if row.is_series_head else 'no'}; "
+                f"withdrawn={'yes' if row.is_withdrawn else 'no'}; "
+                f"current={'yes' if row.is_current_selectable else 'no'}"
+            )
+    show_result("Catalog Discovery / Status", tuple(lines))
+
+
+def _rebuild_catalog(activity: ActivitySummary) -> None:
+    if not confirm_write(
+        "Rebuild Core Academic Catalog",
+        "REBUILD",
+        (
+            "Core academic catalog is disposable derived state.",
+            f"Activity context: {activity.class_id}/{activity.activity_id}",
+            "Canonical registrations/publications/withdrawals are not rewritten.",
+        ),
+    ):
+        return
+    result = rebuild_full_academic_catalog(_root())
+    show_result(
+        "Catalog Result",
+        (
+            "Catalog rebuilt and verified.",
+            f"Publications: {result.metadata.publication_count}",
+            f"Withdrawals: {result.metadata.withdrawal_count}",
+            f"Source snapshot SHA-256: {result.metadata.source_snapshot_sha256}",
+        ),
+    )
+
+
+def _handle_error(error: Exception) -> None:
+    if isinstance(
+        error,
+        (
+            ConcordManifestGenerationConflictError,
+            ConcordAcademicResultPublicationConflictError,
+            RegistryServiceConflictError,
+        ),
+    ) or error.__class__.__name__.endswith("ConflictError"):
+        prompt_conflict_reload()
+        return
+    if isinstance(error, ConcordManifestGenerationPartialSuccessError):
+        show_result(
+            "Partial Success",
+            (
+                str(error),
+                f"Durable manifest revision: {error.state.revision}",
+                "Review canonical producer state before retrying.",
+            ),
+        )
+        return
+    if isinstance(error, ConcordAcademicResultPublicationPartialSuccessError):
+        state = error.state
+        show_result(
+            "Partial Success",
+            (
+                str(error),
+                f"Canonical state: {state.canonical_state}",
+                state.recommended_next_action,
+            ),
+        )
+        return
+    if isinstance(error, RegistryServicePartialSuccessError):
+        show_result(
+            "Partial Success",
+            (str(error), "Review canonical Core registry state before retrying."),
+        )
+        return
+    show_result("Publication Error", (str(error),))
+
+
+def _publication_help() -> None:
+    show_result(
+        "Publication Help",
+        (
+            "Publication is explicit teacher intent and never occurs on menu entry.",
+            "Concord publishes immutable academic-result manifests through Core.",
+            "Publication does not calculate Grades, proficiency, or reporting policy.",
+        ),
+    )
+
+
+def launch_publication_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+) -> None:
+    """Open the deliberate Activity-scoped Academic Publication surface."""
+    while True:
+        clear_screen()
+        print_menu_header("Academic Publication")
+        print(f"Activity: {activity.title}")
+        print(f"Class: {activity.class_id}")
+        print()
+        print("1. Registration status")
+        print("2. Register Activity")
+        print("3. Update registration")
+        print("4. Publication readiness / preview")
+        print("5. Generate immutable manifest")
+        print("6. Publication history / status")
+        print("7. Publish first revision")
+        print("8. Publish superseding revision")
+        print("9. Withdraw exact publication")
+        print("10. Catalog discovery / status")
+        print("11. Rebuild catalog")
+        print_navigation()
+        print()
+        choice = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(choice)
+        if navigation is ConcordMenuChoice.HELP:
+            _publication_help()
+            continue
+        if navigation is NavigationChoice.BACK:
+            return
+        try:
+            activity = show_activity(
+                activity.class_id,
+                activity.activity_id,
+                workspace_root=_root(),
+            ).summary
+            if choice == "1":
+                _registration_status(activity)
+            elif choice == "2":
+                _register(activity)
+            elif choice == "3":
+                _update_registration(activity)
+            elif choice == "4":
+                _show_preview(activity, state)
+            elif choice == "5":
+                _generate(activity, state)
+            elif choice == "6":
+                _publication_status(activity)
+            elif choice == "7":
+                _publish(activity, state, superseding=False)
+            elif choice == "8":
+                _publish(activity, state, superseding=True)
+            elif choice == "9":
+                _withdraw(activity)
+            elif choice == "10":
+                _catalog_status(activity)
+            elif choice == "11":
+                _rebuild_catalog(activity)
+            else:
+                print(navigation_hint_with_help())
+                pause_for_user()
+        except CancelMenuAction:
+            continue
+        except Exception as error:
+            _handle_error(error)

--- a/concord/pds_contract.py
+++ b/concord/pds_contract.py
@@ -1,0 +1,36 @@
+"""Stable public contract identities for Concord Core integration."""
+
+from __future__ import annotations
+
+from typing import Final
+
+CONCORD_MODULE_ID: Final[str] = "concord"
+CONCORD_DISPLAY_NAME: Final[str] = "Concord"
+
+CONCORD_ACADEMIC_WORK_CONTRACT_VERSION: Final[str] = (
+    "concord_academic_work_v1"
+)
+CONCORD_ACADEMIC_WORK_KIND: Final[str] = "collaborative_activity"
+
+CONCORD_ACTIVITY_RECORD_KIND: Final[str] = "activity"
+CONCORD_ACTIVITY_CONTRACT_VERSION: Final[str] = "concord_activity_v1"
+
+ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION: Final[str] = (
+    "concord_academic_result_manifest_v1"
+)
+ACADEMIC_RESULT_MANIFEST_RECORD_TYPE: Final[str] = (
+    "concord_academic_result_manifest"
+)
+CONCORD_ACADEMIC_RESULT_RECORD_SET_ID: Final[str] = "academic_results"
+
+__all__ = [
+    "ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION",
+    "ACADEMIC_RESULT_MANIFEST_RECORD_TYPE",
+    "CONCORD_ACADEMIC_RESULT_RECORD_SET_ID",
+    "CONCORD_ACADEMIC_WORK_CONTRACT_VERSION",
+    "CONCORD_ACADEMIC_WORK_KIND",
+    "CONCORD_ACTIVITY_CONTRACT_VERSION",
+    "CONCORD_ACTIVITY_RECORD_KIND",
+    "CONCORD_DISPLAY_NAME",
+    "CONCORD_MODULE_ID",
+]

--- a/concord/pds_publication.py
+++ b/concord/pds_publication.py
@@ -1,0 +1,64 @@
+"""Installed Core publication compatibility metadata for Concord."""
+
+from pds_core.publication_compatibility import (
+    PublicationContractSupport,
+    PublicationProducerProfile,
+    SourceRecordContractSupport,
+    validate_publication_producer_profile,
+)
+from pds_core.publication_records import PUBLICATION_RECORD_SCHEMA_VERSION
+
+from concord.academic_result_manifest import (
+    ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+)
+from concord.pds_contract import (
+    CONCORD_ACADEMIC_WORK_CONTRACT_VERSION,
+    CONCORD_ACTIVITY_CONTRACT_VERSION,
+    CONCORD_ACTIVITY_RECORD_KIND,
+    CONCORD_DISPLAY_NAME,
+    CONCORD_MODULE_ID,
+)
+
+
+def get_publication_producer_profile() -> PublicationProducerProfile:
+    """Return Concord's validated metadata-only publication profile."""
+    return validate_publication_producer_profile(
+        PublicationProducerProfile(
+            module_id=CONCORD_MODULE_ID,
+            display_name=CONCORD_DISPLAY_NAME,
+            supported_core_publication_schema_versions=frozenset(
+                {PUBLICATION_RECORD_SCHEMA_VERSION}
+            ),
+            supported_academic_work_contract_versions=frozenset(
+                {CONCORD_ACADEMIC_WORK_CONTRACT_VERSION}
+            ),
+            publication_contracts=(
+                PublicationContractSupport(
+                    publication_kind="academic_result_set",
+                    manifest_contract_versions=frozenset(
+                        {ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION}
+                    ),
+                    supported_capabilities=frozenset(
+                        {
+                            "criterion_scores",
+                            "moderated_scores",
+                            "standards_ratings",
+                        }
+                    ),
+                    source_record_contracts=(
+                        SourceRecordContractSupport(
+                            record_kind=CONCORD_ACTIVITY_RECORD_KIND,
+                            contract_versions=frozenset(
+                                {CONCORD_ACTIVITY_CONTRACT_VERSION}
+                            ),
+                            allows_unversioned=False,
+                        ),
+                    ),
+                    allows_missing_source_record=False,
+                ),
+            ),
+        )
+    )
+
+
+__all__ = ["get_publication_producer_profile"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,15 +47,19 @@ The repository now contains:
 * explicit Artifact Review and evidence Moderation with preserved history,
   exact evidence/Subject scope, and a guarded Score handoff; and
 * teacher-controlled Criterion Set, Scoring Scale, Score Record, Score Evidence
-  Link, non-score disposition, and Score revision workflows.
+  Link, non-score disposition, and Score revision workflows; and
+* explicit Core Academic Work Registration, immutable Concord Academic Result
+  Manifest generation, Publication Record supersession/withdrawal, publication
+  producer discovery, and Core academic-catalog reconciliation.
 
 Implementation follows the v0.2.0 vertical-slice sequence tracked by
 [`Paper-Data-Suite/pds-concord#22`](https://github.com/Paper-Data-Suite/pds-concord/issues/22).
 The package baseline, foundational native models, persistence substrate, and
 teacher-local collaboration-context, PDS2 Artifact Page routing, returned Artifact
-assembly, Author/Subject, Review/Moderation, and Criterion/Scale/Score workflows
-are complete. Later issues add publication and consumer integration. The Concord
-routing entry point is declared; the publication entry point remains absent.
+assembly, Author/Subject, Review/Moderation, Criterion/Scale/Score, and academic
+publication workflows are complete. Concord declares separate routing and
+publication-producer entry points. Issue #32 adds the consumer-neutral reader;
+issue #33 owns the full installed Activity-to-publication acceptance.
 
 ### 14. PDS2 Artifact Page integration
 
@@ -90,6 +94,17 @@ Documents immutable Criterion Set and Scale revisions, explicit Activity Set
 selection, type-sensitive native Scale values, teacher-approved Score and
 non-score workflows, durable evidence links, Review/Moderation handoff, Score
 history, direct/menu surfaces, and installed-wheel acceptance.
+
+### 18. Academic result publication
+
+[`implementation/academic-result-publication.md`](implementation/academic-result-publication.md)
+
+Documents explicit Core Academic Work Registration, the immutable
+`concord_academic_result_manifest_v1` projection, semantic projection digests,
+producer revisioning, privacy minimization, publication-producer compatibility,
+first publication, replay, supersession, withdrawal, catalog reconciliation,
+partial-success recovery, direct CLI/menu behavior, and the #32/#33/Meridian
+boundaries.
 
 ### 10. Native model implementation
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented through the v0.2.0 Criterion, Scale, and Score workflow in issue #30.
+Implemented through the v0.2.0 Academic Result Publication workflow in issue #31.
 
 ## Two interfaces, one service layer
 
@@ -118,6 +118,20 @@ concord scan route
 concord scan review list
 concord scan review show
 concord scan review resolve
+
+concord publication register
+concord publication registration-show
+concord publication registration-update
+concord publication manifest-preview
+concord publication manifest-generate
+concord publication manifest-list
+concord publication manifest-show
+concord publication publish
+concord publication supersede
+concord publication withdraw
+concord publication series-show
+concord publication catalog-list
+concord publication catalog-rebuild
 ```
 
 Use `concord <family> <command> --help` for exact flags.
@@ -226,9 +240,11 @@ Q. Quit
 
 An opened Activity includes page preparation/inspection/rendering, Artifact
 inspection and returned assembly, explicit Author/Subject management, Artifact
-Review, evidence Moderation, and Criterion/Scale/Score workflows. Teacher
-writes require operation-specific words such as `CREATE`, `RENDER`, `ASSEMBLE`,
-`ADD`, `UPDATE`, `CORRECT`, `REVIEW`, `MODERATE`, `SCORE`, and `REVISE`.
+Review, evidence Moderation, Criterion/Scale/Score workflows, and an explicit
+Publication surface immediately after Scoring. Teacher writes require
+operation-specific words such as `CREATE`, `RENDER`, `ASSEMBLE`, `ADD`,
+`UPDATE`, `CORRECT`, `REVIEW`, `MODERATE`, `SCORE`, `REVISE`, `REGISTER`,
+`GENERATE`, `PUBLISH`, `WITHDRAW`, and `REBUILD`.
 Global routing review remains
 available when a failed scan has no trustworthy Activity locator.
 
@@ -274,5 +290,6 @@ commit success remains valid if disposable catalog rebuilding later fails.
 
 This contract includes returned Artifact assembly, Author/Subject management,
 Artifact Review, evidence Moderation, Criterion Set and Scoring Scale management,
-and explicit Score entry/revision. It does not add Concord publication, Meridian
-grading policy, Grade calculation, or destructive collaboration-record deletion.
+explicit Score entry/revision, and explicit Academic Result Publication. It does
+not add the issue #32 consumer-neutral reader, Meridian grading policy, Grade or
+proficiency calculation, or destructive collaboration-record deletion.

--- a/docs/implementation/academic-result-publication.md
+++ b/docs/implementation/academic-result-publication.md
@@ -1,0 +1,468 @@
+# Concord Academic Result Publication
+
+## Status
+
+Implemented for issue #31 against the released `pds-core` v0.6.x producer
+contracts. This document describes Concord's producer-owned academic-result
+publication boundary. It does not define the consumer-neutral reader reserved
+for issue #32 or the full installed Activity-to-publication acceptance reserved
+for issue #33.
+
+## Ownership boundary
+
+Concord owns the educational meaning of the Activity, Criteria, Scales, Scores,
+Score Evidence Links, Moderation, native supersession history, and the Concord
+Academic Result Manifest. Core owns Academic Work Registration, Publication
+Records, Publication Withdrawals, publication identity/timestamps, manifest
+path and digest binding, canonical registry persistence, compatibility
+metadata, and the derived academic catalog.
+
+Meridian remains the owner of Grade-item membership, Academic Period
+membership, evidence/attempt selection, scale mapping, proficiency/mastery
+policy, weighting, Grade calculation, overrides, cross-publication
+deduplication, and reporting. Concord publication does not calculate or imply
+those results.
+
+## Stable public identities
+
+The v1 publication boundary uses these exact Concord contract identities:
+
+```text
+module_id                    = concord
+display_name                 = Concord
+academic work contract       = concord_academic_work_v1
+Activity source kind         = activity
+Activity source contract     = concord_activity_v1
+manifest record type         = concord_academic_result_manifest
+manifest contract            = concord_academic_result_manifest_v1
+record-set ID                = academic_results
+Core publication kind        = academic_result_set
+```
+
+For one Activity the shared work identity is:
+
+```text
+ModuleWorkRef(
+    module_id = concord,
+    class_id  = <Activity class_id>,
+    work_id   = <Activity activity_id>,
+)
+```
+
+The required source declaration is exactly:
+
+```text
+ModuleRecordRef(
+    module_id        = concord,
+    record_kind      = activity,
+    record_id        = <Activity activity_id>,
+    contract_version = concord_activity_v1,
+)
+```
+
+The Activity source reference declares identity and contract version; it does
+not create a second mutable Activity document.
+
+## Explicit Academic Work Registration
+
+Registration is explicit teacher academic intent. Activity creation, Focus
+Standard selection, Score entry, Review, or Moderation never registers an
+Activity automatically.
+
+Concord maps registration to Core with:
+
+```text
+producer_contract_version = concord_academic_work_v1
+work_kind                  = collaborative_activity
+source_records             = exactly the versioned Activity reference
+```
+
+The teacher selects Core's exact academic-intent vocabulary independently of
+Concord scoring orientation:
+
+```text
+formative
+summative
+diagnostic
+practice
+feedback_only
+reporting_only
+```
+
+The teacher also selects Core's registration lifecycle independently of
+Activity lifecycle:
+
+```text
+planned
+active
+closed
+cancelled
+```
+
+Registration updates require the exact expected current registration revision.
+Earlier revisions remain immutable. A later Activity title change does not
+silently rewrite Core registration metadata.
+
+## Publishability and read-only preview
+
+Manifest generation requires an existing Core class, exact current Activity,
+valid native graph, explicit current registration, non-`evidence_only` scoring
+orientation, at least one Score Record, exact Criterion/Scale interpretation,
+valid standards relationships, valid evidence lineage, satisfied Moderation,
+and publication-safe public text.
+
+`preview_academic_result_manifest(...)` performs the same semantic projection
+and validation needed for generation but does not create producer manifest
+bytes. The direct CLI and teacher menu use this path for readiness review.
+Simply opening the Publication menu or inspecting readiness does not register,
+generate, publish, supersede, withdraw, or rebuild the catalog.
+
+## Manifest v1 schema
+
+The top-level `concord_academic_result_manifest_v1` contract is closed and
+contains:
+
+```text
+record_type
+contract_version
+producer_module_id
+generated_at
+record_set
+work
+source_activity
+projection
+activity_context
+criterion_sets
+criteria
+scoring_scales
+scores
+score_evidence_links
+moderation_records
+standards_result_projection
+privacy
+```
+
+Unknown top-level fields are rejected. The manifest is self-contained for the
+Concord Score semantics it publishes without requiring private Concord storage.
+
+### Activity context
+
+The projection preserves Activity/work identity, title snapshot, scoring
+orientation, standards profile, ordered Focus Standards, and exact selected
+Criterion Set revisions. Unrelated Activity notes, packet/UI configuration, and
+private operational metadata are excluded.
+
+### Criterion Sets and Criteria
+
+Every Score's exact Criterion is projected with the exact immutable Criterion
+Set revision required to interpret it. Standard-backed Criteria preserve one
+governing Core `standard_id`; local Criteria preserve the absence of a governing
+standard. Alignment metadata on a local Criterion never creates direct
+standards semantics.
+
+### Scoring Scales
+
+Every included Score's exact immutable Scale revision and levels are projected.
+Scale machine values remain type-sensitive. In particular:
+
+```text
+1 != 1.0 != "1" != true
+```
+
+Concord does not normalize native Scale values to percentages, letter grades,
+points, or universal proficiency.
+
+### Scores and native history
+
+V1 includes all valid Score Records in the Activity snapshot, including
+historical Score revisions needed to reproduce current state. Each Score keeps
+its exact target, Criterion, Scale, disposition, value when scored, basis,
+scorer identity, scored time, Moderation-complete state, native predecessor,
+and an explicit `current` or `superseded` state derived only from the native
+supersession chain.
+
+A `concord_group` Score remains a Group Score. Publication never expands Group
+membership into student Scores or infers a target from Author, Subject,
+evidence, Review, or Moderation context.
+
+Non-score dispositions remain valueless:
+
+```text
+insufficient_evidence
+absent
+excused
+not_observed
+not_applicable
+deferred
+```
+
+They are never serialized as zero, the lowest Scale level, failure, or an
+inferred missing-data value.
+
+### Evidence and external lineage
+
+Score Evidence Links preserve exact Concord Artifact/Page identity and external
+producer ownership. External evidence keeps its owner, evidence kind, exact
+record ID/contract, immutable source version, and exact Core Publication
+Reference when one is present. A referenced Core Publication is re-verified for
+existence, lineage, and manifest path/digest integrity before it is retained in
+the Concord projection.
+
+Concord does not import ScoreForm or Quillan to interpret private producer
+state, does not copy source evidence bytes, and does not replace an exact source
+revision with a later logical equivalent.
+
+### Moderation
+
+When an included evidence use depends on Moderation, the exact minimal
+Moderation semantics required to interpret that use are projected: identity,
+evidence and Subject scope, status, permitted use, necessary safe qualification,
+native predecessor, and current/superseded state. Moderation rationale is not
+published.
+
+### Standards result projection
+
+The Standards Result Projection is a relational subset of the Score projection.
+Every standard-backed Score appears exactly once with its governing
+`standard_id`; local Scores never appear there. The Score object remains the
+authoritative target/value/disposition/Scale representation.
+
+## Capability derivation
+
+Capabilities are derived from the exact manifest contents:
+
+```text
+criterion_scores   any valid Concord Score Record exists
+standards_ratings  at least one standard-backed Score exists
+moderated_scores   interpretation of an included consequential Score depends
+                   on projected Moderation
+```
+
+Concord does not advertise `points`, `question_evidence`, or
+`multiple_attempts` in manifest v1.
+
+## Privacy and data minimization
+
+The manifest uses a strict allowlist and a resolved effective privacy policy.
+Publication means discoverability, not authorization.
+
+V1 excludes source scan bytes, rendered pages, complete student work, Artifact
+contents, peer comments, unrestricted Review/teacher notes, student names,
+family information, sensitive medical/disability/counseling/disciplinary
+narrative, credentials/secrets, local machine paths, and unrelated Concord
+records. It also explicitly excludes:
+
+```text
+ScoreRecord.rationale
+StatusReason.note
+ModerationRecord.rationale
+EvidenceLocator.note
+```
+
+Required public semantic display text passes Concord's publication-safe text
+validation. If a required semantic projection cannot be represented safely and
+exactly, generation fails rather than weakening privacy or changing meaning.
+
+## Semantic projection digest and revision policy
+
+Each manifest records the exact source Concord snapshot revision plus a
+producer-owned SHA-256 semantic projection digest. The semantic digest excludes
+envelope values that naturally change between otherwise identical projections,
+including manifest revision, generation time, source snapshot revision,
+generator, revision reason, and the digest itself.
+
+An unrelated native change may advance the Concord snapshot while leaving the
+semantic digest unchanged; in that case Concord reuses the existing producer
+manifest head. A material public change creates the next immutable producer
+manifest revision. Material changes include Score/evidence/Moderation
+revisions, target or Scale corrections, public Criterion/Scale semantic changes,
+privacy changes, and manifest-contract migration.
+
+Producer revision numbers are immutable positive identities. Concord never
+renumbers history merely to remove a gap.
+
+## Canonical JSON and producer storage
+
+Manifest bytes are deterministic UTF-8 JSON with no BOM, deterministic mapping
+and array order, finite JSON numbers only, and one final LF. Platform line
+endings do not affect the bytes.
+
+Immutable producer manifests live under the exact Activity work root:
+
+```text
+classes/<class_id>/modules/concord/work/<activity_id>/
+  exports/manifests/academic_results/
+    1.json
+    2.json
+    ...
+```
+
+Core stores the workspace-relative forward-slash path and SHA-256 of the exact
+manifest bytes. Published bytes are never modified. An existing revision with
+identical bytes may reconcile as existing; the same revision with different
+bytes is an integrity error. No mutable `latest.json` is required.
+
+## Publication producer profile
+
+The installed wheel declares the independent entry point:
+
+```toml
+[project.entry-points."paper_data_suite.publication_producers"]
+concord = "concord.pds_publication:get_publication_producer_profile"
+```
+
+The metadata-only provider advertises Core Publication Record schema `1`,
+`concord_academic_work_v1`, publication kind `academic_result_set`, manifest
+contract `concord_academic_result_manifest_v1`, capabilities
+`criterion_scores`, `standards_ratings`, and `moderated_scores`, and the required
+versioned Activity source. Missing or unversioned sources are not permitted.
+
+This profile is separate from the PDS2 routing `ModuleProfile` exposed through
+`paper_data_suite.modules`. Importing/discovering the publication profile does
+not resolve or mutate a workspace and does not require a sibling PDS package.
+
+## First publication and replay
+
+First publication generates or reuses the exact current producer manifest,
+loads the explicit current registration, derives exact capabilities, builds a
+Core `PublicationManifestRequest`, and calls Core
+`publish_manifest_revision(...)`.
+
+Core owns the Publication Record ID and timestamp. Concord then reloads the
+canonical record, verifies work/source/record-set/registration/capability/path
+and digest agreement, re-verifies exact manifest bytes through Core, evaluates
+compatibility against its own producer profile, rebuilds the derived academic
+catalog, and verifies the exact catalog row.
+
+An identical replay reconciles to the existing Core Publication Record. A
+different interpretation of the same logical producer revision is a conflict or
+integrity failure, never a second publication meaning for that revision.
+
+## Supersession
+
+A material public change creates or reuses the next producer manifest revision.
+Publication supersession requires the explicit expected current Core
+publication ID and calls Core `supersede_manifest_revision(...)`. The successor
+preserves work, publication kind, and `academic_results` series identity,
+advances the record-set revision, and explicitly names
+`supersedes_publication_id`.
+
+Currentness is never inferred from timestamps, IDs, filenames, manifest revision
+ordering, or catalog row ordering. Previous Core Publication Records and
+producer manifest bytes remain immutable.
+
+## Withdrawal and corrected republication
+
+Withdrawal uses Core `PublicationWithdrawalRequest` and
+`withdraw_publication(...)`. It does not delete or rewrite native Concord
+records, producer manifests, Publication Records, or publication-series
+structure. Withdrawing the structural series head leaves no current selectable
+publication and never reactivates a predecessor.
+
+A corrected publication after withdrawal requires a material new producer
+manifest revision and a new Core Publication Record that explicitly supersedes
+the withdrawn structural head. Withdrawal reason is deliberate Core operational
+metadata, not copied from Score or Moderation narrative.
+
+## Catalog discovery and reconciliation
+
+Core's academic catalog is disposable derived state. Canonical registration,
+Publication Record, and Withdrawal JSON remain authoritative.
+
+Concord uses Core `rebuild_academic_catalog(...)` and
+`query_publication_catalog(...)` with `PublicationCatalogQuery`; it never writes
+SQLite directly or discovers publications by crawling work directories. Query
+filters include exact class/work identity, publication kind, `academic_results`
+record set, required capabilities, and Core publication state:
+
+```text
+current
+series_heads
+historical
+withdrawn
+all
+```
+
+Producer-series status distinguishes producer manifest head, structural Core
+publication head, head Withdrawal, current selectable publication, current
+registration revision, catalog availability, and catalog rows. Catalog rows are
+reconciled against canonical Core state and contradictory derived state is
+rejected.
+
+## Partial success and recovery
+
+Producer bytes and Core registry state are separate durable systems. If a Core
+publication/withdrawal is durable but post-write verification or catalog
+reconciliation fails, Concord returns structured partial success describing the
+canonical durable state and the required reconciliation action.
+
+Safe recovery replays the exact operation or rebuilds/reconciles the catalog.
+It never mutates published bytes, reuses one revision for different content,
+changes a digest to bless modified bytes, deletes Core history, fabricates a
+current pointer, drops lineage, or creates a duplicate Publication Record merely
+because catalog verification failed.
+
+## Direct CLI
+
+The noninteractive publication family is:
+
+```text
+concord publication register
+concord publication registration-show
+concord publication registration-update
+concord publication manifest-preview
+concord publication manifest-generate
+concord publication manifest-list
+concord publication manifest-show
+concord publication publish
+concord publication supersede
+concord publication withdraw
+concord publication series-show
+concord publication catalog-list
+concord publication catalog-rebuild
+```
+
+Exit codes retain the Concord contract: `0` success, `1` ordinary
+validation/read/write/integrity failure, `2` usage, `3` stale expected
+revision/head or lock conflict, and `4` structured partial success. List and
+status output stays compact; exact manifest inspection exposes only the already
+publication-safe manifest projection.
+
+## Teacher Publication menu
+
+Each opened Activity exposes **Publication** immediately after **Scoring**. The
+surface provides registration status/create/update, read-only readiness preview,
+immutable generation, publication history/status, first publish, explicit
+supersession, exact withdrawal, catalog discovery/status, and catalog rebuild.
+
+Opening the menu performs no publication mutation. Before generation or publish,
+Concord shows the exact work/registration/source snapshot, record-set revision,
+Score/current/history/standard/local/non-score/moderation counts, capabilities,
+manifest path/digest when available, predecessor publication when applicable,
+and a privacy warning. The menu explicitly states:
+
+```text
+Publication does not calculate a Grade or proficiency.
+Group Scores remain Group Scores.
+```
+
+Writes require deliberate confirmation words `REGISTER`, `GENERATE`, `PUBLISH`,
+`WITHDRAW`, or `REBUILD`. H/B/M/Q navigation and stale-state Reload behavior
+remain unchanged; Reload re-reads state and never force-writes or silently
+retries.
+
+## Producer-management readers and issue boundaries
+
+Issue #31 includes deterministic producer-management readers for exact manifest
+revisions/head/digest, Core publication series, Withdrawal state, current
+selectable publication, registration state, and catalog agreement. These are
+not the final consumer-neutral manifest/artifact reader promised by Issue #32.
+
+Issue #33 owns the full clean-wheel Activity-to-publication end-to-end
+acceptance. Issue #31 limits installed acceptance to proving that the built wheel
+ships and exposes exactly one valid Concord publication producer profile without
+workspace mutation or sibling-module dependencies.
+
+No Meridian adapter, portfolio projection, consumer target policy, Grade,
+proficiency, mastery, Academic Period membership, weighting, or report logic is
+implemented by this publication boundary.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ concord = "concord.cli:main"
 [project.entry-points."paper_data_suite.modules"]
 concord = "concord.pds_module:get_module_profile"
 
+[project.entry-points."paper_data_suite.publication_producers"]
+concord = "concord.pds_publication:get_publication_producer_profile"
+
 [project.urls]
 Documentation = "https://github.com/Paper-Data-Suite/pds-concord/tree/main/docs"
 Repository = "https://github.com/Paper-Data-Suite/pds-concord"

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -26,6 +26,25 @@ EXAMPLE_DRAFT_STATUS = "**Status:** Draft for representative-contract validation
 PROPOSED_CHAIN = (
     "The examples also validate the proposed academic-result publication chain"
 )
+PUBLICATION_DOC = ROOT / "docs" / "implementation" / "academic-result-publication.md"
+STALE_PUBLICATION_PHRASES = (
+    "still does **not** publish academic results",
+    "publication remains absent until issue #31",
+    "Later issues add publication and consumer integration",
+    "the publication entry point remains absent",
+    "It does not add Concord publication",
+    "Implemented through the v0.2.0 Criterion, Scale, and Score workflow in issue #30.",
+)
+REQUIRED_PUBLICATION_DOC_PHRASES = (
+    "concord_academic_work_v1",
+    "concord_activity_v1",
+    "concord_academic_result_manifest_v1",
+    "academic_results",
+    "paper_data_suite.publication_producers",
+    "Issue #32",
+    "Issue #33",
+    "Meridian",
+)
 
 
 class DocumentationError(ValueError):
@@ -99,6 +118,29 @@ def check_documentation() -> None:
     for phrase in STALE_ACTIVE_PHRASES:
         if phrase in active_text:
             failures.append(f"Stale active-status phrase remains: {phrase!r}")
+    if not PUBLICATION_DOC.is_file():
+        failures.append(
+            "Academic result publication implementation document is missing."
+        )
+    else:
+        publication_doc = PUBLICATION_DOC.read_text(encoding="utf-8")
+        for phrase in REQUIRED_PUBLICATION_DOC_PHRASES:
+            if phrase not in publication_doc:
+                failures.append(
+                    "Publication implementation document is missing required "
+                    f"contract wording {phrase!r}."
+                )
+    publication_active_text = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in (
+            ROOT / "README.md",
+            ROOT / "docs" / "README.md",
+            ROOT / "docs" / "cli-contract.md",
+        )
+    )
+    for phrase in STALE_PUBLICATION_PHRASES:
+        if phrase in publication_active_text:
+            failures.append(f"Stale publication-status phrase remains: {phrase!r}")
     integration = (
         ROOT / "docs" / "design" / "pds-core-integration-requirements.md"
     ).read_text(encoding="utf-8")

--- a/scripts/check_package.py
+++ b/scripts/check_package.py
@@ -18,10 +18,18 @@ FORBIDDEN_PREFIXES = (
     "quillan/",
     "portia/",
     "meridian/",
+    "vitrine/",
     ".venv/",
     "build/",
 )
 FORBIDDEN_PARTS = ("__pycache__", ".pytest_cache", ".mypy_cache", "credentials")
+FORBIDDEN_RUNTIME_DEPENDENCIES = {
+    "pds-scoreform",
+    "pds-quillan",
+    "pds-portia",
+    "pds-meridian",
+    "pds-vitrine",
+}
 
 
 class PackageValidationError(ValueError):
@@ -42,7 +50,7 @@ def _metadata(archive: zipfile.ZipFile, names: list[str]) -> Message:
 
 
 def validate_wheel(path: str | Path) -> None:
-    """Validate metadata, intended files, and deliberately absent entry points."""
+    """Validate metadata, intended files, and required integration entry points."""
     wheel = Path(path)
     try:
         with zipfile.ZipFile(wheel) as archive:
@@ -67,6 +75,13 @@ def validate_wheel(path: str | Path) -> None:
         raise PackageValidationError(
             "Runtime Core requirement must be pds-core>=0.6,<0.7."
         )
+    runtime_names = {item.name for item in requirements if item.marker is None}
+    forbidden_runtime = runtime_names & FORBIDDEN_RUNTIME_DEPENDENCIES
+    if forbidden_runtime:
+        raise PackageValidationError(
+            "Sibling PDS runtime dependencies are forbidden: "
+            + ", ".join(sorted(forbidden_runtime))
+        )
     if "[console_scripts]\nconcord = concord.cli:main" not in entry_points:
         raise PackageValidationError("The concord console script is missing.")
     expected_routing = (
@@ -74,8 +89,20 @@ def validate_wheel(path: str | Path) -> None:
     )
     if expected_routing not in entry_points:
         raise PackageValidationError("The Concord routing entry point is missing.")
-    if "paper_data_suite.publication_producers" in entry_points:
-        raise PackageValidationError("Premature publication entry point is declared.")
+    expected_publication = (
+        "[paper_data_suite.publication_producers]\n"
+        "concord = concord.pds_publication:get_publication_producer_profile"
+    )
+    if expected_publication not in entry_points:
+        raise PackageValidationError(
+            "The Concord publication-producer entry point is missing."
+        )
+    if entry_points.count(
+        "concord = concord.pds_publication:get_publication_producer_profile"
+    ) != 1:
+        raise PackageValidationError(
+            "The Concord publication-producer entry point must occur exactly once."
+        )
     required = {"concord/__init__.py", "concord/cli.py", "concord/py.typed"}
     if not required.issubset(names):
         raise PackageValidationError("Wheel is missing intended Concord package files.")

--- a/scripts/smoke_test_wheel.py
+++ b/scripts/smoke_test_wheel.py
@@ -572,12 +572,14 @@ def _workflow_smoke_code() -> str:
             assert loaded.graph.artifact_authors == authors_before_review
             assert loaded.graph.artifact_subjects == subjects_before_review
 
-            assert not any(
-                entry.name == "concord"
+            publication_entries = tuple(
+                entry
                 for entry in entry_points(
                     group="paper_data_suite.publication_producers"
                 )
+                if entry.name == "concord"
             )
+            assert len(publication_entries) == 1
             assert first_snapshot.snapshot_revision == 1
             assert list_record_revisions(
                 root,
@@ -653,6 +655,76 @@ def smoke_test(concord_wheel: Path, core_wheel: Path) -> None:
             ],
             outside,
         )
+
+        profile_workspace = root / "publication-profile-workspace"
+        profile_env = {"PDS_WORKSPACE_ROOT": str(profile_workspace)}
+        _run(
+            [
+                str(python),
+                "-c",
+                textwrap.dedent(
+                    """
+                    import sys
+                    from pds_core.publication_compatibility import (
+                        discover_publication_producer_profiles,
+                        validate_publication_producer_profile,
+                    )
+
+                    profiles = discover_publication_producer_profiles()
+                    assert len(profiles) == 1
+                    profile = profiles[0]
+                    assert validate_publication_producer_profile(profile) == profile
+                    assert profile.module_id == "concord"
+                    assert profile.display_name == "Concord"
+                    assert (
+                        profile.supported_core_publication_schema_versions
+                        == frozenset({"1"})
+                    )
+                    assert (
+                        profile.supported_academic_work_contract_versions
+                        == frozenset({"concord_academic_work_v1"})
+                    )
+                    assert len(profile.publication_contracts) == 1
+                    contract = profile.publication_contracts[0]
+                    assert contract.publication_kind == "academic_result_set"
+                    assert (
+                        contract.manifest_contract_versions
+                        == frozenset({"concord_academic_result_manifest_v1"})
+                    )
+                    assert contract.supported_capabilities == frozenset(
+                        {
+                            "criterion_scores",
+                            "moderated_scores",
+                            "standards_ratings",
+                        }
+                    )
+                    assert contract.allows_missing_source_record is False
+                    assert len(contract.source_record_contracts) == 1
+                    source = contract.source_record_contracts[0]
+                    assert source.record_kind == "activity"
+                    assert source.contract_versions == frozenset(
+                        {"concord_activity_v1"}
+                    )
+                    assert source.allows_unversioned is False
+                    forbidden = {
+                        "scoreform",
+                        "quillan",
+                        "portia",
+                        "meridian",
+                        "vitrine",
+                    }
+                    loaded = {name.split(".")[0].lower() for name in sys.modules}
+                    assert forbidden.isdisjoint(loaded)
+                    """
+                ),
+            ],
+            outside,
+            env=profile_env,
+        )
+        if profile_workspace.exists():
+            raise RuntimeError(
+                "Publication-profile discovery unexpectedly created a workspace."
+            )
 
         absent_workspace = root / "read-only-workspace"
         read_only_env = {"PDS_WORKSPACE_ROOT": str(absent_workspace)}

--- a/tests/fixtures/native_records/standards_activity.json
+++ b/tests/fixtures/native_records/standards_activity.json
@@ -11,6 +11,67 @@
     "score_revision_predecessor_id": "score-standard-1",
     "group_score_creates_student_scores": false
   },
+  "expected_academic_result_manifest_projection": {
+    "contract_version": "concord_academic_result_manifest_v1",
+    "record_type": "concord_academic_result_manifest",
+    "record_set": {"record_set_id": "academic_results", "revision": 1},
+    "work": {
+      "module_id": "concord",
+      "class_id": "class-1",
+      "work_id": "standards-activity"
+    },
+    "source_activity": {
+      "module_id": "concord",
+      "record_kind": "activity",
+      "record_id": "standards-activity",
+      "contract_version": "concord_activity_v1"
+    },
+    "expected_capabilities": [
+      "criterion_scores",
+      "moderated_scores",
+      "standards_ratings"
+    ],
+    "score_projection": [
+      {"score_record_id": "score-standard-1", "current_state": "superseded"},
+      {"score_record_id": "score-standard-2", "current_state": "current"},
+      {"score_record_id": "score-group-1", "current_state": "current", "target_kind": "concord_group"},
+      {"score_record_id": "score-group-nonscore", "current_state": "current", "disposition": "not_observed", "value_present": false}
+    ],
+    "standards_result_score_ids": ["score-standard-1", "score-standard-2"],
+    "moderation_record_ids": ["moderation-1"],
+    "external_evidence_lineage_examples": [
+      {
+        "owning_system": "scoreform",
+        "evidence_kind": "scoreform_result",
+        "record_id": "synthetic-scoreform-result-1",
+        "contract_version": "synthetic_scoreform_result_v1",
+        "immutable_source_version": "1"
+      },
+      {
+        "owning_system": "quillan",
+        "evidence_kind": "quillan_response",
+        "record_id": "synthetic-quillan-response-1",
+        "contract_version": "synthetic_quillan_response_v1",
+        "immutable_source_version": "1"
+      }
+    ],
+    "type_sensitive_scale_values": [1, 1.0, "1", true],
+    "private_fields_excluded": [
+      "score_record.rationale",
+      "status_reason.note",
+      "moderation_record.rationale",
+      "evidence_locator.note",
+      "artifact_content",
+      "source_bytes"
+    ],
+    "downstream_policy_excluded": [
+      "grade",
+      "proficiency",
+      "mastery",
+      "academic_period_id",
+      "weight"
+    ]
+  },
   "records": [
     {
       "record_kind": "activity",

--- a/tests/test_academic_result_manifest_generation_issue31.py
+++ b/tests/test_academic_result_manifest_generation_issue31.py
@@ -1,0 +1,594 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.rosters import create_roster
+from pds_core.routing_models import ModuleWorkRef
+from pds_core.workspace import ensure_workspace_root
+
+from concord.academic_result_manifest import (
+    RevisionReason,
+    academic_result_manifest_from_bytes,
+)
+from concord.academic_result_manifest_generation import (
+    ConcordManifestGenerationConflictError,
+    ConcordManifestGenerationValidationError,
+    GenerateAcademicResultManifestRequest,
+    academic_result_manifest_relative_path,
+    generate_academic_result_manifest,
+    list_academic_result_manifest_revisions,
+    load_academic_result_manifest_head,
+    load_academic_result_manifest_revision,
+    manifest_generation_summary,
+)
+from concord.academic_work_registration import (
+    register_concord_academic_work,
+)
+from concord.models import (
+    PrivacyPolicy,
+    ScoreTargetReference,
+    ScoringScaleLevel,
+    StatusReason,
+    SubjectReference,
+)
+from concord.workflows import (
+    AddScoreRequest,
+    CreateActivityContextRequest,
+    CreateCriterionSetRequest,
+    CreateGroupRequest,
+    CreateScoringScaleRequest,
+    CriterionSpec,
+    ReplaceScoreRequest,
+    SelectActivityCriterionSetsRequest,
+    UpdateActivityRequest,
+    WorkflowActor,
+    add_score,
+    create_activity_context,
+    create_criterion_set,
+    create_group,
+    create_scoring_scale,
+    replace_score,
+    select_activity_criterion_sets,
+    update_activity,
+)
+from concord.workflows.context import actor_reference
+
+
+def _clock(hour: int) -> datetime:
+    return datetime(2026, 8, 14, hour, 0, tzinfo=timezone.utc)
+
+
+def _actor() -> WorkflowActor:
+    return WorkflowActor(
+        actor_id="teacher-1",
+        display_label="Synthetic Teacher",
+        role_label="teacher",
+    )
+
+
+def _student_subject() -> SubjectReference:
+    return SubjectReference(
+        subject_kind="core_student",
+        subject_id="student-1",
+        owning_system="core",
+    )
+
+
+def _workspace(
+    tmp_path: Path,
+) -> tuple[Path, int]:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata(
+            "class-1",
+            "2026-2027",
+            created_at=_clock(8),
+        ),
+    )
+    write_class_roster(
+        root,
+        create_roster(
+            "class-1",
+            (
+                {
+                    "student_id": "student-1",
+                    "last_name": "One",
+                    "first_name": "Alex",
+                    "period": "1",
+                },
+            ),
+        ),
+    )
+    activity = create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            title="Synthetic Publication Activity",
+            activity_type="project",
+            scoring_orientation="local_criteria_only",
+            session_id="session-1",
+            actor=_actor(),
+            activity_status="active",
+            session_status="active",
+            privacy_policy=PrivacyPolicy(
+                classification="classroom_shared"
+            ),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(9),
+    )
+    scale = create_scoring_scale(
+        CreateScoringScaleRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            scoring_scale_id="scale-1",
+            lineage_id="scale-lineage",
+            name="Local scale",
+            revision=1,
+            scale_type="teacher_defined",
+            levels=(
+                ScoringScaleLevel(
+                    value=1,
+                    label="One",
+                    meaning="First exact level.",
+                ),
+                ScoringScaleLevel(
+                    value=2,
+                    label="Two",
+                    meaning="Second exact level.",
+                ),
+            ),
+            status="active",
+            expected_snapshot_revision=activity.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(10),
+    )
+    criterion_set = create_criterion_set(
+        CreateCriterionSetRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            criterion_set_id="set-1",
+            lineage_id="set-lineage",
+            name="Local criteria",
+            purpose="Synthetic publication validation.",
+            revision=1,
+            scope="activity_specific",
+            criterion_set_kind="local",
+            criteria=(
+                CriterionSpec(
+                    criterion_id="criterion-1",
+                    key="collaboration",
+                    label="Collaboration",
+                    definition="Demonstrates collaborative practice.",
+                    criterion_kind="local",
+                    supported_target_kinds=(
+                        "core_student",
+                        "concord_group",
+                    ),
+                    default_scoring_scale_id="scale-1",
+                ),
+            ),
+            status="active",
+            expected_snapshot_revision=scale.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(11),
+    )
+    selected = select_activity_criterion_sets(
+        SelectActivityCriterionSetsRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            criterion_set_ids=("set-1",),
+            expected_snapshot_revision=(
+                criterion_set.commit.snapshot_revision
+            ),
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(12),
+    )
+    group = create_group(
+        CreateGroupRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_id="group-1",
+            label="Group One",
+            status="active",
+            expected_snapshot_revision=selected.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(13),
+    )
+    group_score = add_score(
+        AddScoreRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            score_record_id="score-group-1",
+            target_reference=ScoreTargetReference(
+                target_kind="concord_group",
+                target_id="group-1",
+                owning_system="concord",
+            ),
+            criterion_id="criterion-1",
+            scoring_scale_id="scale-1",
+            disposition="scored",
+            value=1,
+            basis="professional_judgment",
+            rationale=(
+                "Private teacher rationale must never appear in the manifest."
+            ),
+            privacy_policy=PrivacyPolicy(
+                classification="group_and_teacher",
+                audience_references=(
+                    SubjectReference(
+                        subject_kind="concord_group",
+                        subject_id="group-1",
+                        owning_system="concord",
+                    ),
+                ),
+            ),
+            expected_snapshot_revision=group.commit.snapshot_revision,
+            actor=_actor(),
+            session_id="session-1",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(14),
+    )
+    absent_reason = StatusReason(
+        reason_code="absent",
+        recorded_by=actor_reference(_actor()),
+        recorded_at=_clock(14).isoformat(),
+        note="Private absence note must never appear in the manifest.",
+    )
+    absent = add_score(
+        AddScoreRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            score_record_id="score-absent",
+            target_reference=ScoreTargetReference(
+                target_kind="core_student",
+                target_id="student-1",
+                owning_system="core",
+            ),
+            criterion_id="criterion-1",
+            scoring_scale_id="scale-1",
+            disposition="absent",
+            basis="professional_judgment",
+            rationale="Private non-score rationale.",
+            status_reason=absent_reason,
+            privacy_policy=PrivacyPolicy(
+                classification="teacher_and_subjects",
+                audience_references=(_student_subject(),),
+            ),
+            expected_snapshot_revision=(
+                group_score.commit.snapshot_revision
+            ),
+            actor=_actor(),
+            session_id="session-1",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(15),
+    )
+    register_concord_academic_work(
+        root,
+        "class-1",
+        "activity-1",
+        academic_intent="summative",
+        lifecycle="active",
+    )
+    return root, absent.commit.snapshot_revision
+
+
+def _request(
+    revision: int,
+    *,
+    reason: RevisionReason = "initial",
+) -> GenerateAcademicResultManifestRequest:
+    return GenerateAcademicResultManifestRequest(
+        class_id="class-1",
+        activity_id="activity-1",
+        expected_snapshot_revision=revision,
+        actor=_actor(),
+        revision_reason=reason,
+    )
+
+
+def test_generation_projects_native_scores_and_writes_revision_one(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    result = generate_academic_result_manifest(
+        _request(revision),
+        workspace_root=root,
+        clock=lambda: _clock(16),
+    )
+
+    assert result.disposition == "created"
+    assert result.revision == 1
+    assert result.registration_revision == 1
+    assert result.source_snapshot_revision == revision
+    assert result.relative_path == (
+        "classes/class-1/modules/concord/work/activity-1/"
+        "exports/manifests/academic_results/1.json"
+    )
+    assert result.path.read_bytes() == result.content
+    assert academic_result_manifest_from_bytes(result.content) == result.manifest
+    assert result.manifest.projection.source_snapshot_revision == revision
+    assert [item.score_record_id for item in result.manifest.scores] == [
+        "score-absent",
+        "score-group-1",
+    ]
+    group_score = result.manifest.scores[1]
+    assert group_score.target_reference.target_kind == "concord_group"
+    assert group_score.target_reference.target_id == "group-1"
+    assert group_score.value == 1
+    absent = result.manifest.scores[0]
+    assert absent.disposition == "absent"
+    assert absent.value is None
+    assert absent.status_reason is not None
+    assert absent.status_reason.reason_code == "absent"
+
+    assert result.manifest.privacy.classification == "teacher_restricted"
+    assert b"Private teacher rationale" not in result.content
+    assert b"Private absence note" not in result.content
+    assert b"Private non-score rationale" not in result.content
+    assert b"display_label_snapshot" not in result.content
+    assert b"role_snapshot" not in result.content
+
+    replay = generate_academic_result_manifest(
+        _request(revision),
+        workspace_root=root,
+        clock=lambda: _clock(17),
+    )
+    assert replay.disposition == "existing"
+    assert replay.revision == 1
+    assert replay.content == result.content
+
+    summary = manifest_generation_summary(result)
+    assert summary["score_count"] == 2
+    assert summary["current_score_count"] == 2
+    assert summary["historical_score_count"] == 0
+    assert summary["non_score_count"] == 1
+    assert summary["capabilities"] == ("criterion_scores",)
+
+
+def test_unrelated_native_change_reuses_existing_semantic_projection(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    first = generate_academic_result_manifest(
+        _request(revision),
+        workspace_root=root,
+        clock=lambda: _clock(16),
+    )
+    first_bytes = first.content
+
+    updated = update_activity(
+        UpdateActivityRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            description=(
+                "Operational description is intentionally outside the "
+                "academic-result projection."
+            ),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(17),
+    )
+    second = generate_academic_result_manifest(
+        _request(
+            updated.commit.snapshot_revision,
+            reason="native_state_change",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(18),
+    )
+
+    assert second.disposition == "existing"
+    assert second.revision == 1
+    assert second.content == first_bytes
+    assert second.source_snapshot_revision == revision
+    assert second.manifest.projection.source_snapshot_revision == revision
+    assert len(
+        list_academic_result_manifest_revisions(root, first.manifest.work)
+    ) == 1
+
+
+def test_material_score_revision_creates_next_manifest_revision(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    first = generate_academic_result_manifest(
+        _request(revision),
+        workspace_root=root,
+        clock=lambda: _clock(16),
+    )
+    first_bytes = first.content
+
+    replacement = replace_score(
+        ReplaceScoreRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            score_record_id="score-group-1",
+            replacement_score_record_id="score-group-2",
+            correction_id="correction-score-group",
+            reason="Additional observation changed the teacher judgment.",
+            target_reference=ScoreTargetReference(
+                target_kind="concord_group",
+                target_id="group-1",
+                owning_system="concord",
+            ),
+            criterion_id="criterion-1",
+            scoring_scale_id="scale-1",
+            disposition="scored",
+            value=2,
+            basis="professional_judgment",
+            rationale="Revised private teacher rationale.",
+            privacy_policy=PrivacyPolicy(
+                classification="group_and_teacher",
+                audience_references=(
+                    SubjectReference(
+                        subject_kind="concord_group",
+                        subject_id="group-1",
+                        owning_system="concord",
+                    ),
+                ),
+            ),
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            session_id="session-1",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(17),
+    )
+    second = generate_academic_result_manifest(
+        _request(
+            replacement.commit.snapshot_revision,
+            reason="native_state_change",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(18),
+    )
+
+    assert second.disposition == "created"
+    assert second.revision == 2
+    assert second.manifest.projection.source_snapshot_revision == (
+        replacement.commit.snapshot_revision
+    )
+    assert first.path.read_bytes() == first_bytes
+    assert first.content != second.content
+    assert first.manifest.projection.projection_digest != (
+        second.manifest.projection.projection_digest
+    )
+    states = {
+        item.score_record_id: item.current_state
+        for item in second.manifest.scores
+    }
+    assert states["score-group-1"] == "superseded"
+    assert states["score-group-2"] == "current"
+
+    history = list_academic_result_manifest_revisions(
+        root, first.manifest.work
+    )
+    assert [item.revision for item in history] == [1, 2]
+    assert load_academic_result_manifest_revision(
+        root, first.manifest.work, 1
+    ).content == first_bytes
+    assert load_academic_result_manifest_head(
+        root, first.manifest.work
+    ) == history[-1]
+
+
+def test_generation_rejects_stale_snapshot_before_writing(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    updated = update_activity(
+        UpdateActivityRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            description="Native revision advances.",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(16),
+    )
+    assert updated.commit.snapshot_revision > revision
+
+    with pytest.raises(ConcordManifestGenerationConflictError):
+        generate_academic_result_manifest(
+            _request(revision),
+            workspace_root=root,
+            clock=lambda: _clock(17),
+        )
+
+    work = updated.commit.work
+    assert list_academic_result_manifest_revisions(root, work) == ()
+
+
+def test_generation_requires_explicit_registration(tmp_path: Path) -> None:
+    root, _ = _workspace(tmp_path)
+
+    # The exact Core path is intentionally not relied on here; create a second
+    # unregistered Activity instead.
+    activity = create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-1",
+            activity_id="activity-unregistered",
+            title="Unregistered Activity",
+            activity_type="project",
+            scoring_orientation="evidence_only",
+            session_id="session-unregistered",
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(16),
+    )
+
+    with pytest.raises(
+        ConcordManifestGenerationValidationError,
+        match="explicit current Academic Work Registration",
+    ):
+        generate_academic_result_manifest(
+            GenerateAcademicResultManifestRequest(
+                class_id="class-1",
+                activity_id="activity-unregistered",
+                expected_snapshot_revision=activity.commit.snapshot_revision,
+                actor=_actor(),
+                revision_reason="initial",
+            ),
+            workspace_root=root,
+            clock=lambda: _clock(17),
+        )
+
+
+def test_generation_rejects_registration_title_drift(tmp_path: Path) -> None:
+    root, revision = _workspace(tmp_path)
+    updated = update_activity(
+        UpdateActivityRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            title="Title Changed After Registration",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(16),
+    )
+
+    with pytest.raises(
+        ConcordManifestGenerationValidationError,
+        match="explicitly update the registration",
+    ):
+        generate_academic_result_manifest(
+            _request(updated.commit.snapshot_revision),
+            workspace_root=root,
+            clock=lambda: _clock(17),
+        )
+
+
+def test_manifest_path_helper_is_exact() -> None:
+    work = ModuleWorkRef(
+        module_id="concord",
+        class_id="class-1",
+        work_id="activity-1",
+    )
+    assert academic_result_manifest_relative_path(work, 7) == (
+        "classes/class-1/modules/concord/work/activity-1/"
+        "exports/manifests/academic_results/7.json"
+    )

--- a/tests/test_academic_result_manifest_issue31.py
+++ b/tests/test_academic_result_manifest_issue31.py
@@ -1,0 +1,701 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+
+import pytest
+from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef
+
+from concord.academic_result_manifest import (
+    ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+    ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+    AcademicResultManifest,
+    ActivityContextProjection,
+    ConcordAcademicResultManifestDecodeError,
+    ConcordAcademicResultManifestValidationError,
+    CorePublicationReferenceProjection,
+    CriterionProjection,
+    CriterionSetProjection,
+    EvidenceLocatorProjection,
+    EvidenceReferenceProjection,
+    ManifestProjection,
+    ManifestRecordSet,
+    ModerationProjection,
+    PrivacyProjection,
+    PublicActor,
+    RecordReferenceProjection,
+    ScaleLevelProjection,
+    ScoreEvidenceLinkProjection,
+    ScoreProjection,
+    ScoringScaleProjection,
+    StandardsResultProjection,
+    StatusReasonProjection,
+    SubjectReferenceProjection,
+    TargetReferenceProjection,
+    academic_result_manifest_from_bytes,
+    academic_result_manifest_from_dict,
+    academic_result_manifest_to_bytes,
+    academic_result_manifest_to_dict,
+    calculate_semantic_projection_digest,
+    derive_manifest_capabilities,
+    validate_academic_result_manifest,
+    with_semantic_projection_digest,
+)
+
+
+def _time(hour: int) -> datetime:
+    return datetime(2026, 8, 14, hour, 0, tzinfo=timezone.utc)
+
+
+def _actor(actor_id: str = "teacher-1") -> PublicActor:
+    return PublicActor(
+        actor_kind="authorized_adult",
+        actor_id=actor_id,
+        owning_system="concord",
+    )
+
+
+def _external_evidence() -> EvidenceReferenceProjection:
+    student = SubjectReferenceProjection(
+        subject_kind="core_student",
+        subject_id="student-1",
+        owning_system="core",
+        contract_version=None,
+    )
+    return EvidenceReferenceProjection(
+        evidence_kind="scoreform_result",
+        owning_system="scoreform",
+        record_id="result-1",
+        contract_version="scoreform_result_v1",
+        source_publication_reference=CorePublicationReferenceProjection(
+            publication_id="pub_" + ("a" * 32),
+            publication_schema_version="1",
+        ),
+        immutable_source_version=None,
+        locator=EvidenceLocatorProjection(
+            page_number=1,
+            source_page_index=0,
+            section_label="Question 1",
+            row_label=None,
+            column_label=None,
+            participant_label=None,
+            session_id="session-1",
+        ),
+        subject_context=(student,),
+        moderation_requirement="required",
+    )
+
+
+def _manifest() -> AcademicResultManifest:
+    work = ModuleWorkRef(
+        module_id="concord",
+        class_id="class-1",
+        work_id="activity-1",
+    )
+    source = ModuleRecordRef(
+        module_id="concord",
+        record_kind="activity",
+        record_id="activity-1",
+        contract_version="concord_activity_v1",
+    )
+    teacher = _actor()
+    external = _external_evidence()
+    student = SubjectReferenceProjection(
+        subject_kind="core_student",
+        subject_id="student-1",
+        owning_system="core",
+        contract_version=None,
+    )
+
+    local_set = CriterionSetProjection(
+        criterion_set_id="set-local",
+        lineage_id="lineage-local",
+        revision=1,
+        criterion_set_kind="local",
+        scope="activity_specific",
+        criterion_ids=("criterion-local",),
+        status="active",
+        supersedes_criterion_set_id=None,
+        standards_profile_id=None,
+    )
+    standard_set = CriterionSetProjection(
+        criterion_set_id="set-standard",
+        lineage_id="lineage-standard",
+        revision=1,
+        criterion_set_kind="standard_backed",
+        scope="activity_specific",
+        criterion_ids=("criterion-standard",),
+        status="active",
+        supersedes_criterion_set_id=None,
+        standards_profile_id="profile-1",
+    )
+    local_criterion = CriterionProjection(
+        criterion_id="criterion-local",
+        criterion_set_id="set-local",
+        key="collaboration",
+        label="Collaboration",
+        definition="Demonstrates effective collaborative practice.",
+        criterion_kind="local",
+        supported_target_kinds=("concord_group",),
+        status="active",
+        standard_id=None,
+        alignment_standard_ids=("standard-2",),
+        default_scoring_scale_id="scale-local",
+    )
+    standard_criterion = CriterionProjection(
+        criterion_id="criterion-standard",
+        criterion_set_id="set-standard",
+        key="analysis",
+        label="Analysis",
+        definition="Uses evidence to support analysis.",
+        criterion_kind="standard_backed",
+        supported_target_kinds=("core_student",),
+        status="active",
+        standard_id="standard-1",
+        alignment_standard_ids=(),
+        default_scoring_scale_id="scale-standard",
+    )
+    local_scale = ScoringScaleProjection(
+        scoring_scale_id="scale-local",
+        lineage_id="scale-lineage-local",
+        name="Typed local scale",
+        revision=1,
+        scale_type="teacher_defined",
+        levels=(
+            ScaleLevelProjection(1, "Integer", "Integer one.", None, None),
+            ScaleLevelProjection(1.0, "Float", "Float one.", None, None),
+            ScaleLevelProjection("1", "Text", "Text one.", None, None),
+            ScaleLevelProjection(True, "Boolean", "Boolean true.", None, None),
+        ),
+        status="active",
+        supersedes_scoring_scale_id=None,
+    )
+    standard_scale = ScoringScaleProjection(
+        scoring_scale_id="scale-standard",
+        lineage_id="scale-lineage-standard",
+        name="Standards scale",
+        revision=1,
+        scale_type="ordinal",
+        levels=(
+            ScaleLevelProjection(
+                "developing", "Developing", "Developing evidence.", 1, None
+            ),
+            ScaleLevelProjection(
+                "meets", "Meets", "Meets the criterion.", 2, None
+            ),
+        ),
+        status="active",
+        supersedes_scoring_scale_id=None,
+    )
+    local_score = ScoreProjection(
+        score_record_id="score-local",
+        activity_id="activity-1",
+        session_id=None,
+        target_reference=TargetReferenceProjection(
+            target_kind="concord_group",
+            target_id="group-1",
+            owning_system="concord",
+            contract_version=None,
+        ),
+        criterion_id="criterion-local",
+        score_kind="local",
+        standard_id=None,
+        scoring_scale_id="scale-local",
+        disposition="scored",
+        value=True,
+        basis="professional_judgment",
+        scorer=teacher,
+        scored_at=_time(13),
+        moderation_complete=True,
+        status_reason=None,
+        supersedes_score_record_id=None,
+        current_state="current",
+    )
+    standard_score = ScoreProjection(
+        score_record_id="score-standard",
+        activity_id="activity-1",
+        session_id="session-1",
+        target_reference=TargetReferenceProjection(
+            target_kind="core_student",
+            target_id="student-1",
+            owning_system="core",
+            contract_version=None,
+        ),
+        criterion_id="criterion-standard",
+        score_kind="standard_backed",
+        standard_id="standard-1",
+        scoring_scale_id="scale-standard",
+        disposition="scored",
+        value="meets",
+        basis="linked_evidence",
+        scorer=teacher,
+        scored_at=_time(13),
+        moderation_complete=True,
+        status_reason=None,
+        supersedes_score_record_id=None,
+        current_state="current",
+    )
+    moderation = ModerationProjection(
+        moderation_record_id="moderation-1",
+        target_evidence_reference=external,
+        target_subject_references=(student,),
+        status="accepted",
+        permitted_use="support_named_subject",
+        qualification=None,
+        supersedes_moderation_record_id=None,
+        current_state="current",
+    )
+    link = ScoreEvidenceLinkProjection(
+        score_evidence_link_id="link-1",
+        score_record_id="score-standard",
+        evidence_reference=external,
+        evidence_locator=EvidenceLocatorProjection(
+            page_number=1,
+            source_page_index=0,
+            section_label="Question 1",
+            row_label=None,
+            column_label=None,
+            participant_label=None,
+            session_id="session-1",
+        ),
+        subject_context=(student,),
+        relevance_description="Direct evidence for the selected criterion.",
+        significance="primary",
+        moderation_record_id="moderation-1",
+        status="active",
+        supersedes_score_evidence_link_id=None,
+    )
+    manifest = AcademicResultManifest(
+        record_type=ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+        contract_version=ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+        producer_module_id="concord",
+        generated_at=_time(14),
+        record_set=ManifestRecordSet("academic_results", 1),
+        work=work,
+        source_activity=source,
+        projection=ManifestProjection(
+            source_snapshot_revision=12,
+            projection_digest_algorithm="sha256",
+            projection_digest="0" * 64,
+            generated_by=teacher,
+            revision_reason="initial",
+        ),
+        activity_context=ActivityContextProjection(
+            activity_id="activity-1",
+            class_id="class-1",
+            title="Synthetic Collaborative Activity",
+            scoring_orientation="mixed",
+            standards_profile_id="profile-1",
+            focus_standard_ids=("standard-1",),
+            criterion_set_ids=("set-standard", "set-local"),
+        ),
+        criterion_sets=(local_set, standard_set),
+        criteria=(local_criterion, standard_criterion),
+        scoring_scales=(local_scale, standard_scale),
+        scores=(local_score, standard_score),
+        score_evidence_links=(link,),
+        moderation_records=(moderation,),
+        standards_result_projection=(
+            StandardsResultProjection("score-standard", "standard-1"),
+        ),
+        privacy=PrivacyProjection(
+            classification="teacher_and_subjects",
+            audience_references=(student,),
+            policy_reference=None,
+            inherited_from=None,
+        ),
+    )
+    return with_semantic_projection_digest(manifest)
+
+
+def test_manifest_round_trip_is_exact_and_canonical() -> None:
+    manifest = _manifest()
+    data = academic_result_manifest_to_bytes(manifest)
+
+    assert data.endswith(b"\n")
+    assert not data.endswith(b"\n\n")
+    assert data == academic_result_manifest_to_bytes(
+        academic_result_manifest_from_bytes(data)
+    )
+    assert academic_result_manifest_from_bytes(data) == manifest
+
+    native = academic_result_manifest_to_dict(manifest)
+    assert academic_result_manifest_from_dict(native) == manifest
+
+
+def test_manifest_preserves_type_sensitive_scale_values() -> None:
+    restored = academic_result_manifest_from_bytes(
+        academic_result_manifest_to_bytes(_manifest())
+    )
+    levels = restored.scoring_scales[0].levels
+
+    assert type(levels[0].value) is int
+    assert type(levels[1].value) is float
+    assert type(levels[2].value) is str
+    assert type(levels[3].value) is bool
+    assert [level.value for level in levels] == [1, 1.0, "1", True]
+    assert type(restored.scores[0].value) is bool
+
+
+def test_capabilities_are_derived_from_exact_manifest_semantics() -> None:
+    manifest = _manifest()
+    assert derive_manifest_capabilities(manifest) == (
+        "criterion_scores",
+        "standards_ratings",
+        "moderated_scores",
+    )
+
+    unmoderated_evidence = replace(
+        manifest.score_evidence_links[0].evidence_reference,
+        moderation_requirement="not_required",
+    )
+    unmoderated_link = replace(
+        manifest.score_evidence_links[0],
+        evidence_reference=unmoderated_evidence,
+        moderation_record_id=None,
+    )
+    no_moderation = replace(
+        manifest,
+        score_evidence_links=(unmoderated_link,),
+        moderation_records=(),
+        projection=replace(
+            manifest.projection, projection_digest="0" * 64
+        ),
+    )
+    no_moderation = with_semantic_projection_digest(no_moderation)
+    assert derive_manifest_capabilities(no_moderation) == (
+        "criterion_scores",
+        "standards_ratings",
+    )
+
+
+def test_semantic_digest_ignores_revision_envelope_only() -> None:
+    manifest = _manifest()
+    original = calculate_semantic_projection_digest(manifest)
+
+    envelope_change = replace(
+        manifest,
+        generated_at=_time(16),
+        record_set=ManifestRecordSet("academic_results", 9),
+        projection=replace(
+            manifest.projection,
+            source_snapshot_revision=99,
+            generated_by=_actor("teacher-2"),
+            revision_reason="native_state_change",
+            projection_digest="0" * 64,
+        ),
+    )
+    assert calculate_semantic_projection_digest(envelope_change) == original
+
+    changed_score = replace(manifest.scores[0], value="1")
+    semantic_change = replace(
+        manifest,
+        scores=(changed_score, manifest.scores[1]),
+        projection=replace(
+            manifest.projection,
+            projection_digest="0" * 64,
+        ),
+    )
+    assert calculate_semantic_projection_digest(semantic_change) != original
+
+
+def test_manifest_rejects_unknown_or_private_fields() -> None:
+    native = academic_result_manifest_to_dict(_manifest())
+    score = native["scores"][0]
+    assert isinstance(score, dict)
+    score["rationale"] = "This must not be public."
+
+    with pytest.raises(ConcordAcademicResultManifestValidationError):
+        academic_result_manifest_from_dict(native)
+
+
+def test_manifest_projection_omits_private_narrative_fields() -> None:
+    native = academic_result_manifest_to_dict(_manifest())
+    encoded = repr(native)
+
+    assert "rationale" not in encoded
+    assert "'note'" not in encoded
+    assert "aggregation_guidance" not in encoded
+    assert "created_provenance" not in encoded
+    assert "display_label_snapshot" not in encoded
+    assert "role_snapshot" not in encoded
+
+
+def test_non_score_requires_matching_minimized_status_reason() -> None:
+    manifest = _manifest()
+    local = manifest.scores[0]
+    absent = replace(
+        local,
+        disposition="absent",
+        value=None,
+        status_reason=StatusReasonProjection(
+            reason_code="absent",
+            recorded_by=_actor(),
+            recorded_at=_time(13),
+            related_record=RecordReferenceProjection(
+                module_id="concord",
+                record_kind="session",
+                record_id="session-1",
+                contract_version=None,
+            ),
+        ),
+    )
+    candidate = replace(
+        manifest,
+        scores=(absent, manifest.scores[1]),
+        projection=replace(
+            manifest.projection, projection_digest="0" * 64
+        ),
+    )
+    validated = with_semantic_projection_digest(candidate)
+    assert validated.scores[0].value is None
+    assert validated.scores[0].status_reason is not None
+    assert validated.scores[0].status_reason.reason_code == "absent"
+
+    native = academic_result_manifest_to_dict(validated)
+    first_score = native["scores"][0]
+    assert isinstance(first_score, dict)
+    assert "value" not in first_score
+    assert "status_reason" in first_score
+
+    scored_native = academic_result_manifest_to_dict(manifest)
+    scored = scored_native["scores"][0]
+    assert isinstance(scored, dict)
+    assert "value" in scored
+    assert "status_reason" not in scored
+
+    moderation = scored_native["moderation_records"][0]
+    assert isinstance(moderation, dict)
+    assert "qualification" not in moderation
+
+    with pytest.raises(ConcordAcademicResultManifestValidationError):
+        replace(absent, status_reason=None)
+
+
+def test_score_value_must_match_scale_type_sensitively() -> None:
+    manifest = _manifest()
+    local = manifest.scores[0]
+
+    # True is an exact level; a different unsupported value is not.
+    invalid = replace(local, value=False)
+    candidate = replace(
+        manifest,
+        scores=(invalid, manifest.scores[1]),
+        projection=replace(
+            manifest.projection, projection_digest="0" * 64
+        ),
+    )
+    candidate = replace(
+        candidate,
+        projection=replace(
+            candidate.projection,
+            projection_digest=calculate_semantic_projection_digest(candidate),
+        ),
+    )
+    with pytest.raises(ConcordAcademicResultManifestValidationError):
+        validate_academic_result_manifest(candidate)
+
+
+def test_standards_projection_is_exact_standard_backed_subset() -> None:
+    manifest = _manifest()
+
+    missing = replace(
+        manifest,
+        standards_result_projection=(),
+        projection=replace(
+            manifest.projection, projection_digest="0" * 64
+        ),
+    )
+    missing = replace(
+        missing,
+        projection=replace(
+            missing.projection,
+            projection_digest=calculate_semantic_projection_digest(missing),
+        ),
+    )
+    with pytest.raises(ConcordAcademicResultManifestValidationError):
+        validate_academic_result_manifest(missing)
+
+    extra = replace(
+        manifest,
+        standards_result_projection=(
+            StandardsResultProjection("score-local", "standard-2"),
+            StandardsResultProjection("score-standard", "standard-1"),
+        ),
+        projection=replace(
+            manifest.projection, projection_digest="0" * 64
+        ),
+    )
+    extra = replace(
+        extra,
+        projection=replace(
+            extra.projection,
+            projection_digest=calculate_semantic_projection_digest(extra),
+        ),
+    )
+    with pytest.raises(ConcordAcademicResultManifestValidationError):
+        validate_academic_result_manifest(extra)
+
+
+def test_current_state_derives_only_from_explicit_score_supersession() -> None:
+    manifest = _manifest()
+    predecessor = replace(
+        manifest.scores[0],
+        score_record_id="score-local-1",
+        current_state="superseded",
+    )
+    successor = replace(
+        manifest.scores[0],
+        score_record_id="score-local-2",
+        supersedes_score_record_id="score-local-1",
+        current_state="current",
+        scored_at=_time(14),
+    )
+    candidate = replace(
+        manifest,
+        scores=(predecessor, successor, manifest.scores[1]),
+        projection=replace(
+            manifest.projection, projection_digest="0" * 64
+        ),
+    )
+    validated = with_semantic_projection_digest(candidate)
+    assert [item.current_state for item in validated.scores[:2]] == [
+        "superseded",
+        "current",
+    ]
+
+    wrong = replace(
+        validated,
+        scores=(
+            replace(predecessor, current_state="current"),
+            successor,
+            validated.scores[2],
+        ),
+        projection=replace(
+            validated.projection, projection_digest="0" * 64
+        ),
+    )
+    wrong = replace(
+        wrong,
+        projection=replace(
+            wrong.projection,
+            projection_digest=calculate_semantic_projection_digest(wrong),
+        ),
+    )
+    with pytest.raises(ConcordAcademicResultManifestValidationError):
+        validate_academic_result_manifest(wrong)
+
+
+def test_manifest_rejects_evidence_only_or_empty_score_projection() -> None:
+    manifest = _manifest()
+
+    evidence_only = replace(
+        manifest,
+        activity_context=replace(
+            manifest.activity_context,
+            scoring_orientation="evidence_only",
+        ),
+        projection=replace(
+            manifest.projection, projection_digest="0" * 64
+        ),
+    )
+    evidence_only = replace(
+        evidence_only,
+        projection=replace(
+            evidence_only.projection,
+            projection_digest=calculate_semantic_projection_digest(
+                evidence_only
+            ),
+        ),
+    )
+    with pytest.raises(ConcordAcademicResultManifestValidationError):
+        validate_academic_result_manifest(evidence_only)
+
+    empty = replace(
+        manifest,
+        scores=(),
+        score_evidence_links=(),
+        moderation_records=(),
+        standards_result_projection=(),
+        projection=replace(
+            manifest.projection, projection_digest="0" * 64
+        ),
+    )
+    empty = replace(
+        empty,
+        projection=replace(
+            empty.projection,
+            projection_digest=calculate_semantic_projection_digest(empty),
+        ),
+    )
+    with pytest.raises(ConcordAcademicResultManifestValidationError):
+        validate_academic_result_manifest(empty)
+
+
+def test_strict_decoder_rejects_duplicate_keys_and_noncanonical_json() -> None:
+    data = academic_result_manifest_to_bytes(_manifest())
+
+    duplicate = data.replace(
+        b'{"activity_context":',
+        b'{"activity_context":null,"activity_context":',
+        1,
+    )
+    with pytest.raises(ConcordAcademicResultManifestDecodeError):
+        academic_result_manifest_from_bytes(duplicate)
+
+    noncanonical = data.replace(b":", b": ", 1)
+    with pytest.raises(ConcordAcademicResultManifestDecodeError):
+        academic_result_manifest_from_bytes(noncanonical)
+
+
+def test_identity_and_exact_moderation_evidence_are_cross_validated() -> None:
+    manifest = _manifest()
+
+    wrong_source = replace(
+        manifest,
+        source_activity=ModuleRecordRef(
+            module_id="concord",
+            record_kind="activity",
+            record_id="activity-other",
+            contract_version="concord_activity_v1",
+        ),
+        projection=replace(
+            manifest.projection, projection_digest="0" * 64
+        ),
+    )
+    wrong_source = replace(
+        wrong_source,
+        projection=replace(
+            wrong_source.projection,
+            projection_digest=calculate_semantic_projection_digest(
+                wrong_source
+            ),
+        ),
+    )
+    with pytest.raises(ConcordAcademicResultManifestValidationError):
+        validate_academic_result_manifest(wrong_source)
+
+    other_evidence = replace(
+        manifest.score_evidence_links[0].evidence_reference,
+        record_id="result-other",
+    )
+    wrong_moderation = replace(
+        manifest.moderation_records[0],
+        target_evidence_reference=other_evidence,
+    )
+    mismatch = replace(
+        manifest,
+        moderation_records=(wrong_moderation,),
+        projection=replace(
+            manifest.projection, projection_digest="0" * 64
+        ),
+    )
+    mismatch = replace(
+        mismatch,
+        projection=replace(
+            mismatch.projection,
+            projection_digest=calculate_semantic_projection_digest(mismatch),
+        ),
+    )
+    with pytest.raises(ConcordAcademicResultManifestValidationError):
+        validate_academic_result_manifest(mismatch)

--- a/tests/test_academic_result_publication_cli_menu_issue31.py
+++ b/tests/test_academic_result_publication_cli_menu_issue31.py
@@ -1,0 +1,442 @@
+from __future__ import annotations
+
+import argparse
+import inspect
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import cast
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.rosters import create_roster
+from pds_core.workspace import ensure_workspace_root
+
+import concord.cli_app.handlers.publication as publication_handler
+import concord.menu_activity as menu_activity
+import concord.menu_publication as menu_publication
+from concord.academic_result_manifest import RevisionReason
+from concord.academic_result_manifest_generation import (
+    GenerateAcademicResultManifestRequest,
+    list_academic_result_manifest_revisions,
+    manifest_preview_summary,
+    preview_academic_result_manifest,
+)
+from concord.academic_result_publication import (
+    ConcordAcademicResultPublicationConflictError,
+    ConcordAcademicResultPublicationPartialSuccessError,
+    PublicationPartialSuccessState,
+)
+from concord.academic_work_registration import register_concord_academic_work
+from concord.cli import build_parser, main
+from concord.menu_context import MenuSessionContext
+from concord.models import PrivacyPolicy, ScoreTargetReference, ScoringScaleLevel
+from concord.pds_contract import CONCORD_MODULE_ID
+from concord.workflows import (
+    ActivitySummary,
+    AddScoreRequest,
+    CreateActivityContextRequest,
+    CreateCriterionSetRequest,
+    CreateScoringScaleRequest,
+    CriterionSpec,
+    SelectActivityCriterionSetsRequest,
+    WorkflowActor,
+    add_score,
+    create_activity_context,
+    create_criterion_set,
+    create_scoring_scale,
+    select_activity_criterion_sets,
+)
+
+
+def _clock(hour: int) -> datetime:
+    return datetime(2026, 8, 14, hour, 0, tzinfo=timezone.utc)
+
+
+def _actor() -> WorkflowActor:
+    return WorkflowActor(
+        actor_id="teacher-1",
+        display_label="Synthetic Teacher",
+        role_label="teacher",
+    )
+
+
+def _workspace(tmp_path: Path) -> tuple[Path, int]:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata(
+            "class-1",
+            "2026-2027",
+            created_at=_clock(8),
+        ),
+    )
+    write_class_roster(
+        root,
+        create_roster(
+            "class-1",
+            (
+                {
+                    "student_id": "student-1",
+                    "last_name": "One",
+                    "first_name": "Alex",
+                    "period": "1",
+                },
+            ),
+        ),
+    )
+    activity = create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            title="Synthetic Publication Activity",
+            activity_type="project",
+            scoring_orientation="local_criteria_only",
+            session_id="session-1",
+            actor=_actor(),
+            activity_status="active",
+            session_status="active",
+            privacy_policy=PrivacyPolicy(classification="teacher_restricted"),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(9),
+    )
+    scale = create_scoring_scale(
+        CreateScoringScaleRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            scoring_scale_id="scale-1",
+            lineage_id="scale-lineage",
+            name="Local scale",
+            revision=1,
+            scale_type="teacher_defined",
+            levels=(
+                ScoringScaleLevel(
+                    value=1,
+                    label="One",
+                    meaning="First exact level.",
+                ),
+                ScoringScaleLevel(
+                    value=2,
+                    label="Two",
+                    meaning="Second exact level.",
+                ),
+            ),
+            status="active",
+            expected_snapshot_revision=activity.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(10),
+    )
+    criterion_set = create_criterion_set(
+        CreateCriterionSetRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            criterion_set_id="set-1",
+            lineage_id="set-lineage",
+            name="Local criteria",
+            purpose="Synthetic publication validation.",
+            revision=1,
+            scope="activity_specific",
+            criterion_set_kind="local",
+            criteria=(
+                CriterionSpec(
+                    criterion_id="criterion-1",
+                    key="collaboration",
+                    label="Collaboration",
+                    definition="Demonstrates collaborative practice.",
+                    criterion_kind="local",
+                    supported_target_kinds=("core_student",),
+                    default_scoring_scale_id="scale-1",
+                ),
+            ),
+            status="active",
+            expected_snapshot_revision=scale.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(11),
+    )
+    selected = select_activity_criterion_sets(
+        SelectActivityCriterionSetsRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            criterion_set_ids=("set-1",),
+            expected_snapshot_revision=criterion_set.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(12),
+    )
+    scored = add_score(
+        AddScoreRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            score_record_id="score-1",
+            target_reference=ScoreTargetReference(
+                target_kind="core_student",
+                target_id="student-1",
+                owning_system="core",
+            ),
+            criterion_id="criterion-1",
+            scoring_scale_id="scale-1",
+            disposition="scored",
+            value=1,
+            basis="professional_judgment",
+            rationale="Private publication rationale.",
+            privacy_policy=PrivacyPolicy(classification="teacher_restricted"),
+            expected_snapshot_revision=selected.commit.snapshot_revision,
+            actor=_actor(),
+            session_id="session-1",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(13),
+    )
+    register_concord_academic_work(
+        root,
+        "class-1",
+        "activity-1",
+        academic_intent="summative",
+        lifecycle="active",
+    )
+    return root, scored.commit.snapshot_revision
+
+
+def _request(
+    revision: int,
+    *,
+    reason: RevisionReason = "initial",
+) -> GenerateAcademicResultManifestRequest:
+    return GenerateAcademicResultManifestRequest(
+        class_id="class-1",
+        activity_id="activity-1",
+        expected_snapshot_revision=revision,
+        actor=_actor(),
+        revision_reason=reason,
+    )
+
+def _publication_actions(parser: argparse.ArgumentParser) -> set[str]:
+    top = next(
+        action
+        for action in parser._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+    publication = top.choices["publication"]
+    nested = next(
+        action
+        for action in publication._actions
+        if isinstance(action, argparse._SubParsersAction)
+    )
+    return set(nested.choices)
+
+
+def test_parser_exposes_complete_publication_command_family() -> None:
+    actions = _publication_actions(build_parser())
+    assert {
+        "register",
+        "registration-show",
+        "registration-update",
+        "manifest-generate",
+        "manifest-list",
+        "manifest-show",
+        "publish",
+        "supersede",
+        "withdraw",
+        "series-show",
+        "catalog-list",
+        "catalog-rebuild",
+    } <= actions
+
+
+def test_read_only_manifest_preview_does_not_create_manifest(tmp_path: Path) -> None:
+    root, revision = _workspace(tmp_path)
+    preview = preview_academic_result_manifest(
+        _request(revision),
+        workspace_root=root,
+    )
+    summary = manifest_preview_summary(preview)
+    assert preview.disposition == "would_create"
+    assert summary["registration_revision"] == 1
+    assert summary["source_snapshot_revision"] == revision
+    assert summary["score_count"] == 1
+    assert summary["current_score_count"] == 1
+    assert summary["historical_score_count"] == 0
+    assert summary["local_score_count"] == 1
+    assert summary["non_score_count"] == 0
+    assert summary["manifest_sha256"] == preview.sha256
+    assert not preview.path.exists()
+    history = list_academic_result_manifest_revisions(
+        root, preview.manifest.work
+    )
+    assert history == ()
+
+
+def test_direct_manifest_commands_are_compact_and_safe(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root, revision = _workspace(tmp_path)
+    common = [
+        "publication",
+        "manifest-generate",
+        "--workspace-root",
+        str(root),
+        "--class-id",
+        "class-1",
+        "--activity-id",
+        "activity-1",
+        "--expected-snapshot",
+        str(revision),
+        "--actor-id",
+        "teacher-1",
+        "--revision-reason",
+        "initial",
+    ]
+    assert main(common) == 0
+    generated = capsys.readouterr().out
+    assert "Record-set revision: 1" in generated
+    assert "Private publication rationale" not in generated
+
+    assert main(
+        [
+            "publication",
+            "manifest-list",
+            "--workspace-root",
+            str(root),
+            "--class-id",
+            "class-1",
+            "--activity-id",
+            "activity-1",
+        ]
+    ) == 0
+    listed = capsys.readouterr().out
+    assert "1\t" in listed
+    assert "Private publication rationale" not in listed
+
+    assert main(
+        [
+            "publication",
+            "manifest-show",
+            "--workspace-root",
+            str(root),
+            "--class-id",
+            "class-1",
+            "--activity-id",
+            "activity-1",
+            "--revision",
+            "1",
+        ]
+    ) == 0
+    shown = capsys.readouterr().out
+    assert '"record_type":"concord_academic_result_manifest"' in shown
+    assert "Private publication rationale" not in shown
+
+
+def test_publication_errors_preserve_cli_exit_contract(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def conflict(_args: argparse.Namespace) -> int:
+        raise ConcordAcademicResultPublicationConflictError("stale head")
+
+    monkeypatch.setattr(publication_handler, "handle_series_show", conflict)
+    code = main(
+        [
+            "publication",
+            "series-show",
+            "--class-id",
+            "class-1",
+            "--activity-id",
+            "activity-1",
+        ]
+    )
+    assert code == 3
+    assert "Conflict: stale head" in capsys.readouterr().err
+
+    state = PublicationPartialSuccessState(
+        operation="publish",
+        canonical_state="confirmed",
+        manifest_generation=None,
+        generation_partial_state=None,
+        publication=None,
+        recommended_next_action="rebuild catalog",
+    )
+
+    def partial(_args: argparse.Namespace) -> int:
+        raise ConcordAcademicResultPublicationPartialSuccessError(
+            "catalog stale", state
+        )
+
+    monkeypatch.setattr(publication_handler, "handle_series_show", partial)
+    code = main(
+        [
+            "publication",
+            "series-show",
+            "--class-id",
+            "class-1",
+            "--activity-id",
+            "activity-1",
+        ]
+    )
+    assert code == 4
+    error = capsys.readouterr().err
+    assert "Partial success: catalog stale" in error
+    assert "rebuild catalog" in error
+
+
+def test_activity_menu_places_publication_immediately_after_scoring() -> None:
+    source = inspect.getsource(menu_activity.launch_activity_context_menu)
+    assert source.index('print("8. Scoring")') < source.index(
+        'print("9. Publication")'
+    )
+    assert source.index('print("9. Publication")') < source.index(
+        'print("10. Edit Activity")'
+    )
+
+
+def test_entering_publication_menu_then_back_has_no_write_side_effect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    forbidden_names = (
+        "register_concord_academic_work",
+        "update_academic_work_registration",
+        "generate_academic_result_manifest",
+        "publish_concord_academic_results",
+        "supersede_concord_academic_results",
+        "republish_concord_academic_results_after_withdrawal",
+        "withdraw_concord_academic_result_publication",
+        "rebuild_full_academic_catalog",
+    )
+
+    def forbidden(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("publication menu entry must not mutate state")
+
+    for name in forbidden_names:
+        monkeypatch.setattr(menu_publication, name, forbidden)
+    answers = iter(("b",))
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    activity = cast(
+        ActivitySummary,
+        type(
+            "SyntheticActivity",
+            (),
+            {
+                "title": "Synthetic",
+                "class_id": "class-1",
+                "activity_id": "activity-1",
+                "snapshot_revision": 1,
+            },
+        )(),
+    )
+    menu_publication.launch_publication_menu(activity, MenuSessionContext())
+
+
+def test_publication_handler_uses_concord_work_identity() -> None:
+    args = argparse.Namespace(class_id="class-1", activity_id="activity-1")
+    work = publication_handler._work(args)
+    assert work.module_id == CONCORD_MODULE_ID
+    assert work.class_id == "class-1"
+    assert work.work_id == "activity-1"

--- a/tests/test_academic_result_publication_issue31.py
+++ b/tests/test_academic_result_publication_issue31.py
@@ -1,0 +1,1144 @@
+from __future__ import annotations
+
+import tomllib
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.academic_catalog import AcademicCatalogBuildError
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.publication_records import PUBLICATION_RECORD_SCHEMA_VERSION
+from pds_core.publication_storage import (
+    get_current_publication_record,
+    load_publication_withdrawal,
+)
+from pds_core.rosters import create_roster
+from pds_core.routing_models import ModuleRecordRef
+from pds_core.workspace import ensure_workspace_root
+
+import concord.academic_result_publication as publication_module
+from concord.academic_result_manifest import RevisionReason
+from concord.academic_result_manifest_generation import (
+    GenerateAcademicResultManifestRequest,
+    load_academic_result_manifest_revision,
+)
+from concord.academic_result_publication import (
+    ConcordAcademicResultPublicationConflictError,
+    ConcordAcademicResultPublicationIntegrityError,
+    ConcordAcademicResultPublicationNotFoundError,
+    ConcordAcademicResultPublicationPartialSuccessError,
+    load_concord_publication_series_status,
+    publish_concord_academic_results,
+    query_concord_publication_catalog,
+    rebuild_concord_publication_catalog,
+    republish_concord_academic_results_after_withdrawal,
+    supersede_concord_academic_results,
+    withdraw_concord_academic_result_publication,
+)
+from concord.academic_work_registration import register_concord_academic_work
+from concord.models import PrivacyPolicy, ScoreTargetReference, ScoringScaleLevel
+from concord.pds_contract import (
+    CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+    CONCORD_ACADEMIC_WORK_CONTRACT_VERSION,
+    CONCORD_ACTIVITY_CONTRACT_VERSION,
+    CONCORD_ACTIVITY_RECORD_KIND,
+    CONCORD_DISPLAY_NAME,
+    CONCORD_MODULE_ID,
+)
+from concord.pds_publication import get_publication_producer_profile
+from concord.workflows import (
+    AddScoreRequest,
+    CreateActivityContextRequest,
+    CreateCriterionSetRequest,
+    CreateScoringScaleRequest,
+    CriterionSpec,
+    ReplaceScoreRequest,
+    SelectActivityCriterionSetsRequest,
+    WorkflowActor,
+    add_score,
+    create_activity_context,
+    create_criterion_set,
+    create_scoring_scale,
+    replace_score,
+    select_activity_criterion_sets,
+)
+
+
+def _clock(hour: int) -> datetime:
+    return datetime(2026, 8, 14, hour, 0, tzinfo=timezone.utc)
+
+
+def _actor() -> WorkflowActor:
+    return WorkflowActor(
+        actor_id="teacher-1",
+        display_label="Synthetic Teacher",
+        role_label="teacher",
+    )
+
+
+def _workspace(tmp_path: Path) -> tuple[Path, int]:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata(
+            "class-1",
+            "2026-2027",
+            created_at=_clock(8),
+        ),
+    )
+    write_class_roster(
+        root,
+        create_roster(
+            "class-1",
+            (
+                {
+                    "student_id": "student-1",
+                    "last_name": "One",
+                    "first_name": "Alex",
+                    "period": "1",
+                },
+            ),
+        ),
+    )
+    activity = create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            title="Synthetic Publication Activity",
+            activity_type="project",
+            scoring_orientation="local_criteria_only",
+            session_id="session-1",
+            actor=_actor(),
+            activity_status="active",
+            session_status="active",
+            privacy_policy=PrivacyPolicy(
+                classification="teacher_restricted"
+            ),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(9),
+    )
+    scale = create_scoring_scale(
+        CreateScoringScaleRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            scoring_scale_id="scale-1",
+            lineage_id="scale-lineage",
+            name="Local scale",
+            revision=1,
+            scale_type="teacher_defined",
+            levels=(
+                ScoringScaleLevel(
+                    value=1,
+                    label="One",
+                    meaning="First exact level.",
+                ),
+                ScoringScaleLevel(
+                    value=2,
+                    label="Two",
+                    meaning="Second exact level.",
+                ),
+            ),
+            status="active",
+            expected_snapshot_revision=activity.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(10),
+    )
+    criterion_set = create_criterion_set(
+        CreateCriterionSetRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            criterion_set_id="set-1",
+            lineage_id="set-lineage",
+            name="Local criteria",
+            purpose="Synthetic publication validation.",
+            revision=1,
+            scope="activity_specific",
+            criterion_set_kind="local",
+            criteria=(
+                CriterionSpec(
+                    criterion_id="criterion-1",
+                    key="collaboration",
+                    label="Collaboration",
+                    definition="Demonstrates collaborative practice.",
+                    criterion_kind="local",
+                    supported_target_kinds=("core_student",),
+                    default_scoring_scale_id="scale-1",
+                ),
+            ),
+            status="active",
+            expected_snapshot_revision=scale.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(11),
+    )
+    selected = select_activity_criterion_sets(
+        SelectActivityCriterionSetsRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            criterion_set_ids=("set-1",),
+            expected_snapshot_revision=criterion_set.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(12),
+    )
+    scored = add_score(
+        AddScoreRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            score_record_id="score-1",
+            target_reference=ScoreTargetReference(
+                target_kind="core_student",
+                target_id="student-1",
+                owning_system="core",
+            ),
+            criterion_id="criterion-1",
+            scoring_scale_id="scale-1",
+            disposition="scored",
+            value=1,
+            basis="professional_judgment",
+            rationale="Private publication rationale.",
+            privacy_policy=PrivacyPolicy(
+                classification="teacher_restricted"
+            ),
+            expected_snapshot_revision=selected.commit.snapshot_revision,
+            actor=_actor(),
+            session_id="session-1",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(13),
+    )
+    register_concord_academic_work(
+        root,
+        "class-1",
+        "activity-1",
+        academic_intent="summative",
+        lifecycle="active",
+    )
+    return root, scored.commit.snapshot_revision
+
+
+def _request(
+    revision: int,
+    *,
+    reason: RevisionReason = "initial",
+) -> GenerateAcademicResultManifestRequest:
+    return GenerateAcademicResultManifestRequest(
+        class_id="class-1",
+        activity_id="activity-1",
+        expected_snapshot_revision=revision,
+        actor=_actor(),
+        revision_reason=reason,
+    )
+
+
+def test_publication_producer_profile_and_entry_point_are_exact() -> None:
+    profile = get_publication_producer_profile()
+    assert profile.module_id == CONCORD_MODULE_ID
+    assert profile.display_name == CONCORD_DISPLAY_NAME
+    assert profile.supported_core_publication_schema_versions == frozenset(
+        {PUBLICATION_RECORD_SCHEMA_VERSION}
+    )
+    assert profile.supported_academic_work_contract_versions == frozenset(
+        {CONCORD_ACADEMIC_WORK_CONTRACT_VERSION}
+    )
+    assert len(profile.publication_contracts) == 1
+    support = profile.publication_contracts[0]
+    assert support.publication_kind == "academic_result_set"
+    assert support.manifest_contract_versions == frozenset(
+        {"concord_academic_result_manifest_v1"}
+    )
+    assert support.supported_capabilities == frozenset(
+        {"criterion_scores", "moderated_scores", "standards_ratings"}
+    )
+    assert not support.allows_missing_source_record
+    assert len(support.source_record_contracts) == 1
+    source = support.source_record_contracts[0]
+    assert source.record_kind == CONCORD_ACTIVITY_RECORD_KIND
+    assert source.contract_versions == frozenset(
+        {CONCORD_ACTIVITY_CONTRACT_VERSION}
+    )
+    assert not source.allows_unversioned
+
+    data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
+    entry_points = data["project"]["entry-points"]
+    assert entry_points["paper_data_suite.publication_producers"] == {
+        "concord": "concord.pds_publication:get_publication_producer_profile"
+    }
+    assert entry_points["paper_data_suite.modules"] == {
+        "concord": "concord.pds_module:get_module_profile"
+    }
+
+
+def test_first_publication_exact_mapping_and_replay(tmp_path: Path) -> None:
+    root, snapshot_revision = _workspace(tmp_path)
+    request = _request(snapshot_revision)
+    created = publish_concord_academic_results(
+        request,
+        workspace_root=root,
+        clock=lambda: _clock(14),
+    )
+
+    publication = created.publication
+    generation = created.manifest_generation
+    expected_source = ModuleRecordRef(
+        module_id=CONCORD_MODULE_ID,
+        record_kind=CONCORD_ACTIVITY_RECORD_KIND,
+        record_id="activity-1",
+        contract_version=CONCORD_ACTIVITY_CONTRACT_VERSION,
+    )
+    assert created.disposition == "created"
+    assert publication.publication_id.startswith("pub_")
+    assert publication.work == generation.manifest.work
+    assert publication.source_record == expected_source
+    assert publication.publication_kind == "academic_result_set"
+    assert publication.capabilities == ("criterion_scores",)
+    assert publication.record_set_id == CONCORD_ACADEMIC_RESULT_RECORD_SET_ID
+    assert publication.record_set_revision == 1
+    assert publication.manifest_contract_version == (
+        "concord_academic_result_manifest_v1"
+    )
+    assert publication.manifest_path == generation.relative_path
+    assert publication.manifest_digest_algorithm == "sha256"
+    assert publication.manifest_digest == generation.sha256
+    assert publication.academic_work_registration_revision == 1
+    assert publication.supersedes_publication_id is None
+    assert created.registration.registration_revision == 1
+    assert created.compatibility.compatible
+    assert created.compatibility.codes == ()
+    assert generation.path.read_bytes() == generation.content
+    assert b"Private publication rationale" not in generation.content
+
+    replay = publish_concord_academic_results(
+        request,
+        workspace_root=root,
+        clock=lambda: _clock(15),
+    )
+    assert replay.disposition == "existing"
+    assert replay.publication == publication
+    assert replay.manifest_generation.disposition == "existing"
+    assert replay.manifest_generation.revision == 1
+    assert replay.manifest_generation.content == generation.content
+
+
+def test_first_publication_never_silently_supersedes_existing_series(
+    tmp_path: Path,
+) -> None:
+    root, snapshot_revision = _workspace(tmp_path)
+    first = publish_concord_academic_results(
+        _request(snapshot_revision),
+        workspace_root=root,
+        clock=lambda: _clock(14),
+    )
+    first_bytes = first.manifest_generation.path.read_bytes()
+
+    replaced = replace_score(
+        ReplaceScoreRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            score_record_id="score-1",
+            replacement_score_record_id="score-2",
+            correction_id="correction-1",
+            reason="Additional observation changed teacher judgment.",
+            target_reference=ScoreTargetReference(
+                target_kind="core_student",
+                target_id="student-1",
+                owning_system="core",
+            ),
+            criterion_id="criterion-1",
+            scoring_scale_id="scale-1",
+            disposition="scored",
+            value=2,
+            basis="professional_judgment",
+            rationale="Private revised rationale.",
+            privacy_policy=PrivacyPolicy(
+                classification="teacher_restricted"
+            ),
+            expected_snapshot_revision=snapshot_revision,
+            actor=_actor(),
+            session_id="session-1",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(15),
+    )
+
+    with pytest.raises(ConcordAcademicResultPublicationConflictError):
+        publish_concord_academic_results(
+            _request(
+                replaced.commit.snapshot_revision,
+                reason="native_state_change",
+            ),
+            workspace_root=root,
+            clock=lambda: _clock(16),
+        )
+
+    unpublished = load_academic_result_manifest_revision(
+        root,
+        first.publication.work,
+        2,
+    )
+    assert unpublished.revision == 2
+    assert unpublished.path.exists()
+    assert unpublished.manifest.scores[-1].value == 2
+    assert first.manifest_generation.path.read_bytes() == first_bytes
+
+
+def test_explicit_supersession_exact_mapping_replay_and_immutability(
+    tmp_path: Path,
+) -> None:
+    root, snapshot_revision = _workspace(tmp_path)
+    first = publish_concord_academic_results(
+        _request(snapshot_revision),
+        workspace_root=root,
+        clock=lambda: _clock(14),
+    )
+    first_manifest_bytes = first.manifest_generation.path.read_bytes()
+    first_record_path = (
+        root
+        / "registry"
+        / "publications"
+        / f"{first.publication.publication_id}.json"
+    )
+    first_record_bytes = first_record_path.read_bytes()
+
+    replaced = replace_score(
+        ReplaceScoreRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            score_record_id="score-1",
+            replacement_score_record_id="score-2",
+            correction_id="correction-1",
+            reason="Additional observation changed teacher judgment.",
+            target_reference=ScoreTargetReference(
+                target_kind="core_student",
+                target_id="student-1",
+                owning_system="core",
+            ),
+            criterion_id="criterion-1",
+            scoring_scale_id="scale-1",
+            disposition="scored",
+            value=2,
+            basis="professional_judgment",
+            rationale="Private revised rationale.",
+            privacy_policy=PrivacyPolicy(
+                classification="teacher_restricted"
+            ),
+            expected_snapshot_revision=snapshot_revision,
+            actor=_actor(),
+            session_id="session-1",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(15),
+    )
+    successor_request = _request(
+        replaced.commit.snapshot_revision,
+        reason="native_state_change",
+    )
+    created = supersede_concord_academic_results(
+        successor_request,
+        expected_current_publication_id=first.publication.publication_id,
+        workspace_root=root,
+        clock=lambda: _clock(16),
+    )
+
+    assert created.disposition == "created"
+    assert created.publication.record_set_revision == 2
+    assert created.publication.supersedes_publication_id == (
+        first.publication.publication_id
+    )
+    assert created.publication.source_record == first.publication.source_record
+    assert created.publication.work == first.publication.work
+    assert created.publication.publication_kind == "academic_result_set"
+    assert created.publication.record_set_id == (
+        CONCORD_ACADEMIC_RESULT_RECORD_SET_ID
+    )
+    assert created.publication.capabilities == ("criterion_scores",)
+    assert created.manifest_generation.manifest.scores[-1].value == 2
+    assert first.manifest_generation.path.read_bytes() == first_manifest_bytes
+    assert first_record_path.read_bytes() == first_record_bytes
+
+    successor_manifest_bytes = created.manifest_generation.path.read_bytes()
+    replay = supersede_concord_academic_results(
+        successor_request,
+        expected_current_publication_id=first.publication.publication_id,
+        workspace_root=root,
+        clock=lambda: _clock(17),
+    )
+    assert replay.disposition == "existing"
+    assert replay.publication == created.publication
+    assert replay.manifest_generation.disposition == "existing"
+    assert replay.manifest_generation.revision == 2
+    assert replay.manifest_generation.path.read_bytes() == successor_manifest_bytes
+    assert first.manifest_generation.path.read_bytes() == first_manifest_bytes
+    assert first_record_path.read_bytes() == first_record_bytes
+
+
+def test_supersession_rejects_stale_expected_head_before_core_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, snapshot_revision = _workspace(tmp_path)
+    first = publish_concord_academic_results(
+        _request(snapshot_revision),
+        workspace_root=root,
+        clock=lambda: _clock(14),
+    )
+    first_record_path = (
+        root
+        / "registry"
+        / "publications"
+        / f"{first.publication.publication_id}.json"
+    )
+    first_record_bytes = first_record_path.read_bytes()
+    replaced = replace_score(
+        ReplaceScoreRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            score_record_id="score-1",
+            replacement_score_record_id="score-2",
+            correction_id="correction-1",
+            reason="Material change before stale supersession test.",
+            target_reference=ScoreTargetReference(
+                target_kind="core_student",
+                target_id="student-1",
+                owning_system="core",
+            ),
+            criterion_id="criterion-1",
+            scoring_scale_id="scale-1",
+            disposition="scored",
+            value=2,
+            basis="professional_judgment",
+            rationale="Private stale-head rationale.",
+            privacy_policy=PrivacyPolicy(
+                classification="teacher_restricted"
+            ),
+            expected_snapshot_revision=snapshot_revision,
+            actor=_actor(),
+            session_id="session-1",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(15),
+    )
+    successor_request = _request(
+        replaced.commit.snapshot_revision,
+        reason="native_state_change",
+    )
+    real_supersede = publication_module.supersede_manifest_revision
+    core_called = False
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal core_called
+        core_called = True
+        raise AssertionError("Core supersession must not run for a stale head")
+
+    monkeypatch.setattr(
+        publication_module,
+        "supersede_manifest_revision",
+        forbidden,
+    )
+    with pytest.raises(ConcordAcademicResultPublicationConflictError):
+        supersede_concord_academic_results(
+            successor_request,
+            expected_current_publication_id="pub_" + ("0" * 32),
+            workspace_root=root,
+            clock=lambda: _clock(16),
+        )
+    assert not core_called
+    assert first_record_path.read_bytes() == first_record_bytes
+    unpublished = load_academic_result_manifest_revision(
+        root,
+        first.publication.work,
+        2,
+    )
+    assert unpublished.manifest.scores[-1].value == 2
+
+    monkeypatch.setattr(
+        publication_module,
+        "supersede_manifest_revision",
+        real_supersede,
+    )
+    recovered = supersede_concord_academic_results(
+        successor_request,
+        expected_current_publication_id=first.publication.publication_id,
+        workspace_root=root,
+        clock=lambda: _clock(17),
+    )
+    assert recovered.disposition == "created"
+    assert recovered.manifest_generation.disposition == "existing"
+    assert recovered.manifest_generation.revision == 2
+    assert recovered.publication.supersedes_publication_id == (
+        first.publication.publication_id
+    )
+
+
+def test_supersession_requires_a_later_material_public_projection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, snapshot_revision = _workspace(tmp_path)
+    first = publish_concord_academic_results(
+        _request(snapshot_revision),
+        workspace_root=root,
+        clock=lambda: _clock(14),
+    )
+    core_called = False
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        nonlocal core_called
+        core_called = True
+        raise AssertionError("Core supersession must not run without a successor")
+
+    monkeypatch.setattr(
+        publication_module,
+        "supersede_manifest_revision",
+        forbidden,
+    )
+    with pytest.raises(ConcordAcademicResultPublicationConflictError):
+        supersede_concord_academic_results(
+            _request(snapshot_revision, reason="native_state_change"),
+            expected_current_publication_id=first.publication.publication_id,
+            workspace_root=root,
+            clock=lambda: _clock(15),
+        )
+    assert not core_called
+    assert first.manifest_generation.path.read_bytes() == (
+        first.manifest_generation.content
+    )
+    assert tuple(first.manifest_generation.path.parent.glob("*.json")) == (
+        first.manifest_generation.path,
+    )
+
+
+def test_withdrawal_is_idempotent_and_never_reactivates_predecessor(
+    tmp_path: Path,
+) -> None:
+    root, snapshot_revision = _workspace(tmp_path)
+    first = publish_concord_academic_results(
+        _request(snapshot_revision),
+        workspace_root=root,
+        clock=lambda: _clock(14),
+    )
+    first_record_path = (
+        root
+        / "registry"
+        / "publications"
+        / f"{first.publication.publication_id}.json"
+    )
+    first_record_bytes = first_record_path.read_bytes()
+    first_manifest_bytes = first.manifest_generation.path.read_bytes()
+
+    replaced = replace_score(
+        ReplaceScoreRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            score_record_id="score-1",
+            replacement_score_record_id="score-2",
+            correction_id="correction-withdrawal-1",
+            reason="Material correction before withdrawal.",
+            target_reference=ScoreTargetReference(
+                target_kind="core_student",
+                target_id="student-1",
+                owning_system="core",
+            ),
+            criterion_id="criterion-1",
+            scoring_scale_id="scale-1",
+            disposition="scored",
+            value=2,
+            basis="professional_judgment",
+            rationale="Private withdrawal rationale.",
+            privacy_policy=PrivacyPolicy(
+                classification="teacher_restricted"
+            ),
+            expected_snapshot_revision=snapshot_revision,
+            actor=_actor(),
+            session_id="session-1",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(15),
+    )
+    second = supersede_concord_academic_results(
+        _request(
+            replaced.commit.snapshot_revision,
+            reason="native_state_change",
+        ),
+        expected_current_publication_id=first.publication.publication_id,
+        workspace_root=root,
+        clock=lambda: _clock(16),
+    )
+    second_record_path = (
+        root
+        / "registry"
+        / "publications"
+        / f"{second.publication.publication_id}.json"
+    )
+    second_record_bytes = second_record_path.read_bytes()
+    second_manifest_bytes = second.manifest_generation.path.read_bytes()
+
+    withdrawn = withdraw_concord_academic_result_publication(
+        "class-1",
+        "activity-1",
+        publication_id=second.publication.publication_id,
+        reason="Teacher requested correction before reuse.",
+        workspace_root=root,
+    )
+    assert withdrawn.disposition == "created"
+    assert withdrawn.publication == second.publication
+    assert withdrawn.withdrawal.publication_id == second.publication.publication_id
+    assert withdrawn.manifest_verification == "verified"
+    assert get_current_publication_record(
+        root,
+        second.publication.work,
+        "academic_result_set",
+        CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+    ) is None
+    assert first_record_path.read_bytes() == first_record_bytes
+    assert second_record_path.read_bytes() == second_record_bytes
+    assert first.manifest_generation.path.read_bytes() == first_manifest_bytes
+    assert second.manifest_generation.path.read_bytes() == second_manifest_bytes
+
+    replay = withdraw_concord_academic_result_publication(
+        "class-1",
+        "activity-1",
+        publication_id=second.publication.publication_id,
+        reason="Teacher requested correction before reuse.",
+        workspace_root=root,
+    )
+    assert replay.disposition == "existing"
+    assert replay.withdrawal == withdrawn.withdrawal
+    assert get_current_publication_record(
+        root,
+        second.publication.work,
+        "academic_result_set",
+        CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+    ) is None
+
+
+def test_withdrawal_rejects_different_reason_on_replay(tmp_path: Path) -> None:
+    root, snapshot_revision = _workspace(tmp_path)
+    first = publish_concord_academic_results(
+        _request(snapshot_revision),
+        workspace_root=root,
+        clock=lambda: _clock(14),
+    )
+    withdraw_concord_academic_result_publication(
+        "class-1",
+        "activity-1",
+        publication_id=first.publication.publication_id,
+        reason="Original withdrawal reason.",
+        workspace_root=root,
+    )
+    with pytest.raises(ConcordAcademicResultPublicationConflictError):
+        withdraw_concord_academic_result_publication(
+            "class-1",
+            "activity-1",
+            publication_id=first.publication.publication_id,
+            reason="Contradictory withdrawal reason.",
+            workspace_root=root,
+        )
+
+
+def test_withdrawal_remains_possible_when_bound_manifest_is_missing(
+    tmp_path: Path,
+) -> None:
+    root, snapshot_revision = _workspace(tmp_path)
+    first = publish_concord_academic_results(
+        _request(snapshot_revision),
+        workspace_root=root,
+        clock=lambda: _clock(14),
+    )
+    publication_path = (
+        root
+        / "registry"
+        / "publications"
+        / f"{first.publication.publication_id}.json"
+    )
+    publication_bytes = publication_path.read_bytes()
+    first.manifest_generation.path.unlink()
+
+    withdrawn = withdraw_concord_academic_result_publication(
+        "class-1",
+        "activity-1",
+        publication_id=first.publication.publication_id,
+        reason="Manifest requires repair before any future publication.",
+        workspace_root=root,
+    )
+    assert withdrawn.disposition == "created"
+    assert withdrawn.manifest_verification == "missing"
+    assert publication_path.read_bytes() == publication_bytes
+    assert load_publication_withdrawal(
+        root,
+        first.publication.publication_id,
+    ) == withdrawn.withdrawal
+    assert get_current_publication_record(
+        root,
+        first.publication.work,
+        "academic_result_set",
+        CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+    ) is None
+
+
+def test_corrected_republication_explicitly_supersedes_withdrawn_head(
+    tmp_path: Path,
+) -> None:
+    root, snapshot_revision = _workspace(tmp_path)
+    first = publish_concord_academic_results(
+        _request(snapshot_revision),
+        workspace_root=root,
+        clock=lambda: _clock(14),
+    )
+    withdrawn = withdraw_concord_academic_result_publication(
+        "class-1",
+        "activity-1",
+        publication_id=first.publication.publication_id,
+        reason="Correction required.",
+        workspace_root=root,
+    )
+    first_record_path = (
+        root
+        / "registry"
+        / "publications"
+        / f"{first.publication.publication_id}.json"
+    )
+    first_record_bytes = first_record_path.read_bytes()
+    first_manifest_bytes = first.manifest_generation.path.read_bytes()
+
+    with pytest.raises(ConcordAcademicResultPublicationConflictError):
+        republish_concord_academic_results_after_withdrawal(
+            _request(snapshot_revision, reason="projection_correction"),
+            expected_withdrawn_head_publication_id=(
+                first.publication.publication_id
+            ),
+            workspace_root=root,
+            clock=lambda: _clock(15),
+        )
+    assert tuple(first.manifest_generation.path.parent.glob("*.json")) == (
+        first.manifest_generation.path,
+    )
+
+    replaced = replace_score(
+        ReplaceScoreRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            score_record_id="score-1",
+            replacement_score_record_id="score-2",
+            correction_id="correction-republish-1",
+            reason="Correct withdrawn academic result.",
+            target_reference=ScoreTargetReference(
+                target_kind="core_student",
+                target_id="student-1",
+                owning_system="core",
+            ),
+            criterion_id="criterion-1",
+            scoring_scale_id="scale-1",
+            disposition="scored",
+            value=2,
+            basis="professional_judgment",
+            rationale="Private corrected rationale.",
+            privacy_policy=PrivacyPolicy(
+                classification="teacher_restricted"
+            ),
+            expected_snapshot_revision=snapshot_revision,
+            actor=_actor(),
+            session_id="session-1",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(16),
+    )
+    corrected_request = _request(
+        replaced.commit.snapshot_revision,
+        reason="native_state_change",
+    )
+    corrected = republish_concord_academic_results_after_withdrawal(
+        corrected_request,
+        expected_withdrawn_head_publication_id=first.publication.publication_id,
+        workspace_root=root,
+        clock=lambda: _clock(17),
+    )
+    assert corrected.disposition == "created"
+    assert corrected.publication.record_set_revision == 2
+    assert corrected.publication.supersedes_publication_id == (
+        first.publication.publication_id
+    )
+    assert corrected.manifest_generation.revision == 2
+    assert load_publication_withdrawal(
+        root,
+        first.publication.publication_id,
+    ) == withdrawn.withdrawal
+    assert first_record_path.read_bytes() == first_record_bytes
+    assert first.manifest_generation.path.read_bytes() == first_manifest_bytes
+    assert get_current_publication_record(
+        root,
+        first.publication.work,
+        "academic_result_set",
+        CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+    ) == corrected.publication
+
+    replay = republish_concord_academic_results_after_withdrawal(
+        corrected_request,
+        expected_withdrawn_head_publication_id=first.publication.publication_id,
+        workspace_root=root,
+        clock=lambda: _clock(18),
+    )
+    assert replay.disposition == "existing"
+    assert replay.publication == corrected.publication
+    assert replay.manifest_generation.disposition == "existing"
+    assert replay.manifest_generation.revision == 2
+
+
+def test_series_status_reports_missing_catalog_without_creating_it(
+    tmp_path: Path,
+) -> None:
+    root, _snapshot_revision = _workspace(tmp_path)
+
+    state = load_concord_publication_series_status(
+        "class-1",
+        "activity-1",
+        workspace_root=root,
+    )
+
+    assert state.producer_revisions == ()
+    assert state.producer_head is None
+    assert state.producer_head_projection_digest is None
+    assert state.publications == ()
+    assert state.withdrawals == ()
+    assert state.core_head is None
+    assert state.core_head_withdrawal is None
+    assert state.current_selectable_publication is None
+    assert state.current_registration_revision == 1
+    assert not state.catalog_available
+    assert state.catalog_rows == ()
+
+    with pytest.raises(ConcordAcademicResultPublicationNotFoundError):
+        query_concord_publication_catalog(
+            "class-1",
+            "activity-1",
+            state="all",
+            workspace_root=root,
+        )
+
+
+def test_catalog_rebuild_query_and_series_state_follow_canonical_lifecycle(
+    tmp_path: Path,
+) -> None:
+    root, snapshot_revision = _workspace(tmp_path)
+    first = publish_concord_academic_results(
+        _request(snapshot_revision),
+        workspace_root=root,
+        clock=lambda: _clock(14),
+    )
+    first_row = first.catalog.publication
+    assert first_row.publication_id == first.publication.publication_id
+    assert first_row.is_series_head
+    assert not first_row.is_withdrawn
+    assert first_row.is_current_selectable
+
+    current = query_concord_publication_catalog(
+        "class-1",
+        "activity-1",
+        required_capabilities=("criterion_scores",),
+        state="current",
+        workspace_root=root,
+    )
+    assert current == (first_row,)
+    assert query_concord_publication_catalog(
+        "class-1",
+        "activity-1",
+        required_capabilities=("standards_ratings",),
+        state="current",
+        workspace_root=root,
+    ) == ()
+
+    replaced = replace_score(
+        ReplaceScoreRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            score_record_id="score-1",
+            replacement_score_record_id="score-2",
+            correction_id="correction-catalog",
+            reason="Material catalog lifecycle change.",
+            target_reference=ScoreTargetReference(
+                target_kind="core_student",
+                target_id="student-1",
+                owning_system="core",
+            ),
+            criterion_id="criterion-1",
+            scoring_scale_id="scale-1",
+            disposition="scored",
+            value=2,
+            basis="professional_judgment",
+            rationale="Private catalog lifecycle rationale.",
+            privacy_policy=PrivacyPolicy(
+                classification="teacher_restricted"
+            ),
+            expected_snapshot_revision=snapshot_revision,
+            actor=_actor(),
+            session_id="session-1",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(15),
+    )
+    second = supersede_concord_academic_results(
+        _request(
+            replaced.commit.snapshot_revision,
+            reason="native_state_change",
+        ),
+        expected_current_publication_id=first.publication.publication_id,
+        workspace_root=root,
+        clock=lambda: _clock(16),
+    )
+    assert second.catalog.publication.is_series_head
+    assert second.catalog.publication.is_current_selectable
+
+    superseded_state = load_concord_publication_series_status(
+        "class-1",
+        "activity-1",
+        workspace_root=root,
+    )
+    assert superseded_state.producer_revisions == (1, 2)
+    assert superseded_state.producer_head_revision == 2
+    assert superseded_state.producer_head_projection_digest == (
+        second.manifest_generation.manifest.projection.projection_digest
+    )
+    assert superseded_state.core_head == second.publication
+    assert superseded_state.current_selectable_publication == second.publication
+    assert superseded_state.catalog_available
+    assert len(superseded_state.catalog_rows) == 2
+    by_id = {
+        row.publication_id: row for row in superseded_state.catalog_rows
+    }
+    assert not by_id[first.publication.publication_id].is_series_head
+    assert not by_id[first.publication.publication_id].is_current_selectable
+    assert by_id[second.publication.publication_id].is_series_head
+    assert by_id[second.publication.publication_id].is_current_selectable
+
+    withdrawn = withdraw_concord_academic_result_publication(
+        "class-1",
+        "activity-1",
+        publication_id=second.publication.publication_id,
+        reason="Teacher requested correction before republication.",
+        workspace_root=root,
+    )
+    assert withdrawn.catalog.publication.is_series_head
+    assert withdrawn.catalog.publication.is_withdrawn
+    assert not withdrawn.catalog.publication.is_current_selectable
+
+    withdrawn_state = load_concord_publication_series_status(
+        "class-1",
+        "activity-1",
+        workspace_root=root,
+    )
+    assert withdrawn_state.core_head == second.publication
+    assert withdrawn_state.core_head_withdrawal == withdrawn.withdrawal
+    assert withdrawn_state.current_selectable_publication is None
+    assert withdrawn_state.catalog_available
+    withdrawn_row = next(
+        row
+        for row in withdrawn_state.catalog_rows
+        if row.publication_id == second.publication.publication_id
+    )
+    assert withdrawn_row.is_series_head
+    assert withdrawn_row.is_withdrawn
+    assert not withdrawn_row.is_current_selectable
+
+    rebuilt = rebuild_concord_publication_catalog(
+        "class-1",
+        "activity-1",
+        publication_id=second.publication.publication_id,
+        workspace_root=root,
+    )
+    assert rebuilt.publication == withdrawn_row
+
+
+def test_series_status_rejects_catalog_rows_that_disagree_with_canonical_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, snapshot_revision = _workspace(tmp_path)
+    publish_concord_academic_results(
+        _request(snapshot_revision),
+        workspace_root=root,
+        clock=lambda: _clock(14),
+    )
+
+    monkeypatch.setattr(
+        publication_module,
+        "query_publication_catalog",
+        lambda *_args, **_kwargs: (),
+    )
+    with pytest.raises(ConcordAcademicResultPublicationIntegrityError):
+        load_concord_publication_series_status(
+            "class-1",
+            "activity-1",
+            workspace_root=root,
+        )
+
+
+def test_catalog_failure_after_canonical_publish_is_recoverable_partial_success(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, snapshot_revision = _workspace(tmp_path)
+    request = _request(snapshot_revision)
+    real_rebuild = publication_module.rebuild_academic_catalog
+
+    def fail_rebuild(*_args: object, **_kwargs: object) -> object:
+        raise AcademicCatalogBuildError("Synthetic catalog rebuild failure.")
+
+    monkeypatch.setattr(
+        publication_module,
+        "rebuild_academic_catalog",
+        fail_rebuild,
+    )
+    with pytest.raises(
+        ConcordAcademicResultPublicationPartialSuccessError
+    ) as captured:
+        publish_concord_academic_results(
+            request,
+            workspace_root=root,
+            clock=lambda: _clock(14),
+        )
+
+    state = captured.value.state
+    assert state.canonical_state == "confirmed"
+    assert state.publication is not None
+    assert state.catalog_rebuild_attempted
+    assert not state.catalog_replacement_completed
+    assert not state.catalog_verification_completed
+    assert state.catalog_build is None
+    assert isinstance(state.catalog_error, AcademicCatalogBuildError)
+    assert get_current_publication_record(
+        root,
+        state.publication.work,
+        "academic_result_set",
+        CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+    ) == state.publication
+
+    monkeypatch.setattr(
+        publication_module,
+        "rebuild_academic_catalog",
+        real_rebuild,
+    )
+    recovered = publish_concord_academic_results(
+        request,
+        workspace_root=root,
+        clock=lambda: _clock(15),
+    )
+    assert recovered.disposition == "existing"
+    assert recovered.publication == state.publication
+    assert recovered.manifest_generation.disposition == "existing"
+    assert recovered.catalog.publication.is_current_selectable
+    final_state = load_concord_publication_series_status(
+        "class-1",
+        "activity-1",
+        workspace_root=root,
+    )
+    assert len(final_state.publications) == 1
+    assert final_state.catalog_available

--- a/tests/test_academic_work_registration_issue31.py
+++ b/tests/test_academic_work_registration_issue31.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.workspace import ensure_workspace_root
+
+from concord.academic_work_registration import (
+    ConcordAcademicWorkRegistrationConflictError,
+    ConcordAcademicWorkRegistrationNotFoundError,
+    ConcordAcademicWorkRegistrationValidationError,
+    ManagedActivityRegistrationContext,
+    build_concord_academic_work_registration_request,
+    list_concord_academic_work_registration_revisions,
+    load_concord_academic_work_registration_revision,
+    load_current_concord_academic_work_registration,
+    load_managed_activity_registration_context,
+    register_concord_academic_work,
+    update_concord_academic_work_registration,
+)
+from concord.pds_contract import (
+    ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+    ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+    CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+    CONCORD_ACADEMIC_WORK_CONTRACT_VERSION,
+    CONCORD_ACADEMIC_WORK_KIND,
+    CONCORD_ACTIVITY_CONTRACT_VERSION,
+    CONCORD_ACTIVITY_RECORD_KIND,
+    CONCORD_MODULE_ID,
+)
+from concord.workflows import (
+    CreateActivityContextRequest,
+    UpdateActivityRequest,
+    WorkflowActor,
+    create_activity_context,
+    update_activity,
+)
+
+
+def _clock(hour: int) -> datetime:
+    return datetime(2026, 8, 14, hour, 0, tzinfo=timezone.utc)
+
+
+def _workspace(tmp_path: Path, *, title: str = "Synthetic Activity") -> Path:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    metadata = create_class_metadata(
+        "class-1",
+        "2026-2027",
+        created_at=_clock(12),
+    )
+    write_class_metadata_for_class(root, metadata)
+    create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            title=title,
+            activity_type="project",
+            scoring_orientation="evidence_only",
+            session_id="session-1",
+            actor=WorkflowActor(actor_id="teacher-1"),
+            activity_status="active",
+            session_status="active",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(13),
+    )
+    return root
+
+
+def test_public_contract_identities_are_stable() -> None:
+    assert CONCORD_MODULE_ID == "concord"
+    assert CONCORD_ACADEMIC_WORK_CONTRACT_VERSION == (
+        "concord_academic_work_v1"
+    )
+    assert CONCORD_ACADEMIC_WORK_KIND == "collaborative_activity"
+    assert CONCORD_ACTIVITY_RECORD_KIND == "activity"
+    assert CONCORD_ACTIVITY_CONTRACT_VERSION == "concord_activity_v1"
+    assert ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION == (
+        "concord_academic_result_manifest_v1"
+    )
+    assert ACADEMIC_RESULT_MANIFEST_RECORD_TYPE == (
+        "concord_academic_result_manifest"
+    )
+    assert CONCORD_ACADEMIC_RESULT_RECORD_SET_ID == "academic_results"
+
+
+def test_registration_context_and_request_use_exact_activity_source(
+    tmp_path: Path,
+) -> None:
+    root = _workspace(tmp_path)
+    context = load_managed_activity_registration_context(
+        root, "class-1", "activity-1"
+    )
+    request = build_concord_academic_work_registration_request(
+        context,
+        academic_intent="summative",
+        lifecycle="active",
+    )
+
+    assert context.work.module_id == "concord"
+    assert context.work.class_id == "class-1"
+    assert context.work.work_id == "activity-1"
+    assert context.snapshot_revision == 1
+    assert context.source_record.module_id == "concord"
+    assert context.source_record.record_kind == "activity"
+    assert context.source_record.record_id == "activity-1"
+    assert context.source_record.contract_version == "concord_activity_v1"
+
+    assert request.work == context.work
+    assert request.title == "Synthetic Activity"
+    assert request.work_kind == "collaborative_activity"
+    assert request.producer_contract_version == "concord_academic_work_v1"
+    assert request.academic_intent == "summative"
+    assert request.lifecycle == "active"
+    assert request.source_records == (context.source_record,)
+
+
+def test_registration_is_explicit_idempotent_and_versioned(
+    tmp_path: Path,
+) -> None:
+    root = _workspace(tmp_path)
+
+    assert (
+        load_current_concord_academic_work_registration(
+            root, "class-1", "activity-1"
+        )
+        is None
+    )
+    assert (
+        load_managed_activity_registration_context(
+            root, "class-1", "activity-1"
+        ).snapshot_revision
+        == 1
+    )
+
+    first = register_concord_academic_work(
+        root,
+        "class-1",
+        "activity-1",
+        academic_intent="summative",
+        lifecycle="active",
+    )
+    assert first.disposition == "created"
+    assert first.registration.registration_revision == 1
+
+    replay = register_concord_academic_work(
+        root,
+        "class-1",
+        "activity-1",
+        academic_intent="summative",
+        lifecycle="active",
+    )
+    assert replay.disposition == "existing"
+    assert replay.registration == first.registration
+    assert list_concord_academic_work_registration_revisions(
+        root, "class-1", "activity-1"
+    ) == (1,)
+
+    with pytest.raises(ConcordAcademicWorkRegistrationConflictError):
+        register_concord_academic_work(
+            root,
+            "class-1",
+            "activity-1",
+            academic_intent="formative",
+            lifecycle="active",
+        )
+
+
+def test_activity_change_does_not_mutate_registration_until_explicit_update(
+    tmp_path: Path,
+) -> None:
+    root = _workspace(tmp_path)
+    first = register_concord_academic_work(
+        root,
+        "class-1",
+        "activity-1",
+        academic_intent="summative",
+        lifecycle="active",
+    )
+
+    updated_activity = update_activity(
+        UpdateActivityRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            expected_snapshot_revision=1,
+            actor=WorkflowActor(actor_id="teacher-1"),
+            title="Revised Activity Title",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(14),
+    )
+    assert updated_activity.commit.snapshot_revision == 2
+
+    unchanged_registration = load_current_concord_academic_work_registration(
+        root, "class-1", "activity-1"
+    )
+    assert unchanged_registration == first.registration
+    assert unchanged_registration is not None
+    assert unchanged_registration.title == "Synthetic Activity"
+
+    second = update_concord_academic_work_registration(
+        root,
+        "class-1",
+        "activity-1",
+        academic_intent="formative",
+        lifecycle="closed",
+        expected_current_revision=1,
+    )
+    assert second.disposition == "updated"
+    assert second.registration.registration_revision == 2
+    assert second.registration.title == "Revised Activity Title"
+    assert second.registration.academic_intent == "formative"
+    assert second.registration.lifecycle == "closed"
+    assert second.registration.created_at == first.registration.created_at
+    assert second.registration.updated_at >= first.registration.updated_at
+
+    assert list_concord_academic_work_registration_revisions(
+        root, "class-1", "activity-1"
+    ) == (1, 2)
+    historical = load_concord_academic_work_registration_revision(
+        root, "class-1", "activity-1", 1
+    )
+    assert historical == first.registration
+
+    stale_replay = update_concord_academic_work_registration(
+        root,
+        "class-1",
+        "activity-1",
+        academic_intent="formative",
+        lifecycle="closed",
+        expected_current_revision=1,
+    )
+    assert stale_replay.disposition == "existing"
+    assert stale_replay.registration == second.registration
+
+    with pytest.raises(ConcordAcademicWorkRegistrationConflictError):
+        update_concord_academic_work_registration(
+            root,
+            "class-1",
+            "activity-1",
+            academic_intent="diagnostic",
+            lifecycle="active",
+            expected_current_revision=1,
+        )
+
+    with pytest.raises(ConcordAcademicWorkRegistrationConflictError):
+        update_concord_academic_work_registration(
+            root,
+            "class-1",
+            "activity-1",
+            academic_intent="diagnostic",
+            lifecycle="active",
+            expected_current_revision=99,
+        )
+
+
+def test_registration_rejects_missing_activity_and_invalid_public_title(
+    tmp_path: Path,
+) -> None:
+    root = _workspace(tmp_path)
+
+    with pytest.raises(ConcordAcademicWorkRegistrationNotFoundError):
+        load_managed_activity_registration_context(
+            root, "class-1", "activity-missing"
+        )
+
+    context = load_managed_activity_registration_context(
+        root, "class-1", "activity-1"
+    )
+    unsafe = ManagedActivityRegistrationContext(
+        work=context.work,
+        source_record=context.source_record,
+        title="Unsafe\nTitle",
+        snapshot_revision=context.snapshot_revision,
+    )
+    with pytest.raises(ConcordAcademicWorkRegistrationValidationError):
+        build_concord_academic_work_registration_request(
+            unsafe,
+            academic_intent="summative",
+            lifecycle="active",
+        )
+
+
+def test_academic_intent_and_lifecycle_are_not_inferred_from_activity(
+    tmp_path: Path,
+) -> None:
+    root = _workspace(tmp_path)
+    context = load_managed_activity_registration_context(
+        root, "class-1", "activity-1"
+    )
+
+    formative_closed = build_concord_academic_work_registration_request(
+        context,
+        academic_intent="formative",
+        lifecycle="closed",
+    )
+    reporting_planned = build_concord_academic_work_registration_request(
+        context,
+        academic_intent="reporting_only",
+        lifecycle="planned",
+    )
+
+    assert formative_closed.academic_intent == "formative"
+    assert formative_closed.lifecycle == "closed"
+    assert reporting_planned.academic_intent == "reporting_only"
+    assert reporting_planned.lifecycle == "planned"

--- a/tests/test_native_record_fixtures.py
+++ b/tests/test_native_record_fixtures.py
@@ -46,6 +46,66 @@ def test_integrated_fixture_keeps_semantic_identities_distinct() -> None:
     assert proof["group_score_creates_student_scores"] is False
 
 
+def test_integrated_fixture_declares_publication_expectations() -> None:
+    fixture = _load(FIXTURES / "standards_activity.json")
+    expected = fixture["expected_academic_result_manifest_projection"]
+    assert isinstance(expected, dict)
+    assert expected["contract_version"] == "concord_academic_result_manifest_v1"
+    assert expected["record_type"] == "concord_academic_result_manifest"
+    work = expected["work"]
+    assert isinstance(work, dict)
+    assert work == {
+        "module_id": "concord",
+        "class_id": "class-1",
+        "work_id": "standards-activity",
+    }
+    assert expected["expected_capabilities"] == [
+        "criterion_scores",
+        "moderated_scores",
+        "standards_ratings",
+    ]
+    assert expected["score_projection"] == [
+        {"score_record_id": "score-standard-1", "current_state": "superseded"},
+        {"score_record_id": "score-standard-2", "current_state": "current"},
+        {
+            "score_record_id": "score-group-1",
+            "current_state": "current",
+            "target_kind": "concord_group",
+        },
+        {
+            "score_record_id": "score-group-nonscore",
+            "current_state": "current",
+            "disposition": "not_observed",
+            "value_present": False,
+        },
+    ]
+    assert expected["standards_result_score_ids"] == [
+        "score-standard-1",
+        "score-standard-2",
+    ]
+    lineage = expected["external_evidence_lineage_examples"]
+    assert isinstance(lineage, list)
+    assert len(lineage) == 2
+    assert all(isinstance(item, dict) for item in lineage)
+    assert {
+        item["owning_system"]
+        for item in lineage
+        if isinstance(item, dict)
+    } == {"scoreform", "quillan"}
+    values = expected["type_sensitive_scale_values"]
+    assert isinstance(values, list)
+    assert [type(value) for value in values] == [int, float, str, bool]
+    excluded = expected["private_fields_excluded"]
+    assert isinstance(excluded, list)
+    assert "score_record.rationale" in excluded
+    assert "status_reason.note" in excluded
+    assert "moderation_record.rationale" in excluded
+    assert "evidence_locator.note" in excluded
+    policy = expected["downstream_policy_excluded"]
+    assert isinstance(policy, list)
+    assert {"grade", "proficiency", "mastery"} <= set(policy)
+
+
 def test_integrated_fixture_is_a_valid_record_graph() -> None:
     fixture = _load(FIXTURES / "standards_activity.json")
     records = fixture["records"]

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -37,7 +37,13 @@ def test_built_wheel_metadata_and_contents(built_wheel: Path) -> None:
     assert (
         "[paper_data_suite.modules]\nconcord = concord.pds_module:get_module_profile"
     ) in entry_points
-    assert "paper_data_suite.publication_producers" not in entry_points
+    assert (
+        "[paper_data_suite.publication_producers]\n"
+        "concord = concord.pds_publication:get_publication_producer_profile"
+    ) in entry_points
+    assert entry_points.count(
+        "concord = concord.pds_publication:get_publication_producer_profile"
+    ) == 1
 
 
 def test_wheel_contains_only_concord_package(built_wheel: Path) -> None:
@@ -56,5 +62,6 @@ def test_wheel_contains_only_concord_package(built_wheel: Path) -> None:
         "quillan/",
         "portia/",
         "meridian/",
+        "vitrine/",
     )
     assert not any(name.lower().startswith(forbidden) for name in names)

--- a/tests/test_read_only_imports.py
+++ b/tests/test_read_only_imports.py
@@ -21,7 +21,12 @@ def test_all_public_baseline_modules_import_read_only(
     unchanged_directory: Path,
 ) -> None:
     result = _run(
-        "import concord, concord.cli, concord.constants; print(concord.__version__)",
+        (
+            "import concord, concord.cli, concord.constants, "
+            "concord.pds_publication as p; "
+            "assert p.get_publication_producer_profile().module_id=='concord'; "
+            "print(concord.__version__)"
+        ),
         unchanged_directory,
     )
     assert result.returncode == 0, result.stderr
@@ -29,8 +34,9 @@ def test_all_public_baseline_modules_import_read_only(
 
 def test_import_does_not_import_sibling_modules(unchanged_directory: Path) -> None:
     statement = (
-        "import sys, concord; "
-        "forbidden={'scoreform','quillan','portia','meridian'}; "
+        "import sys, concord, concord.pds_publication as p; "
+        "assert p.get_publication_producer_profile().module_id=='concord'; "
+        "forbidden={'scoreform','quillan','portia','meridian','vitrine'}; "
         "assert forbidden.isdisjoint({n.split('.')[0].lower() for n in sys.modules})"
     )
     result = _run(statement, unchanged_directory)


### PR DESCRIPTION
Closes #31

## Summary

Implements Concord as a first-class Core 0.6 academic-result producer.

This change adds:

- explicit Core Academic Work Registration for Concord Activities;
- the immutable `concord_academic_result_manifest_v1` contract;
- native Concord scoring-state projection and semantic change detection;
- immutable producer manifest revision storage;
- the Concord `paper_data_suite.publication_producers` profile;
- first publication through Core registry services;
- explicit publication supersession;
- withdrawal and corrected post-withdrawal republication;
- Core academic-catalog reconciliation and discovery;
- typed publication-series state;
- direct publication CLI commands;
- an Activity-scoped teacher Publication menu;
- publication documentation and synthetic fixture expectations;
- built-wheel package/profile discovery and isolated acceptance coverage.

## Architecture

The implemented publication flow is:

```text
Concord Activity
    -> explicit Core Academic Work Registration
    -> validated native Concord scoring state
    -> immutable Concord Academic Result Manifest revision
    -> immutable Core Publication Record
    -> Core academic catalog
```

Concord remains authoritative for native scoring semantics and producer
manifest generation. Core remains authoritative for registration,
Publication Records, Withdrawals, publication-series lifecycle, registry
persistence, and catalog derivation.

No Meridian grading/reporting policy is implemented.

## Contract identities

```text
module_id: concord
academic work: concord_academic_work_v1
source Activity: concord_activity_v1
manifest: concord_academic_result_manifest_v1
record set: academic_results
publication kind: academic_result_set
```

The installed producer profile advertises:

```text
criterion_scores
standards_ratings
moderated_scores
```

with capabilities derived from exact manifest contents.

## Publication lifecycle

The implementation supports:

- idempotent initial registration;
- optimistic registration updates;
- semantic no-change manifest reuse;
- immutable material manifest revisions;
- idempotent first publication;
- explicit-head supersession;
- immutable withdrawal;
- corrected publication after withdrawal explicitly superseding the withdrawn head;
- catalog rebuild/reconciliation;
- structured canonical-success/catalog-failure recovery.

Published manifest bytes and Core publication history remain immutable.

## Privacy and boundaries

Manifest v1 uses an allowlisted publication projection.

It excludes private narrative and source content including:

- Score rationale;
- StatusReason note;
- Moderation rationale;
- EvidenceLocator note;
- Artifact/source contents;
- unrestricted review notes;
- student names and unrelated private records.

Group Scores remain Group Scores. Non-score dispositions remain valueless.
Publication does not calculate Grades or proficiency.

Issue #32 remains responsible for the consumer-neutral reader API.
Issue #33 remains responsible for the full installed Activity-to-publication
end-to-end acceptance path.

## Interfaces

Direct CLI adds the `concord publication` family for:

- registration;
- manifest preview/generation/history;
- first publication;
- supersession;
- withdrawal;
- publication-series state;
- catalog query/rebuild.

The teacher Activity menu adds an explicit Publication surface after Scoring,
with review-before-write behavior and deliberate confirmation words.

No Score, evidence, Moderation, or Artifact mutation automatically publishes.

## Validation

Local released-Core validation used:

```text
pds-core 0.6.0
```

authenticated through the repository's existing Core-wheel verifier.

Results:

```text
454 passed
6 skipped — Windows filesystem symlink capability only

Ruff: passed
Mypy strict: passed
Documentation integrity: passed
pip check: passed
Build: passed
Twine: passed
Package-content validation: passed
Installed-wheel smoke: passed
git diff --check: passed
```

The isolated smoke installed:

```text
pds-concord 0.2.0.dev0
pds-core 0.6.0
```

and verified the packaged publication-producer entry point/profile outside
the source checkout.

## Requirement disposition

No known Issue #31 requirement has been intentionally deferred except the
boundaries explicitly assigned by the issue itself:

- consumer-neutral manifest reader — #32;
- full clean-wheel Activity-to-publication acceptance — #33.

The hosted Ubuntu/Windows Python 3.11–3.14 matrix remains the final CI
verification for this pull request.