### PR TITLE
Expose a consumer-neutral manifest and artifact reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- A pure `concord.academic_result_reader` facade for exact canonical Academic
+  Result Manifest v1 bytes, whole-model validation, exact producer-native
+  lookups, and type-sensitive Scoring Scale values.
+- A separate `concord.academic_result_artifacts` authorization-gated reader for
+  exact historical Concord Artifact evidence with authorization-before-I/O,
+  bounded page/Artifact PDF representation, retained-source integrity, and
+  privacy-minimized Author/Subject projection.
+- A shared neutral Artifact rendering layer used by both consumer reads and the
+  existing teacher assembly workflow, including verified-byte rendering and
+  fail-closed missing/ambiguous retained evidence.
+- Isolated-wheel reader smoke coverage and explicit wheel-content checks for the
+  public reader modules without adding sibling PDS runtime dependencies.
+
 - Explicit Core Academic Work Registration for Concord Activities plus immutable
   `concord_academic_result_manifest_v1` generation with semantic no-churn
   revisioning and publication-safe projection.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,11 @@ plus teacher-controlled Criterion Sets, Scoring Scales, Score Records, Score
 Evidence Links, non-score dispositions, and Score revision history. Concord now
 also publishes explicitly registered Activity results as immutable
 `concord_academic_result_manifest_v1` revisions through Core Publication Records
-and the derived academic catalog. Concord does **not** calculate Grades or
-proficiency; Meridian owns downstream grading/reporting policy, and issue #32
-owns the consumer-neutral manifest reader.
+and the derived academic catalog. Concord now also exposes a consumer-neutral
+canonical manifest reader and a separately authorization-gated, bounded Artifact
+reader. Concord does **not** calculate Grades or proficiency; Meridian owns
+downstream grading/reporting policy. The complete clean-wheel producer-to-consumer
+acceptance path remains assigned to issue #33.
 
 ## Requirements and installation
 
@@ -153,6 +155,9 @@ Criterion, Scale, and Score behavior is documented in the
 Academic-result registration, manifest generation, publication lifecycle, and
 catalog reconciliation are documented in the
 [publication implementation guide](docs/implementation/academic-result-publication.md).
+Consumer-neutral manifest interpretation and authorization-gated bounded Artifact
+access are documented in the
+[consumer reader guide](docs/implementation/academic-result-reader.md).
 Canonical persistence and recovery rules remain documented in the
 [canonical storage guide](docs/implementation/canonical-storage.md).
 
@@ -173,7 +178,7 @@ python scripts/validate_repository.py --core-wheel <wheel>
 
 The validator authenticates the exact Core v0.6.0 wheel, runs pytest, Ruff,
 strict Mypy, documentation checks, package builds, Twine validation, package
-inspection, isolated installed-wheel workflow/menu smoke tests, and
+inspection, isolated installed-wheel workflow/menu/public-reader smoke tests, and
 `git diff --check`.
 
 Core exposes routing through `paper_data_suite.modules` and publication through

--- a/concord/academic_result_artifacts.py
+++ b/concord/academic_result_artifacts.py
@@ -1,0 +1,1163 @@
+"""Consumer-neutral contracts and authorized Concord Artifact source resolution.
+
+Public contract models remain presentation-neutral. Native workspace access is
+permitted only behind the explicit deployment-owned authorization gate, and
+resolution is bound to the exact historical Concord snapshot named by the
+validated Academic Result Manifest.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, NoReturn, Protocol, TypeAlias
+
+from pds_core.identifiers import validate_identifier
+from pds_core.routing_models import ModuleWorkRef
+
+from concord.academic_result_manifest import (
+    AcademicResultManifest,
+    ConcordAcademicResultManifestValidationError,
+    CorePublicationReferenceProjection,
+    EvidenceLocatorProjection,
+    EvidenceReferenceProjection,
+    PublicActor,
+    RecordReferenceProjection,
+    ScoreEvidenceLinkProjection,
+    SubjectReferenceProjection,
+    validate_academic_result_manifest,
+)
+from concord.academic_result_reader import (
+    ConcordAcademicResultReaderNotFoundError,
+    lookup_academic_result_score_evidence_link,
+)
+from concord.model_validation import ConcordRecordGraph
+from concord.models import (
+    ActorReference,
+    ArtifactAuthor,
+    ArtifactInstance,
+    ArtifactPage,
+    ArtifactSubject,
+    ConcordRecordReference,
+    EvidenceLocator,
+    EvidenceReference,
+    ParticipantReference,
+    ScoreEvidenceLink,
+    SubjectReference,
+)
+from concord.pds_contract import (
+    CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+    CONCORD_MODULE_ID,
+)
+from concord.storage import load_record_graph_at_snapshot
+from concord.storage_errors import (
+    ConcordStorageError,
+    ConcordStorageNotFoundError,
+)
+from concord.storage_models import ConcordLoadedRecordGraph
+
+AcademicResultArtifactRepresentation: TypeAlias = Literal[
+    "returned_artifact_pdf"
+]
+ArtifactAuthorizationStatus: TypeAlias = Literal[
+    "allowed",
+    "denied",
+    "unresolved",
+]
+
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_EXTENSION_KEY = re.compile(r"^[a-z][a-z0-9_-]*:[a-z][a-z0-9_-]*$")
+_ARTIFACT_CATEGORIES = frozenset(
+    {
+        "student_work",
+        "observation",
+        "discussion_record",
+        "laboratory_record",
+        "project_record",
+    }
+)
+_AUTHORSHIP_MODES = frozenset(
+    {
+        "individual_author",
+        "co_author",
+        "observer",
+        "recorder",
+        "recorder_for_group",
+        "collective_group_author",
+        "teacher_author",
+        "authorized_adult_author",
+        "unknown",
+    }
+)
+_ATTRIBUTION_STATUSES = frozenset(
+    {"proposed", "confirmed", "disputed", "unknown", "superseded"}
+)
+_REPRESENTATION_STATUSES = frozenset(
+    {
+        "individual_view",
+        "recorder_summary",
+        "majority_position",
+        "unanimous_position",
+        "multiple_named_positions",
+        "no_consensus",
+        "not_applicable",
+    }
+)
+_SUBJECT_ROLES = frozenset(
+    {
+        "observed_participant",
+        "represented_group",
+        "activity_context",
+        "session_context",
+        "evaluated_artifact",
+        "general_subject",
+    }
+)
+_CONFIRMATION_STATUSES = frozenset(
+    {"proposed", "confirmed", "disputed", "unresolved", "superseded"}
+)
+_PRIVACY_CLASSIFICATIONS = frozenset(
+    {
+        "teacher_restricted",
+        "teacher_and_subjects",
+        "group_and_teacher",
+        "classroom_shared",
+        "inherited",
+        "external_policy",
+    }
+)
+
+
+class ConcordAcademicResultArtifactError(Exception):
+    """Base failure for public Concord Academic Result Artifact access."""
+
+
+class ConcordAcademicResultArtifactValidationError(
+    ConcordAcademicResultArtifactError, ValueError
+):
+    """Artifact request or public projection violates the public contract."""
+
+
+class ConcordAcademicResultArtifactAuthorizationError(
+    ConcordAcademicResultArtifactError
+):
+    """External authorization did not affirmatively allow Artifact I/O."""
+
+
+class ConcordAcademicResultArtifactNotFoundError(
+    ConcordAcademicResultArtifactError, LookupError
+):
+    """An authorized exact historical canonical object is absent."""
+
+
+class ConcordAcademicResultArtifactUnavailableError(
+    ConcordAcademicResultArtifactError
+):
+    """Represented evidence cannot produce the bounded Artifact."""
+
+
+class ConcordAcademicResultArtifactAmbiguityError(
+    ConcordAcademicResultArtifactError
+):
+    """Represented evidence cannot resolve to one exact Artifact."""
+
+
+class ConcordAcademicResultArtifactIntegrityError(
+    ConcordAcademicResultArtifactError
+):
+    """Historical identity, lineage, path, digest, or output integrity failed."""
+
+
+def _fail(message: str) -> NoReturn:
+    raise ConcordAcademicResultArtifactValidationError(message)
+
+
+def _identifier(value: object, field: str) -> str:
+    if not isinstance(value, str):
+        _fail(f"{field} must be a safe identifier.")
+    try:
+        return validate_identifier(value, field)
+    except (TypeError, ValueError) as error:
+        raise ConcordAcademicResultArtifactValidationError(
+            f"{field} must be a safe identifier."
+        ) from error
+
+
+def _optional_identifier(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    return _identifier(value, field)
+
+
+def _lower_identifier(value: object, field: str) -> str:
+    result = _identifier(value, field)
+    if result != result.lower():
+        _fail(f"{field} must be lowercase.")
+    return result
+
+
+def _positive_int(value: object, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        _fail(f"{field} must be a positive integer.")
+    return value
+
+
+def _optional_public_text(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    return _public_text(value, field)
+
+
+def _public_text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        _fail(f"{field} must be nonempty and trimmed.")
+    if len(value) > 512:
+        _fail(f"{field} is too long.")
+    if any(
+        unicodedata.category(character) in {"Cc", "Cf", "Cs", "Zl", "Zp"}
+        for character in value
+    ):
+        _fail(f"{field} must be control-free.")
+    return value
+
+
+def _controlled(value: object, field: str, allowed: frozenset[str]) -> str:
+    if not isinstance(value, str) or value not in allowed:
+        _fail(f"{field} must be one of: {', '.join(sorted(allowed))}.")
+    return value
+
+
+def _controlled_key(
+    value: object,
+    field: str,
+    builtins: frozenset[str],
+) -> str:
+    text = _public_text(value, field)
+    if text not in builtins and _EXTENSION_KEY.fullmatch(text) is None:
+        _fail(f"{field} must be a built-in or namespace-qualified key.")
+    return text
+
+
+def _sha256(value: object, field: str) -> str:
+    if not isinstance(value, str) or _SHA256.fullmatch(value) is None:
+        _fail(f"{field} must be a lowercase SHA-256 digest.")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultParticipantReferenceProjection:
+    participant_kind: str
+    participant_id: str
+    owning_system: str
+
+    def __post_init__(self) -> None:
+        _controlled(
+            self.participant_kind,
+            "participant_reference.participant_kind",
+            frozenset({"core_student", "authorized_actor"}),
+        )
+        _identifier(
+            self.participant_id,
+            "participant_reference.participant_id",
+        )
+        _lower_identifier(
+            self.owning_system,
+            "participant_reference.owning_system",
+        )
+
+
+AcademicResultArtifactAuthorReference: TypeAlias = (
+    AcademicResultParticipantReferenceProjection
+    | PublicActor
+    | RecordReferenceProjection
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultArtifactPageProjection:
+    artifact_page_id: str
+    page_number: int
+
+    def __post_init__(self) -> None:
+        _identifier(self.artifact_page_id, "artifact_page.artifact_page_id")
+        _positive_int(self.page_number, "artifact_page.page_number")
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultArtifactProjection:
+    artifact_instance_id: str
+    artifact_category: str
+    session_id: str | None
+    group_id: str | None
+    pages: tuple[AcademicResultArtifactPageProjection, ...]
+    privacy_classification: str
+
+    def __post_init__(self) -> None:
+        _identifier(
+            self.artifact_instance_id,
+            "artifact.artifact_instance_id",
+        )
+        _controlled_key(
+            self.artifact_category,
+            "artifact.artifact_category",
+            _ARTIFACT_CATEGORIES,
+        )
+        _optional_identifier(self.session_id, "artifact.session_id")
+        _optional_identifier(self.group_id, "artifact.group_id")
+        pages = tuple(self.pages)
+        if not pages or any(
+            not isinstance(item, AcademicResultArtifactPageProjection)
+            for item in pages
+        ):
+            _fail("artifact.pages must contain public Artifact Page projections.")
+        if len({item.artifact_page_id for item in pages}) != len(pages):
+            _fail("artifact.pages must not repeat Artifact Page identities.")
+        if len({item.page_number for item in pages}) != len(pages):
+            _fail("artifact.pages must not repeat logical page numbers.")
+        object.__setattr__(self, "pages", pages)
+        _controlled(
+            self.privacy_classification,
+            "artifact.privacy_classification",
+            _PRIVACY_CLASSIFICATIONS,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultArtifactAuthorProjection:
+    artifact_author_id: str
+    artifact_instance_id: str
+    author_reference: AcademicResultArtifactAuthorReference | None
+    authorship_mode: str
+    attribution_status: str
+    represented_group_id: str | None
+    representation_status: str | None
+
+    def __post_init__(self) -> None:
+        _identifier(
+            self.artifact_author_id,
+            "artifact_author.artifact_author_id",
+        )
+        _identifier(
+            self.artifact_instance_id,
+            "artifact_author.artifact_instance_id",
+        )
+        if self.author_reference is not None and not isinstance(
+            self.author_reference,
+            (
+                AcademicResultParticipantReferenceProjection,
+                PublicActor,
+                RecordReferenceProjection,
+            ),
+        ):
+            _fail("artifact_author.author_reference is invalid.")
+        _controlled(
+            self.authorship_mode,
+            "artifact_author.authorship_mode",
+            _AUTHORSHIP_MODES,
+        )
+        _controlled(
+            self.attribution_status,
+            "artifact_author.attribution_status",
+            _ATTRIBUTION_STATUSES,
+        )
+        _optional_identifier(
+            self.represented_group_id,
+            "artifact_author.represented_group_id",
+        )
+        if self.representation_status is not None:
+            _controlled(
+                self.representation_status,
+                "artifact_author.representation_status",
+                _REPRESENTATION_STATUSES,
+            )
+        if self.authorship_mode == "unknown":
+            if self.author_reference is not None:
+                _fail("unknown authorship must not invent an author reference.")
+            if self.attribution_status != "unknown":
+                _fail("unknown authorship requires unknown attribution status.")
+            if (
+                self.represented_group_id is not None
+                or self.representation_status is not None
+            ):
+                _fail("unknown authorship cannot carry representation context.")
+        elif self.author_reference is None:
+            _fail("known authorship requires an exact author reference.")
+        if (
+            self.authorship_mode == "recorder_for_group"
+            and self.represented_group_id is None
+        ):
+            _fail("recorder_for_group requires represented_group_id.")
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultArtifactSubjectProjection:
+    artifact_subject_id: str
+    artifact_instance_id: str
+    subject_reference: SubjectReferenceProjection
+    subject_role: str
+    confirmation_status: str
+    criterion_id: str | None
+
+    def __post_init__(self) -> None:
+        _identifier(
+            self.artifact_subject_id,
+            "artifact_subject.artifact_subject_id",
+        )
+        _identifier(
+            self.artifact_instance_id,
+            "artifact_subject.artifact_instance_id",
+        )
+        if not isinstance(self.subject_reference, SubjectReferenceProjection):
+            _fail("artifact_subject.subject_reference is invalid.")
+        _controlled_key(
+            self.subject_role,
+            "artifact_subject.subject_role",
+            _SUBJECT_ROLES,
+        )
+        _controlled(
+            self.confirmation_status,
+            "artifact_subject.confirmation_status",
+            _CONFIRMATION_STATUSES,
+        )
+        _optional_identifier(self.criterion_id, "artifact_subject.criterion_id")
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultArtifactAuthorizationRequest:
+    work: ModuleWorkRef
+    record_set_id: str
+    record_set_revision: int
+    source_snapshot_revision: int
+    score_record_id: str
+    score_evidence_link_id: str
+    evidence_reference: EvidenceReferenceProjection
+    purpose: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.work, ModuleWorkRef):
+            _fail("authorization work must be a ModuleWorkRef.")
+        if self.work.module_id != CONCORD_MODULE_ID:
+            _fail('authorization work.module_id must be exactly "concord".')
+        if self.record_set_id != CONCORD_ACADEMIC_RESULT_RECORD_SET_ID:
+            _fail('record_set_id must be exactly "academic_results".')
+        _positive_int(self.record_set_revision, "record_set_revision")
+        _positive_int(self.source_snapshot_revision, "source_snapshot_revision")
+        _identifier(self.score_record_id, "score_record_id")
+        _identifier(self.score_evidence_link_id, "score_evidence_link_id")
+        if not isinstance(self.evidence_reference, EvidenceReferenceProjection):
+            _fail("evidence_reference must be an EvidenceReferenceProjection.")
+        if self.evidence_reference.owning_system != CONCORD_MODULE_ID:
+            _fail("Artifact authorization requires Concord-owned evidence.")
+        if self.evidence_reference.evidence_kind not in {
+            "artifact_instance",
+            "artifact_page",
+        }:
+            _fail(
+                "Artifact authorization requires artifact_instance or "
+                "artifact_page evidence."
+            )
+        _public_text(self.purpose, "purpose")
+
+
+@dataclass(frozen=True, slots=True)
+class AcademicResultArtifactAuthorizationDecision:
+    status: ArtifactAuthorizationStatus
+
+    def __post_init__(self) -> None:
+        _controlled(
+            self.status,
+            "authorization status",
+            frozenset({"allowed", "denied", "unresolved"}),
+        )
+
+
+class AcademicResultArtifactAuthorizationGate(Protocol):
+    """Deployment-owned decision gate invoked before native Artifact I/O."""
+
+    def authorize(
+        self,
+        request: AcademicResultArtifactAuthorizationRequest,
+    ) -> AcademicResultArtifactAuthorizationDecision: ...
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorizedAcademicResultArtifact:
+    representation: AcademicResultArtifactRepresentation
+    work: ModuleWorkRef
+    record_set_revision: int
+    source_snapshot_revision: int
+    score_record_id: str
+    score_evidence_link_id: str
+    evidence_reference: EvidenceReferenceProjection
+    artifact: AcademicResultArtifactProjection
+    authors: tuple[AcademicResultArtifactAuthorProjection, ...]
+    subjects: tuple[AcademicResultArtifactSubjectProjection, ...]
+    media_type: str
+    sha256: str
+    byte_size: int
+    content: bytes
+
+    def __post_init__(self) -> None:
+        if self.representation != "returned_artifact_pdf":
+            _fail('representation must be exactly "returned_artifact_pdf".')
+        if not isinstance(self.work, ModuleWorkRef):
+            _fail("result work must be a ModuleWorkRef.")
+        if self.work.module_id != CONCORD_MODULE_ID:
+            _fail('result work.module_id must be exactly "concord".')
+        _positive_int(self.record_set_revision, "record_set_revision")
+        _positive_int(self.source_snapshot_revision, "source_snapshot_revision")
+        _identifier(self.score_record_id, "score_record_id")
+        _identifier(self.score_evidence_link_id, "score_evidence_link_id")
+        if not isinstance(self.evidence_reference, EvidenceReferenceProjection):
+            _fail("evidence_reference must be an EvidenceReferenceProjection.")
+        if (
+            self.evidence_reference.owning_system != CONCORD_MODULE_ID
+            or self.evidence_reference.evidence_kind
+            not in {"artifact_instance", "artifact_page"}
+        ):
+            _fail("result evidence must be Concord-owned Artifact evidence.")
+        if not isinstance(self.artifact, AcademicResultArtifactProjection):
+            _fail("artifact must be an AcademicResultArtifactProjection.")
+        page_ids = {item.artifact_page_id for item in self.artifact.pages}
+        if self.evidence_reference.evidence_kind == "artifact_instance":
+            if (
+                self.evidence_reference.record_id
+                != self.artifact.artifact_instance_id
+            ):
+                _fail("Artifact Instance evidence identity is inconsistent.")
+        elif self.evidence_reference.record_id not in page_ids:
+            _fail("Artifact Page evidence identity is inconsistent.")
+
+        authors = tuple(self.authors)
+        if any(
+            not isinstance(item, AcademicResultArtifactAuthorProjection)
+            for item in authors
+        ):
+            _fail("authors contains an invalid public Author projection.")
+        if len({item.artifact_author_id for item in authors}) != len(authors):
+            _fail("authors must not repeat Artifact Author identities.")
+        if any(
+            item.artifact_instance_id != self.artifact.artifact_instance_id
+            for item in authors
+        ):
+            _fail("Artifact Author belongs to another Artifact Instance.")
+        object.__setattr__(self, "authors", authors)
+
+        subjects = tuple(self.subjects)
+        if any(
+            not isinstance(item, AcademicResultArtifactSubjectProjection)
+            for item in subjects
+        ):
+            _fail("subjects contains an invalid public Subject projection.")
+        if len({item.artifact_subject_id for item in subjects}) != len(subjects):
+            _fail("subjects must not repeat Artifact Subject identities.")
+        if any(
+            item.artifact_instance_id != self.artifact.artifact_instance_id
+            for item in subjects
+        ):
+            _fail("Artifact Subject belongs to another Artifact Instance.")
+        object.__setattr__(self, "subjects", subjects)
+
+        if self.media_type != "application/pdf":
+            _fail('media_type must be exactly "application/pdf".')
+        _sha256(self.sha256, "sha256")
+        if isinstance(self.byte_size, bool) or not isinstance(self.byte_size, int):
+            _fail("byte_size must be an integer.")
+        if self.byte_size < 1:
+            _fail("byte_size must be positive.")
+        if type(self.content) is not bytes:
+            _fail("content must be immutable bytes.")
+        if not self.content.startswith(b"%PDF"):
+            _fail("content must contain PDF bytes.")
+        if self.byte_size != len(self.content):
+            _fail("byte_size does not match content length.")
+        if self.sha256 != hashlib.sha256(self.content).hexdigest():
+            _fail("sha256 does not match returned Artifact bytes.")
+
+
+@dataclass(frozen=True, slots=True)
+class _AuthorizedAcademicResultArtifactContext:
+    request: AcademicResultArtifactAuthorizationRequest
+    loaded: ConcordLoadedRecordGraph
+    artifact_instance: ArtifactInstance
+    evidence_page: ArtifactPage | None
+    artifact: AcademicResultArtifactProjection
+    authors: tuple[AcademicResultArtifactAuthorProjection, ...]
+    subjects: tuple[AcademicResultArtifactSubjectProjection, ...]
+
+
+def _project_subject_reference(
+    value: SubjectReference,
+) -> SubjectReferenceProjection:
+    return SubjectReferenceProjection(
+        subject_kind=value.subject_kind,
+        subject_id=value.subject_id,
+        owning_system=value.owning_system,
+        contract_version=value.contract_version,
+    )
+
+
+def _project_locator(
+    value: EvidenceLocator | None,
+) -> EvidenceLocatorProjection | None:
+    if value is None:
+        return None
+    return EvidenceLocatorProjection(
+        page_number=value.page_number,
+        source_page_index=value.source_page_index,
+        section_label=value.section_label,
+        row_label=value.row_label,
+        column_label=value.column_label,
+        participant_label=value.participant_label,
+        session_id=value.session_id,
+    )
+
+
+def _project_evidence_reference(
+    value: EvidenceReference,
+) -> EvidenceReferenceProjection:
+    publication = value.source_publication_reference
+    return EvidenceReferenceProjection(
+        evidence_kind=value.evidence_kind,
+        owning_system=value.owning_system,
+        record_id=value.record_id,
+        contract_version=value.contract_version,
+        source_publication_reference=(
+            CorePublicationReferenceProjection(
+                publication_id=publication.publication_id,
+                publication_schema_version=publication.publication_schema_version,
+            )
+            if publication is not None
+            else None
+        ),
+        immutable_source_version=value.immutable_source_version,
+        locator=_project_locator(value.locator),
+        subject_context=tuple(
+            _project_subject_reference(item) for item in value.subject_context
+        ),
+        moderation_requirement=value.moderation_requirement,
+    )
+
+
+def _project_score_evidence_link(
+    value: ScoreEvidenceLink,
+) -> ScoreEvidenceLinkProjection:
+    return ScoreEvidenceLinkProjection(
+        score_evidence_link_id=value.score_evidence_link_id,
+        score_record_id=value.score_record_id,
+        evidence_reference=_project_evidence_reference(value.evidence_reference),
+        evidence_locator=_project_locator(value.evidence_locator),
+        subject_context=tuple(
+            _project_subject_reference(item) for item in value.subject_context
+        ),
+        relevance_description=value.relevance_description,
+        significance=value.significance,
+        moderation_record_id=value.moderation_record_id,
+        status=value.status,
+        supersedes_score_evidence_link_id=value.supersedes_score_evidence_link_id,
+    )
+
+
+def _project_author_reference(
+    value: ParticipantReference | ActorReference | ConcordRecordReference | None,
+) -> AcademicResultArtifactAuthorReference | None:
+    if value is None:
+        return None
+    if isinstance(value, ParticipantReference):
+        return AcademicResultParticipantReferenceProjection(
+            participant_kind=value.participant_kind,
+            participant_id=value.participant_id,
+            owning_system=value.owning_system,
+        )
+    if isinstance(value, ActorReference):
+        return PublicActor(
+            actor_kind=value.actor_kind,
+            actor_id=value.actor_id,
+            owning_system=value.owning_system,
+        )
+    if isinstance(value, ConcordRecordReference):
+        return RecordReferenceProjection(
+            module_id=CONCORD_MODULE_ID,
+            record_kind=value.record_kind,
+            record_id=value.record_id,
+            contract_version=value.contract_version,
+        )
+    raise ConcordAcademicResultArtifactIntegrityError(
+        "Historical Artifact Author reference is invalid."
+    )
+
+
+def _project_artifact_author(
+    value: ArtifactAuthor,
+) -> AcademicResultArtifactAuthorProjection:
+    return AcademicResultArtifactAuthorProjection(
+        artifact_author_id=value.artifact_author_id,
+        artifact_instance_id=value.artifact_instance_id,
+        author_reference=_project_author_reference(value.author_reference),
+        authorship_mode=value.authorship_mode,
+        attribution_status=value.attribution_status,
+        represented_group_id=value.represented_group_id,
+        representation_status=value.representation_status,
+    )
+
+
+def _project_artifact_subject(
+    value: ArtifactSubject,
+) -> AcademicResultArtifactSubjectProjection:
+    return AcademicResultArtifactSubjectProjection(
+        artifact_subject_id=value.artifact_subject_id,
+        artifact_instance_id=value.artifact_instance_id,
+        subject_reference=_project_subject_reference(value.subject_reference),
+        subject_role=value.subject_role,
+        confirmation_status=value.confirmation_status,
+        criterion_id=value.criterion_id,
+    )
+
+
+def _current_artifact_authors(
+    graph: ConcordRecordGraph,
+    artifact_instance_id: str,
+) -> tuple[ArtifactAuthor, ...]:
+    """Return current Author associations as of this exact historical graph."""
+    superseded_ids = {
+        item.supersedes_artifact_author_id
+        for item in graph.artifact_authors
+        if item.supersedes_artifact_author_id is not None
+    }
+    return tuple(
+        item
+        for item in graph.artifact_authors
+        if item.artifact_instance_id == artifact_instance_id
+        and item.artifact_author_id not in superseded_ids
+        and item.attribution_status != "superseded"
+    )
+
+
+def _current_artifact_subjects(
+    graph: ConcordRecordGraph,
+    artifact_instance_id: str,
+) -> tuple[ArtifactSubject, ...]:
+    """Return current Subject associations as of this exact historical graph."""
+    superseded_ids = {
+        item.supersedes_artifact_subject_id
+        for item in graph.artifact_subjects
+        if item.supersedes_artifact_subject_id is not None
+    }
+    return tuple(
+        item
+        for item in graph.artifact_subjects
+        if item.artifact_instance_id == artifact_instance_id
+        and item.artifact_subject_id not in superseded_ids
+        and item.confirmation_status != "superseded"
+    )
+
+
+def _project_artifact(
+    graph: ConcordRecordGraph,
+    artifact: ArtifactInstance,
+) -> AcademicResultArtifactProjection:
+    page_by_id = {item.artifact_page_id: item for item in graph.artifact_pages}
+    pages: list[AcademicResultArtifactPageProjection] = []
+    for page_id in artifact.page_ids:
+        page = page_by_id.get(page_id)
+        if page is None:
+            raise ConcordAcademicResultArtifactIntegrityError(
+                "Historical Artifact references a missing Artifact Page."
+            )
+        if page.artifact_instance_id != artifact.artifact_instance_id:
+            raise ConcordAcademicResultArtifactIntegrityError(
+                "Historical Artifact Page belongs to another Artifact Instance."
+            )
+        pages.append(
+            AcademicResultArtifactPageProjection(
+                artifact_page_id=page.artifact_page_id,
+                page_number=page.page_number,
+            )
+        )
+    return AcademicResultArtifactProjection(
+        artifact_instance_id=artifact.artifact_instance_id,
+        artifact_category=artifact.artifact_category,
+        session_id=artifact.session_id,
+        group_id=artifact.group_id,
+        pages=tuple(pages),
+        privacy_classification=artifact.privacy_policy.classification,
+    )
+
+
+def _validated_artifact_manifest(
+    manifest: AcademicResultManifest,
+) -> AcademicResultManifest:
+    invalid = False
+    try:
+        checked = validate_academic_result_manifest(manifest)
+    except ConcordAcademicResultManifestValidationError:
+        invalid = True
+        checked = None
+    if invalid or checked is None:
+        raise ConcordAcademicResultArtifactValidationError(
+            "Academic-result manifest model is invalid."
+        )
+    return checked
+
+
+def _manifest_artifact_link(
+    manifest: AcademicResultManifest,
+    score_evidence_link_id: str,
+) -> ScoreEvidenceLinkProjection:
+    _identifier(score_evidence_link_id, "score_evidence_link_id")
+    missing = False
+    try:
+        link = lookup_academic_result_score_evidence_link(
+            manifest,
+            score_evidence_link_id,
+        )
+    except ConcordAcademicResultReaderNotFoundError:
+        missing = True
+        link = None
+    if missing or link is None:
+        raise ConcordAcademicResultArtifactNotFoundError(
+            "Requested evidence link is not represented in this manifest."
+        )
+    evidence = link.evidence_reference
+    if (
+        evidence.owning_system != CONCORD_MODULE_ID
+        or evidence.evidence_kind not in {"artifact_instance", "artifact_page"}
+    ):
+        raise ConcordAcademicResultArtifactValidationError(
+            "Requested evidence link is not Concord-owned Artifact evidence."
+        )
+    return link
+
+
+def _authorize_artifact_request(
+    request: AcademicResultArtifactAuthorizationRequest,
+    authorization_gate: AcademicResultArtifactAuthorizationGate,
+) -> None:
+    gate_failed = False
+    try:
+        decision = authorization_gate.authorize(request)
+    except Exception:
+        gate_failed = True
+        decision = None
+    if gate_failed:
+        raise ConcordAcademicResultArtifactAuthorizationError(
+            "Artifact authorization could not be affirmed."
+        )
+    if (
+        not isinstance(decision, AcademicResultArtifactAuthorizationDecision)
+        or decision.status != "allowed"
+    ):
+        raise ConcordAcademicResultArtifactAuthorizationError(
+            "Artifact authorization was not affirmed."
+        )
+
+
+def _load_authorized_historical_graph(
+    workspace_root: str | Path,
+    request: AcademicResultArtifactAuthorizationRequest,
+) -> ConcordLoadedRecordGraph:
+    failure: str | None = None
+    try:
+        loaded = load_record_graph_at_snapshot(
+            workspace_root,
+            request.work,
+            request.source_snapshot_revision,
+        )
+    except ConcordStorageNotFoundError:
+        failure = "not_found"
+        loaded = None
+    except ConcordStorageError:
+        failure = "integrity"
+        loaded = None
+    if failure == "not_found":
+        raise ConcordAcademicResultArtifactNotFoundError(
+            "Authorized historical Concord state is unavailable."
+        )
+    if failure == "integrity" or loaded is None:
+        raise ConcordAcademicResultArtifactIntegrityError(
+            "Authorized historical Concord state could not be verified."
+        )
+    if loaded.snapshot_revision != request.source_snapshot_revision:
+        raise ConcordAcademicResultArtifactIntegrityError(
+            "Historical Concord snapshot revision is inconsistent."
+        )
+    if not isinstance(loaded.graph, ConcordRecordGraph):
+        raise ConcordAcademicResultArtifactIntegrityError(
+            "Historical Concord graph is invalid."
+        )
+    return loaded
+
+
+def _verify_historical_evidence(
+    loaded: ConcordLoadedRecordGraph,
+    request: AcademicResultArtifactAuthorizationRequest,
+    manifest_link: ScoreEvidenceLinkProjection,
+) -> tuple[ArtifactInstance, ArtifactPage | None]:
+    graph = loaded.graph
+    if (
+        len(graph.activities) != 1
+        or graph.activities[0].work_reference != request.work
+    ):
+        raise ConcordAcademicResultArtifactIntegrityError(
+            "Historical Concord Activity identity is inconsistent."
+        )
+
+    native_score = next(
+        (
+            item
+            for item in graph.score_records
+            if item.score_record_id == request.score_record_id
+        ),
+        None,
+    )
+    if native_score is None:
+        raise ConcordAcademicResultArtifactNotFoundError(
+            "Manifest-required historical Score is unavailable."
+        )
+    if native_score.activity_id != request.work.work_id:
+        raise ConcordAcademicResultArtifactIntegrityError(
+            "Historical Score belongs to another Activity."
+        )
+
+    native_link = next(
+        (
+            item
+            for item in graph.score_evidence_links
+            if item.score_evidence_link_id == request.score_evidence_link_id
+        ),
+        None,
+    )
+    if native_link is None:
+        raise ConcordAcademicResultArtifactNotFoundError(
+            "Manifest-required historical evidence link is unavailable."
+        )
+    if native_link.score_record_id != native_score.score_record_id:
+        raise ConcordAcademicResultArtifactIntegrityError(
+            "Historical evidence link belongs to another Score."
+        )
+    projection_failed = False
+    try:
+        projected_link = _project_score_evidence_link(native_link)
+    except (TypeError, ValueError):
+        projection_failed = True
+        projected_link = None
+    if projection_failed or projected_link is None:
+        raise ConcordAcademicResultArtifactIntegrityError(
+            "Historical evidence link cannot reproduce the public projection."
+        )
+    if projected_link != manifest_link:
+        raise ConcordAcademicResultArtifactIntegrityError(
+            "Historical evidence link disagrees with the manifest projection."
+        )
+
+    evidence = native_link.evidence_reference
+    artifact_by_id = {
+        item.artifact_instance_id: item for item in graph.artifact_instances
+    }
+    page_by_id = {item.artifact_page_id: item for item in graph.artifact_pages}
+    evidence_page: ArtifactPage | None = None
+    if evidence.evidence_kind == "artifact_instance":
+        artifact = artifact_by_id.get(evidence.record_id)
+        if artifact is None:
+            raise ConcordAcademicResultArtifactNotFoundError(
+                "Manifest-required historical Artifact is unavailable."
+            )
+    elif evidence.evidence_kind == "artifact_page":
+        evidence_page = page_by_id.get(evidence.record_id)
+        if evidence_page is None:
+            raise ConcordAcademicResultArtifactNotFoundError(
+                "Manifest-required historical Artifact Page is unavailable."
+            )
+        artifact = artifact_by_id.get(evidence_page.artifact_instance_id)
+        if artifact is None:
+            raise ConcordAcademicResultArtifactNotFoundError(
+                "Historical Artifact Page parent is unavailable."
+            )
+    else:
+        raise ConcordAcademicResultArtifactIntegrityError(
+            "Historical evidence is not Concord Artifact evidence."
+        )
+
+    if artifact.activity_id != request.work.work_id:
+        raise ConcordAcademicResultArtifactIntegrityError(
+            "Historical Artifact belongs to another Activity."
+        )
+    if (
+        evidence_page is not None
+        and evidence_page.artifact_page_id not in artifact.page_ids
+    ):
+        raise ConcordAcademicResultArtifactIntegrityError(
+            "Historical Artifact Page is not selected by its Artifact Instance."
+        )
+    return artifact, evidence_page
+
+
+def _resolve_authorized_academic_result_artifact_context(
+    workspace_root: str | Path,
+    manifest: AcademicResultManifest,
+    score_evidence_link_id: str,
+    *,
+    purpose: str,
+    authorization_gate: AcademicResultArtifactAuthorizationGate,
+) -> _AuthorizedAcademicResultArtifactContext:
+    """Authorize first, then verify exact historical Concord Artifact lineage."""
+    checked = _validated_artifact_manifest(manifest)
+    manifest_link = _manifest_artifact_link(
+        checked,
+        score_evidence_link_id,
+    )
+    request = AcademicResultArtifactAuthorizationRequest(
+        work=checked.work,
+        record_set_id=checked.record_set.record_set_id,
+        record_set_revision=checked.record_set.revision,
+        source_snapshot_revision=checked.projection.source_snapshot_revision,
+        score_record_id=manifest_link.score_record_id,
+        score_evidence_link_id=manifest_link.score_evidence_link_id,
+        evidence_reference=manifest_link.evidence_reference,
+        purpose=purpose,
+    )
+
+    # This is intentionally the last operation before any native workspace I/O.
+    _authorize_artifact_request(request, authorization_gate)
+
+    loaded = _load_authorized_historical_graph(workspace_root, request)
+    artifact_instance, evidence_page = _verify_historical_evidence(
+        loaded,
+        request,
+        manifest_link,
+    )
+    graph = loaded.graph
+    artifact = _project_artifact(graph, artifact_instance)
+    authors = tuple(
+        _project_artifact_author(item)
+        for item in _current_artifact_authors(
+            graph,
+            artifact_instance.artifact_instance_id,
+        )
+    )
+    subjects = tuple(
+        _project_artifact_subject(item)
+        for item in _current_artifact_subjects(
+            graph,
+            artifact_instance.artifact_instance_id,
+        )
+    )
+    return _AuthorizedAcademicResultArtifactContext(
+        request=request,
+        loaded=loaded,
+        artifact_instance=artifact_instance,
+        evidence_page=evidence_page,
+        artifact=artifact,
+        authors=authors,
+        subjects=subjects,
+    )
+
+
+def read_authorized_academic_result_artifact(
+    workspace_root: str | Path,
+    manifest: AcademicResultManifest,
+    score_evidence_link_id: str,
+    *,
+    purpose: str,
+    authorization_gate: AcademicResultArtifactAuthorizationGate,
+) -> AuthorizedAcademicResultArtifact:
+    """Return one authorization-gated bounded Concord Artifact PDF."""
+    context = _resolve_authorized_academic_result_artifact_context(
+        workspace_root,
+        manifest,
+        score_evidence_link_id,
+        purpose=purpose,
+        authorization_gate=authorization_gate,
+    )
+
+    # Import only after authorization and historical identity verification.
+    # The neutral rendering layer contains no workflow or publication orchestration.
+    from concord.artifact_rendering import (
+        ReturnedArtifactRenderAmbiguityError,
+        ReturnedArtifactRenderError,
+        ReturnedArtifactRenderIntegrityError,
+        ReturnedArtifactRenderUnavailableError,
+        render_returned_artifact_pdf,
+    )
+
+    render_failure: str | None = None
+    try:
+        content = render_returned_artifact_pdf(
+            workspace_root,
+            context.loaded.graph,
+            context.artifact_instance,
+            evidence_page=context.evidence_page,
+        )
+    except ReturnedArtifactRenderAmbiguityError:
+        render_failure = "ambiguity"
+        content = None
+    except ReturnedArtifactRenderUnavailableError:
+        render_failure = "unavailable"
+        content = None
+    except ReturnedArtifactRenderIntegrityError:
+        render_failure = "integrity"
+        content = None
+    except ReturnedArtifactRenderError:
+        render_failure = "unsupported"
+        content = None
+
+    if render_failure == "ambiguity":
+        raise ConcordAcademicResultArtifactAmbiguityError(
+            "Authorized Artifact evidence has ambiguous returned-source lineage."
+        )
+    if render_failure == "integrity":
+        raise ConcordAcademicResultArtifactIntegrityError(
+            "Authorized Artifact source bytes could not be verified."
+        )
+    if render_failure == "unavailable":
+        raise ConcordAcademicResultArtifactUnavailableError(
+            "Authorized Artifact evidence has no complete returned representation."
+        )
+    if render_failure == "unsupported" or content is None:
+        raise ConcordAcademicResultArtifactUnavailableError(
+            "Authorized Artifact evidence cannot produce a returned representation."
+        )
+
+    return AuthorizedAcademicResultArtifact(
+        representation="returned_artifact_pdf",
+        work=context.request.work,
+        record_set_revision=context.request.record_set_revision,
+        source_snapshot_revision=context.request.source_snapshot_revision,
+        score_record_id=context.request.score_record_id,
+        score_evidence_link_id=context.request.score_evidence_link_id,
+        evidence_reference=context.request.evidence_reference,
+        artifact=context.artifact,
+        authors=context.authors,
+        subjects=context.subjects,
+        media_type="application/pdf",
+        sha256=hashlib.sha256(content).hexdigest(),
+        byte_size=len(content),
+        content=content,
+    )
+
+
+__all__ = (
+    "AcademicResultArtifactAuthorizationDecision",
+    "AcademicResultArtifactAuthorizationGate",
+    "AcademicResultArtifactAuthorizationRequest",
+    "AcademicResultArtifactAuthorProjection",
+    "AcademicResultArtifactAuthorReference",
+    "AcademicResultArtifactPageProjection",
+    "AcademicResultArtifactProjection",
+    "AcademicResultArtifactRepresentation",
+    "AcademicResultArtifactSubjectProjection",
+    "AcademicResultParticipantReferenceProjection",
+    "ArtifactAuthorizationStatus",
+    "AuthorizedAcademicResultArtifact",
+    "ConcordAcademicResultArtifactAmbiguityError",
+    "ConcordAcademicResultArtifactAuthorizationError",
+    "ConcordAcademicResultArtifactError",
+    "ConcordAcademicResultArtifactIntegrityError",
+    "ConcordAcademicResultArtifactNotFoundError",
+    "ConcordAcademicResultArtifactUnavailableError",
+    "ConcordAcademicResultArtifactValidationError",
+    "read_authorized_academic_result_artifact",
+)

--- a/concord/academic_result_manifest.py
+++ b/concord/academic_result_manifest.py
@@ -691,9 +691,18 @@ class ScoringScaleProjection:
             "scoring_scale.supersedes_scoring_scale_id",
         )
 
-    def has_value(self, value: JsonScalar) -> bool:
+    def level_for_value(
+        self, value: JsonScalar
+    ) -> ScaleLevelProjection | None:
+        """Return the exact type-sensitive Scale level for one JSON scalar."""
         key = _scalar_key(value)
-        return any(_scalar_key(level.value) == key for level in self.levels)
+        return next(
+            (level for level in self.levels if _scalar_key(level.value) == key),
+            None,
+        )
+
+    def has_value(self, value: JsonScalar) -> bool:
+        return self.level_for_value(value) is not None
 
 
 @dataclass(frozen=True, slots=True)

--- a/concord/academic_result_reader.py
+++ b/concord/academic_result_reader.py
@@ -1,0 +1,293 @@
+"""Consumer-neutral reader for Concord Academic Result Manifest v1."""
+
+from __future__ import annotations
+
+import math
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from concord.academic_result_manifest import (
+    AcademicResultManifest,
+    ConcordAcademicResultManifestDecodeError,
+    ConcordAcademicResultManifestValidationError,
+    CriterionProjection,
+    CriterionSetProjection,
+    JsonScalar,
+    ModerationProjection,
+    ScaleLevelProjection,
+    ScoreEvidenceLinkProjection,
+    ScoreProjection,
+    ScoringScaleProjection,
+    TargetReferenceProjection,
+    academic_result_manifest_from_bytes,
+    academic_result_manifest_to_bytes,
+)
+from concord.academic_result_manifest import (
+    validate_academic_result_manifest as validate_manifest,
+)
+
+_CANONICAL_DECODE_MESSAGES = frozenset(
+    {
+        "manifest must end with exactly one LF.",
+        "manifest JSON is not canonical.",
+    }
+)
+
+
+class ConcordAcademicResultReaderError(Exception):
+    """Base failure for public Concord manifest reading and lookup."""
+
+
+class ConcordAcademicResultReaderValidationError(
+    ConcordAcademicResultReaderError, ValueError
+):
+    """Reader input violates the public consumer-neutral contract."""
+
+
+class ConcordAcademicResultReaderDecodeError(
+    ConcordAcademicResultReaderValidationError
+):
+    """Immutable bytes are not an exact valid Concord academic-result manifest."""
+
+
+class ConcordAcademicResultReaderNotFoundError(
+    ConcordAcademicResultReaderError, LookupError
+):
+    """An exact validated lookup is absent from the supplied manifest."""
+
+
+def _safe_identifier(value: object, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise ConcordAcademicResultReaderValidationError(
+            f"{field_name} must be a safe identifier."
+        )
+    try:
+        return validate_identifier(value, field_name)
+    except (IdentifierValidationError, TypeError, ValueError) as error:
+        raise ConcordAcademicResultReaderValidationError(
+            f"{field_name} must be a safe identifier."
+        ) from error
+
+
+def _json_scalar(value: object) -> JsonScalar:
+    if not isinstance(value, (str, int, float, bool)):
+        raise ConcordAcademicResultReaderValidationError(
+            "Scale value must be a non-null JSON scalar."
+        )
+    if isinstance(value, float) and not math.isfinite(value):
+        raise ConcordAcademicResultReaderValidationError(
+            "Scale value must be finite."
+        )
+    return value
+
+
+def read_academic_result_manifest(value: bytes) -> AcademicResultManifest:
+    """Decode, validate, and require exact canonical Concord manifest bytes."""
+    if type(value) is not bytes:
+        raise ConcordAcademicResultReaderValidationError(
+            "Academic-result manifest input must be immutable bytes."
+        )
+    try:
+        manifest = academic_result_manifest_from_bytes(value)
+    except ConcordAcademicResultManifestDecodeError as error:
+        if str(error) in _CANONICAL_DECODE_MESSAGES:
+            raise ConcordAcademicResultReaderValidationError(
+                "Academic-result manifest bytes are not canonical."
+            ) from error
+        raise ConcordAcademicResultReaderDecodeError(
+            "Academic-result manifest bytes are invalid."
+        ) from error
+    except ConcordAcademicResultManifestValidationError as error:
+        raise ConcordAcademicResultReaderDecodeError(
+            "Academic-result manifest bytes are invalid."
+        ) from error
+    try:
+        canonical = academic_result_manifest_to_bytes(manifest)
+    except ConcordAcademicResultManifestValidationError as error:
+        raise ConcordAcademicResultReaderValidationError(
+            "Academic-result manifest could not be validated canonically."
+        ) from error
+    if canonical != value:
+        raise ConcordAcademicResultReaderValidationError(
+            "Academic-result manifest bytes are not canonical."
+        )
+    return manifest
+
+
+def validate_academic_result_manifest(
+    manifest: AcademicResultManifest,
+) -> AcademicResultManifest:
+    """Validate one existing immutable manifest model without I/O."""
+    try:
+        return validate_manifest(manifest)
+    except ConcordAcademicResultManifestValidationError as error:
+        raise ConcordAcademicResultReaderValidationError(
+            "Academic-result manifest model is invalid."
+        ) from error
+
+
+def lookup_academic_result_criterion_set(
+    manifest: AcademicResultManifest,
+    criterion_set_id: str,
+) -> CriterionSetProjection:
+    """Return one exact represented Criterion Set."""
+    checked = validate_academic_result_manifest(manifest)
+    target = _safe_identifier(criterion_set_id, "criterion_set_id")
+    for criterion_set in checked.criterion_sets:
+        if criterion_set.criterion_set_id == target:
+            return criterion_set
+    raise ConcordAcademicResultReaderNotFoundError(
+        "Requested Criterion Set is not represented in this manifest."
+    )
+
+
+def lookup_academic_result_criterion(
+    manifest: AcademicResultManifest,
+    criterion_id: str,
+) -> CriterionProjection:
+    """Return one exact represented Criterion."""
+    checked = validate_academic_result_manifest(manifest)
+    target = _safe_identifier(criterion_id, "criterion_id")
+    for criterion in checked.criteria:
+        if criterion.criterion_id == target:
+            return criterion
+    raise ConcordAcademicResultReaderNotFoundError(
+        "Requested Criterion is not represented in this manifest."
+    )
+
+
+def lookup_academic_result_scoring_scale(
+    manifest: AcademicResultManifest,
+    scoring_scale_id: str,
+) -> ScoringScaleProjection:
+    """Return one exact represented Scoring Scale."""
+    checked = validate_academic_result_manifest(manifest)
+    target = _safe_identifier(scoring_scale_id, "scoring_scale_id")
+    for scale in checked.scoring_scales:
+        if scale.scoring_scale_id == target:
+            return scale
+    raise ConcordAcademicResultReaderNotFoundError(
+        "Requested Scoring Scale is not represented in this manifest."
+    )
+
+
+def lookup_academic_result_scale_level(
+    manifest: AcademicResultManifest,
+    scoring_scale_id: str,
+    value: JsonScalar,
+) -> ScaleLevelProjection:
+    """Return one exact type-sensitive Scale level without coercion."""
+    scale = lookup_academic_result_scoring_scale(manifest, scoring_scale_id)
+    target = _json_scalar(value)
+    level = scale.level_for_value(target)
+    if level is not None:
+        return level
+    raise ConcordAcademicResultReaderNotFoundError(
+        "Requested Scale level is not represented in this manifest."
+    )
+
+
+def lookup_academic_result_score(
+    manifest: AcademicResultManifest,
+    score_record_id: str,
+) -> ScoreProjection:
+    """Return one exact represented producer Score revision."""
+    checked = validate_academic_result_manifest(manifest)
+    target = _safe_identifier(score_record_id, "score_record_id")
+    for score in checked.scores:
+        if score.score_record_id == target:
+            return score
+    raise ConcordAcademicResultReaderNotFoundError(
+        "Requested Score is not represented in this manifest."
+    )
+
+
+def lookup_academic_result_score_evidence_link(
+    manifest: AcademicResultManifest,
+    score_evidence_link_id: str,
+) -> ScoreEvidenceLinkProjection:
+    """Return one exact represented Score Evidence Link."""
+    checked = validate_academic_result_manifest(manifest)
+    target = _safe_identifier(
+        score_evidence_link_id,
+        "score_evidence_link_id",
+    )
+    for link in checked.score_evidence_links:
+        if link.score_evidence_link_id == target:
+            return link
+    raise ConcordAcademicResultReaderNotFoundError(
+        "Requested Score Evidence Link is not represented in this manifest."
+    )
+
+
+def list_academic_result_score_evidence_links(
+    manifest: AcademicResultManifest,
+    score_record_id: str,
+) -> tuple[ScoreEvidenceLinkProjection, ...]:
+    """Return every represented Evidence Link for one exact Score in manifest order."""
+    checked = validate_academic_result_manifest(manifest)
+    score = lookup_academic_result_score(checked, score_record_id)
+    return tuple(
+        link
+        for link in checked.score_evidence_links
+        if link.score_record_id == score.score_record_id
+    )
+
+
+def lookup_academic_result_moderation(
+    manifest: AcademicResultManifest,
+    moderation_record_id: str,
+) -> ModerationProjection:
+    """Return one exact represented public Moderation revision."""
+    checked = validate_academic_result_manifest(manifest)
+    target = _safe_identifier(moderation_record_id, "moderation_record_id")
+    for moderation in checked.moderation_records:
+        if moderation.moderation_record_id == target:
+            return moderation
+    raise ConcordAcademicResultReaderNotFoundError(
+        "Requested Moderation record is not represented in this manifest."
+    )
+
+
+def list_academic_result_scores_for_target(
+    manifest: AcademicResultManifest,
+    target: TargetReferenceProjection,
+) -> tuple[ScoreProjection, ...]:
+    """Return every represented Score for one exact target without selection."""
+    checked = validate_academic_result_manifest(manifest)
+    if not isinstance(target, TargetReferenceProjection):
+        raise ConcordAcademicResultReaderValidationError(
+            "target must be a TargetReferenceProjection."
+        )
+    return tuple(
+        score for score in checked.scores if score.target_reference == target
+    )
+
+
+__all__ = (
+    "AcademicResultManifest",
+    "ConcordAcademicResultReaderDecodeError",
+    "ConcordAcademicResultReaderError",
+    "ConcordAcademicResultReaderNotFoundError",
+    "ConcordAcademicResultReaderValidationError",
+    "CriterionProjection",
+    "CriterionSetProjection",
+    "JsonScalar",
+    "ModerationProjection",
+    "ScaleLevelProjection",
+    "ScoreEvidenceLinkProjection",
+    "ScoreProjection",
+    "ScoringScaleProjection",
+    "TargetReferenceProjection",
+    "list_academic_result_score_evidence_links",
+    "list_academic_result_scores_for_target",
+    "lookup_academic_result_criterion",
+    "lookup_academic_result_criterion_set",
+    "lookup_academic_result_moderation",
+    "lookup_academic_result_scale_level",
+    "lookup_academic_result_score",
+    "lookup_academic_result_score_evidence_link",
+    "lookup_academic_result_scoring_scale",
+    "read_academic_result_manifest",
+    "validate_academic_result_manifest",
+)

--- a/concord/artifact_rendering.py
+++ b/concord/artifact_rendering.py
@@ -1,0 +1,672 @@
+"""Neutral read-only retained Artifact rendering primitives."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import stat as stat_module
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from concord.model_validation import ConcordRecordGraph
+from concord.models import ArtifactInstance, ArtifactPage, ScanReference
+
+_IMAGE_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".tif", ".tiff"})
+
+
+class ReturnedArtifactRenderError(ValueError):
+    """Base class for read-only returned-Artifact rendering failures."""
+
+
+class ReturnedArtifactRenderUnavailableError(ReturnedArtifactRenderError):
+    """Required returned Artifact evidence is unavailable."""
+
+
+class ReturnedArtifactRenderAmbiguityError(ReturnedArtifactRenderError):
+    """Returned Artifact evidence has more than one valid occurrence."""
+
+
+class ReturnedArtifactRenderIntegrityError(ReturnedArtifactRenderError):
+    """Retained-source integrity or bounded rendering failed."""
+
+
+@dataclass(frozen=True, slots=True)
+class VerifiedRetainedSource:
+    """Exact retained-source bytes after containment and SHA-256 verification."""
+
+    suffix: str
+    content: bytes
+
+    def __post_init__(self) -> None:
+        if self.suffix not in _IMAGE_EXTENSIONS | {".pdf"}:
+            raise ReturnedArtifactRenderIntegrityError(
+                "verified retained source has an unsupported extension."
+            )
+        if type(self.content) is not bytes or not self.content:
+            raise ReturnedArtifactRenderIntegrityError(
+                "verified retained source must contain immutable bytes."
+            )
+
+
+def _is_link_like(path: Path) -> bool:
+    if path.is_symlink():
+        return True
+    try:
+        attributes = int(getattr(path.lstat(), "st_file_attributes", 0))
+    except FileNotFoundError:
+        return False
+    except OSError as error:
+        raise ReturnedArtifactRenderIntegrityError(
+            "retained-source filesystem metadata could not be verified."
+        ) from error
+    reparse = int(getattr(stat_module, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+    return bool(reparse and attributes & reparse)
+
+
+def _assert_no_link_like_ancestors(path: Path, *, stop: Path) -> None:
+    current = path
+    while True:
+        if os.path.lexists(current) and _is_link_like(current):
+            raise ReturnedArtifactRenderIntegrityError(
+                "retained-source path traverses a link-like filesystem object."
+            )
+        if current == stop:
+            return
+        if stop not in current.parents:
+            raise ReturnedArtifactRenderIntegrityError(
+                "retained-source path escaped the workspace root."
+            )
+        current = current.parent
+
+
+def _retained_source_parts(scan: ScanReference) -> tuple[str, ...]:
+    relative = PurePosixPath(scan.retained_source_relative_path)
+    parts = tuple(relative.parts)
+    if (
+        relative.is_absolute()
+        or not parts
+        or any(part in {"", ".", ".."} for part in parts)
+    ):
+        raise ReturnedArtifactRenderIntegrityError(
+            "retained-source path is not a safe relative path."
+        )
+    return parts
+
+
+def _read_fd_bytes(descriptor: int) -> bytes:
+    chunks: list[bytes] = []
+    while True:
+        chunk = os.read(descriptor, 1024 * 1024)
+        if not chunk:
+            break
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _open_posix_root_directory(root: Path) -> int:
+    """Open every supplied root component without following links."""
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    directory = getattr(os, "O_DIRECTORY", 0)
+    cloexec = getattr(os, "O_CLOEXEC", 0)
+    if not nofollow or not directory:
+        raise ReturnedArtifactRenderIntegrityError(
+            "platform cannot enforce non-link retained-source traversal."
+        )
+
+    absolute = Path(os.path.abspath(os.fspath(root)))
+    if not absolute.is_absolute() or not absolute.anchor:
+        raise ReturnedArtifactRenderIntegrityError(
+            "workspace root is not an absolute filesystem path."
+        )
+
+    current: int | None = None
+    try:
+        current = os.open(
+            absolute.anchor,
+            os.O_RDONLY | directory | nofollow | cloexec,
+        )
+        for part in absolute.parts[1:]:
+            next_descriptor = os.open(
+                part,
+                os.O_RDONLY | directory | nofollow | cloexec,
+                dir_fd=current,
+            )
+            try:
+                if not stat_module.S_ISDIR(os.fstat(next_descriptor).st_mode):
+                    raise ReturnedArtifactRenderIntegrityError(
+                        "workspace root traverses a non-directory filesystem object."
+                    )
+            except BaseException:
+                os.close(next_descriptor)
+                raise
+            os.close(current)
+            current = next_descriptor
+        if not stat_module.S_ISDIR(os.fstat(current).st_mode):
+            raise ReturnedArtifactRenderIntegrityError(
+                "workspace root must be an ordinary non-link directory."
+            )
+        result = current
+        current = None
+        return result
+    except ReturnedArtifactRenderIntegrityError:
+        raise
+    except OSError as error:
+        raise ReturnedArtifactRenderIntegrityError(
+            "workspace root could not be safely opened."
+        ) from error
+    finally:
+        if current is not None:
+            try:
+                os.close(current)
+            except OSError:
+                pass
+
+
+def _read_posix_contained_file(root: Path, parts: tuple[str, ...]) -> bytes:
+    """Traverse from one no-follow root handle and read one exact file."""
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    directory = getattr(os, "O_DIRECTORY", 0)
+    cloexec = getattr(os, "O_CLOEXEC", 0)
+    if not nofollow or not directory:
+        raise ReturnedArtifactRenderIntegrityError(
+            "platform cannot enforce non-link retained-source traversal."
+        )
+
+    current: int | None = None
+    opened_file: int | None = None
+    try:
+        current = _open_posix_root_directory(root)
+        for part in parts[:-1]:
+            next_descriptor = os.open(
+                part,
+                os.O_RDONLY | directory | nofollow | cloexec,
+                dir_fd=current,
+            )
+            try:
+                if not stat_module.S_ISDIR(os.fstat(next_descriptor).st_mode):
+                    raise ReturnedArtifactRenderIntegrityError(
+                        "retained-source ancestor is not an ordinary directory."
+                    )
+            except BaseException:
+                os.close(next_descriptor)
+                raise
+            os.close(current)
+            current = next_descriptor
+
+        opened_file = os.open(
+            parts[-1],
+            os.O_RDONLY
+            | nofollow
+            | cloexec
+            | getattr(os, "O_BINARY", 0),
+            dir_fd=current,
+        )
+        if not stat_module.S_ISREG(os.fstat(opened_file).st_mode):
+            raise ReturnedArtifactRenderIntegrityError(
+                "retained source must be an ordinary non-link file."
+            )
+        return _read_fd_bytes(opened_file)
+    except ReturnedArtifactRenderIntegrityError:
+        raise
+    except OSError as error:
+        raise ReturnedArtifactRenderIntegrityError(
+            "retained source could not be safely opened."
+        ) from error
+    finally:
+        if opened_file is not None:
+            try:
+                os.close(opened_file)
+            except OSError:
+                pass
+        if current is not None:
+            try:
+                os.close(current)
+            except OSError:
+                pass
+
+
+def _windows_final_path(handle: int) -> Path:
+    import ctypes
+
+    kernel32 = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
+    get_final = kernel32.GetFinalPathNameByHandleW
+    get_final.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_wchar_p,
+        ctypes.c_ulong,
+        ctypes.c_ulong,
+    ]
+    get_final.restype = ctypes.c_ulong
+
+    size = get_final(ctypes.c_void_p(handle), None, 0, 0)
+    if size == 0:
+        raise ReturnedArtifactRenderIntegrityError(
+            "retained-source handle path could not be verified."
+        )
+    buffer = ctypes.create_unicode_buffer(size + 1)
+    written = get_final(
+        ctypes.c_void_p(handle),
+        buffer,
+        len(buffer),
+        0,
+    )
+    if written == 0 or written >= len(buffer):
+        raise ReturnedArtifactRenderIntegrityError(
+            "retained-source handle path could not be verified."
+        )
+    raw = buffer.value
+    if raw.startswith("\\\\?\\UNC\\"):
+        raw = "\\\\" + raw[8:]
+    elif raw.startswith("\\\\?\\"):
+        raw = raw[4:]
+    return Path(raw)
+
+
+def _windows_path_key(path: Path) -> str:
+    return os.path.normcase(os.path.normpath(str(path)))
+
+
+def _read_windows_contained_file(root: Path, parts: tuple[str, ...]) -> bytes:
+    """Read beneath one retained, verified non-reparse Windows root handle."""
+    import ctypes
+    import importlib
+
+    kernel32 = getattr(ctypes, "WinDLL")("kernel32", use_last_error=True)
+    create_file = kernel32.CreateFileW
+    create_file.argtypes = [
+        ctypes.c_wchar_p,
+        ctypes.c_ulong,
+        ctypes.c_ulong,
+        ctypes.c_void_p,
+        ctypes.c_ulong,
+        ctypes.c_ulong,
+        ctypes.c_void_p,
+    ]
+    create_file.restype = ctypes.c_void_p
+    get_info = kernel32.GetFileInformationByHandleEx
+    get_info.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_int,
+        ctypes.c_void_p,
+        ctypes.c_ulong,
+    ]
+    get_info.restype = ctypes.c_int
+    close_handle = kernel32.CloseHandle
+    close_handle.argtypes = [ctypes.c_void_p]
+    close_handle.restype = ctypes.c_int
+
+    class _FileAttributeTagInfo(ctypes.Structure):
+        _fields_ = [
+            ("file_attributes", ctypes.c_ulong),
+            ("reparse_tag", ctypes.c_ulong),
+        ]
+
+    generic_read = 0x80000000
+    file_read_attributes = 0x00000080
+    share_read = 0x00000001
+    open_existing = 3
+    open_reparse_point = 0x00200000
+    backup_semantics = 0x02000000
+    sequential_scan = 0x08000000
+    invalid_handle = ctypes.c_void_p(-1).value
+    reparse_attribute = 0x00000400
+    directory_attribute = 0x00000010
+    file_attribute_tag_info = 9
+
+    root_absolute = Path(os.path.abspath(os.fspath(root)))
+    raw_root_handle = create_file(
+        str(root_absolute),
+        file_read_attributes,
+        share_read,
+        None,
+        open_existing,
+        open_reparse_point | backup_semantics,
+        None,
+    )
+    root_handle = int(ctypes.cast(raw_root_handle, ctypes.c_void_p).value or 0)
+    if not root_handle or root_handle == invalid_handle:
+        raise ReturnedArtifactRenderIntegrityError(
+            "workspace root could not be safely opened."
+        )
+
+    source_handle = 0
+    descriptor: int | None = None
+    try:
+        root_info = _FileAttributeTagInfo()
+        if not get_info(
+            ctypes.c_void_p(root_handle),
+            file_attribute_tag_info,
+            ctypes.byref(root_info),
+            ctypes.sizeof(root_info),
+        ):
+            raise ReturnedArtifactRenderIntegrityError(
+                "workspace root handle attributes could not be verified."
+            )
+        if (
+            root_info.file_attributes & reparse_attribute
+            or not root_info.file_attributes & directory_attribute
+        ):
+            raise ReturnedArtifactRenderIntegrityError(
+                "workspace root must be an ordinary non-link directory."
+            )
+
+        root_final = _windows_final_path(root_handle)
+        if _windows_path_key(root_final) != _windows_path_key(root_absolute):
+            raise ReturnedArtifactRenderIntegrityError(
+                "workspace root handle did not identify the supplied root."
+            )
+
+        candidate = root_final.joinpath(*parts)
+        raw_source_handle = create_file(
+            str(candidate),
+            generic_read,
+            share_read,
+            None,
+            open_existing,
+            open_reparse_point | sequential_scan,
+            None,
+        )
+        source_handle = int(
+            ctypes.cast(raw_source_handle, ctypes.c_void_p).value or 0
+        )
+        if not source_handle or source_handle == invalid_handle:
+            raise ReturnedArtifactRenderIntegrityError(
+                "retained source could not be safely opened."
+            )
+
+        source_info = _FileAttributeTagInfo()
+        if not get_info(
+            ctypes.c_void_p(source_handle),
+            file_attribute_tag_info,
+            ctypes.byref(source_info),
+            ctypes.sizeof(source_info),
+        ):
+            raise ReturnedArtifactRenderIntegrityError(
+                "retained-source handle attributes could not be verified."
+            )
+        if (
+            source_info.file_attributes & reparse_attribute
+            or source_info.file_attributes & directory_attribute
+        ):
+            raise ReturnedArtifactRenderIntegrityError(
+                "retained source must be an ordinary non-link file."
+            )
+
+        final_path = _windows_final_path(source_handle)
+        if _windows_path_key(final_path) != _windows_path_key(candidate):
+            raise ReturnedArtifactRenderIntegrityError(
+                "retained-source handle did not resolve to its canonical path."
+            )
+        try:
+            final_path.relative_to(root_final)
+        except ValueError as error:
+            raise ReturnedArtifactRenderIntegrityError(
+                "retained-source handle escaped the workspace root."
+            ) from error
+
+        _assert_no_link_like_ancestors(candidate, stop=root_final)
+        msvcrt = importlib.import_module("msvcrt")
+        open_osfhandle = getattr(msvcrt, "open_osfhandle")
+        descriptor = open_osfhandle(
+            source_handle,
+            os.O_RDONLY | getattr(os, "O_BINARY", 0),
+        )
+        source_handle = 0
+        if not stat_module.S_ISREG(os.fstat(descriptor).st_mode):
+            raise ReturnedArtifactRenderIntegrityError(
+                "retained source must be an ordinary non-link file."
+            )
+        return _read_fd_bytes(descriptor)
+    except ReturnedArtifactRenderIntegrityError:
+        raise
+    except (OSError, ValueError) as error:
+        raise ReturnedArtifactRenderIntegrityError(
+            "retained source could not be safely read."
+        ) from error
+    finally:
+        if descriptor is not None:
+            try:
+                os.close(descriptor)
+            except OSError:
+                pass
+        elif source_handle:
+            close_handle(ctypes.c_void_p(source_handle))
+        close_handle(ctypes.c_void_p(root_handle))
+
+
+def validate_retained_source(
+    root: Path,
+    scan: ScanReference,
+) -> VerifiedRetainedSource:
+    """Read and verify one retained source from one no-follow root trust chain."""
+    root_path = Path(os.path.abspath(os.fspath(root)))
+    parts = _retained_source_parts(scan)
+    try:
+        if os.name == "nt":
+            data = _read_windows_contained_file(root_path, parts)
+        else:
+            data = _read_posix_contained_file(root_path, parts)
+    except ReturnedArtifactRenderIntegrityError:
+        raise
+    except Exception as error:
+        raise ReturnedArtifactRenderIntegrityError(
+            "retained source could not be safely read."
+        ) from error
+
+    if hashlib.sha256(data).hexdigest() != scan.retained_source_sha256:
+        raise ReturnedArtifactRenderIntegrityError(
+            "retained-source digest does not match the canonical Scan Reference."
+        )
+    return VerifiedRetainedSource(
+        suffix=PurePosixPath(scan.retained_source_relative_path).suffix.lower(),
+        content=data,
+    )
+
+
+def render_retained_source_page(
+    source: VerifiedRetainedSource,
+    source_page_number: int,
+) -> Any:
+    """Decode exactly one physical page from already-verified source bytes."""
+    suffix = source.suffix
+    try:
+        from PIL import Image
+    except ImportError as error:  # pragma: no cover - installation guard
+        raise ReturnedArtifactRenderIntegrityError(
+            "Pillow is required for returned-Artifact rendering."
+        ) from error
+
+    if suffix in _IMAGE_EXTENSIONS:
+        if source_page_number != 1:
+            raise ReturnedArtifactRenderIntegrityError(
+                "image retained sources contain only physical page 1."
+            )
+        try:
+            with Image.open(io.BytesIO(source.content)) as image:
+                return image.convert("RGB").copy()
+        except Exception as error:
+            raise ReturnedArtifactRenderIntegrityError(
+                "retained image could not be decoded."
+            ) from error
+
+    if suffix != ".pdf":
+        raise ReturnedArtifactRenderIntegrityError(
+            f"unsupported retained-source extension: {suffix}"
+        )
+    try:
+        import pypdfium2
+    except ImportError as error:  # pragma: no cover - installation guard
+        raise ReturnedArtifactRenderIntegrityError(
+            "pypdfium2 is required for PDF returned-Artifact rendering."
+        ) from error
+    try:
+        document = pypdfium2.PdfDocument(source.content)
+    except Exception as error:
+        raise ReturnedArtifactRenderIntegrityError(
+            "retained PDF could not be opened."
+        ) from error
+    try:
+        page_count = len(document)
+        if source_page_number < 1 or source_page_number > page_count:
+            raise ReturnedArtifactRenderIntegrityError(
+                "Scan Reference physical page is outside the retained PDF."
+            )
+        page = document[source_page_number - 1]
+        return page.render(scale=2).to_pil().convert("RGB").copy()
+    except ReturnedArtifactRenderIntegrityError:
+        raise
+    except Exception as error:
+        raise ReturnedArtifactRenderIntegrityError(
+            "retained PDF physical page could not be rendered."
+        ) from error
+    finally:
+        document.close()
+
+
+def encode_returned_artifact_pdf(images: tuple[Any, ...], created_at: str) -> bytes:
+    """Encode ordered RGB images as deterministic returned-Artifact PDF bytes."""
+    if not images:
+        raise ReturnedArtifactRenderIntegrityError(
+            "returned-Artifact rendering requires at least one page."
+        )
+    try:
+        canonical_time = datetime.fromisoformat(
+            created_at.replace("Z", "+00:00")
+        ).astimezone(timezone.utc).timetuple()
+    except ValueError as error:
+        raise ReturnedArtifactRenderIntegrityError(
+            "Artifact creation provenance has an invalid timestamp."
+        ) from error
+    output = io.BytesIO()
+    try:
+        images[0].save(
+            output,
+            "PDF",
+            save_all=True,
+            append_images=list(images[1:]),
+            resolution=150.0,
+            creationDate=canonical_time,
+            modDate=canonical_time,
+        )
+    except Exception as error:
+        raise ReturnedArtifactRenderIntegrityError(
+            "returned Artifact PDF could not be encoded."
+        ) from error
+    data = output.getvalue()
+    if not data.startswith(b"%PDF"):
+        raise ReturnedArtifactRenderIntegrityError(
+            "returned Artifact encoder did not produce PDF bytes."
+        )
+    return data
+
+
+def _artifact_pages(
+    artifact: ArtifactInstance,
+    graph: ConcordRecordGraph,
+) -> dict[str, ArtifactPage]:
+    pages = {item.artifact_page_id: item for item in graph.artifact_pages}
+    for page_id in artifact.page_ids:
+        page = pages.get(page_id)
+        if page is None or page.artifact_instance_id != artifact.artifact_instance_id:
+            raise ReturnedArtifactRenderIntegrityError(
+                "Artifact declared page structure is inconsistent."
+            )
+    return pages
+
+
+def _single_scan(
+    artifact: ArtifactInstance,
+    page: ArtifactPage,
+    graph: ConcordRecordGraph,
+) -> ScanReference:
+    candidates = tuple(
+        sorted(
+            (
+                item
+                for item in graph.scan_references
+                if item.artifact_page_id == page.artifact_page_id
+            ),
+            key=lambda item: item.scan_reference_id,
+        )
+    )
+    if not candidates:
+        raise ReturnedArtifactRenderUnavailableError(
+            "required returned Artifact page is unavailable."
+        )
+    if len(candidates) > 1:
+        raise ReturnedArtifactRenderAmbiguityError(
+            "returned Artifact page has multiple canonical scan occurrences."
+        )
+    scan = candidates[0]
+    if (
+        scan.activity_id != artifact.activity_id
+        or scan.artifact_page_id != page.artifact_page_id
+        or scan.route_id != page.route_id
+    ):
+        raise ReturnedArtifactRenderIntegrityError(
+            "Scan Reference contradicts the canonical Artifact Page."
+        )
+    return scan
+
+
+def _selected_scans(
+    artifact: ArtifactInstance,
+    graph: ConcordRecordGraph,
+    evidence_page: ArtifactPage | None,
+) -> tuple[ScanReference, ...]:
+    pages = _artifact_pages(artifact, graph)
+    if evidence_page is not None:
+        if (
+            evidence_page.artifact_instance_id != artifact.artifact_instance_id
+            or evidence_page.artifact_page_id not in artifact.page_ids
+        ):
+            raise ReturnedArtifactRenderIntegrityError(
+                "Artifact Page is inconsistent with its Artifact Instance."
+            )
+        canonical_page = pages.get(evidence_page.artifact_page_id)
+        if canonical_page != evidence_page:
+            raise ReturnedArtifactRenderIntegrityError(
+                "Artifact Page is not the exact historical page selected by the graph."
+            )
+        return (_single_scan(artifact, evidence_page, graph),)
+
+    required = tuple(
+        pages[page_id]
+        for page_id in artifact.page_ids
+        if pages[page_id].return_expected
+    )
+    if not required:
+        raise ReturnedArtifactRenderUnavailableError(
+            "Artifact has no return-expected pages to render."
+        )
+    return tuple(_single_scan(artifact, page, graph) for page in required)
+
+
+def render_returned_artifact_pdf(
+    workspace_root: str | Path,
+    graph: ConcordRecordGraph,
+    artifact: ArtifactInstance,
+    *,
+    evidence_page: ArtifactPage | None = None,
+) -> bytes:
+    """Render exact historical returned Artifact evidence without durable writes."""
+    root = Path(workspace_root)
+    scans = _selected_scans(artifact, graph, evidence_page)
+    images: list[Any] = []
+    try:
+        for scan in scans:
+            source = validate_retained_source(root, scan)
+            images.append(
+                render_retained_source_page(source, scan.source_page_number)
+            )
+        return encode_returned_artifact_pdf(
+            tuple(images), artifact.created_provenance.timestamp
+        )
+    finally:
+        for image in images:
+            close = getattr(image, "close", None)
+            if callable(close):
+                close()

--- a/concord/storage.py
+++ b/concord/storage.py
@@ -153,18 +153,26 @@ def load_work_marker(
     return value
 
 
-def load_record_revision(
-    workspace_root: str | Path,
+def _record_revision_from_bytes(
+    data: bytes,
+    *,
     work: ModuleWorkRef,
     record_kind: str,
     record_id: str,
     record_revision: int,
 ) -> tuple[Record, ConcordRecordRevision]:
+    """Parse and verify one already-read immutable record revision."""
     descriptor = descriptor_for_kind(record_kind)
-    path = record_revision_path(
-        workspace_root, work, record_kind, record_id, record_revision
-    )
-    envelope, _ = _parse(path, revision_from_dict, missing=True)
+    try:
+        envelope = revision_from_dict(strict_json_loads(data))
+    except (
+        ConcordStorageReadError,
+        ConcordStorageValidationError,
+        ValueError,
+    ) as error:
+        raise ConcordStorageReadError(
+            "invalid canonical record revision bytes."
+        ) from error
     if (
         envelope.work != work
         or envelope.record_kind != record_kind
@@ -174,7 +182,12 @@ def load_record_revision(
         raise ConcordStorageIntegrityError(
             "record envelope identity disagrees with its canonical path."
         )
-    record = record_from_dict(record_kind, envelope.body)
+    try:
+        record = record_from_dict(record_kind, envelope.body)
+    except ValueError as error:
+        raise ConcordStorageReadError(
+            "invalid canonical record body."
+        ) from error
     if (
         getattr(record, descriptor.identity_field) != record_id
         or record_to_dict(record) != envelope.body
@@ -184,6 +197,25 @@ def load_record_revision(
         )
     return record, envelope
 
+
+def load_record_revision(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+    record_kind: str,
+    record_id: str,
+    record_revision: int,
+) -> tuple[Record, ConcordRecordRevision]:
+    path = record_revision_path(
+        workspace_root, work, record_kind, record_id, record_revision
+    )
+    data = read_canonical_bytes(path, missing=True)
+    return _record_revision_from_bytes(
+        data,
+        work=work,
+        record_kind=record_kind,
+        record_id=record_id,
+        record_revision=record_revision,
+    )
 
 def _visible(path: Path, description: str) -> tuple[Path, ...]:
     try:
@@ -290,21 +322,32 @@ def _load_snapshot_chain(
     return target, target_bytes
 
 
-def load_work_snapshot(
-    workspace_root: str | Path, work: ModuleWorkRef, snapshot_revision: int
-) -> tuple[ConcordWorkSnapshot, str]:
-    value, data = _load_snapshot_chain(workspace_root, work, snapshot_revision)
+def _validated_snapshot_graph(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+    snapshot: ConcordWorkSnapshot,
+) -> ConcordRecordGraph:
+    """Materialize a graph from the exact bytes bound by one snapshot."""
     selected_records: list[Record] = []
-    for ref in value.records:
+    for ref in snapshot.records:
         record_path = record_revision_path(
-            workspace_root, work, ref.record_kind, ref.record_id, ref.record_revision
+            workspace_root,
+            work,
+            ref.record_kind,
+            ref.record_id,
+            ref.record_revision,
         )
-        if _sha(read_canonical_bytes(record_path, missing=True)) != ref.sha256:
+        data = read_canonical_bytes(record_path, missing=True)
+        if _sha(data) != ref.sha256:
             raise ConcordStorageIntegrityError(
                 f"record digest mismatch for {ref.record_kind}:{ref.record_id}."
             )
-        record, _ = load_record_revision(
-            workspace_root, work, ref.record_kind, ref.record_id, ref.record_revision
+        record, _ = _record_revision_from_bytes(
+            data,
+            work=work,
+            record_kind=ref.record_kind,
+            record_id=ref.record_id,
+            record_revision=ref.record_revision,
         )
         selected_records.append(record)
     try:
@@ -324,8 +367,35 @@ def load_work_snapshot(
         raise ConcordStorageIntegrityError(
             f"snapshot graph is invalid: {error}"
         ) from error
+    return graph
+
+
+def load_work_snapshot(
+    workspace_root: str | Path, work: ModuleWorkRef, snapshot_revision: int
+) -> tuple[ConcordWorkSnapshot, str]:
+    value, data = _load_snapshot_chain(workspace_root, work, snapshot_revision)
+    _validated_snapshot_graph(workspace_root, work, value)
     return value, _sha(data)
 
+
+def load_record_graph_at_snapshot(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+    snapshot_revision: int,
+) -> ConcordLoadedRecordGraph:
+    """Load one exact immutable historical graph without consulting current.json."""
+    load_work_marker(workspace_root, work)
+    snapshot, snapshot_bytes = _load_snapshot_chain(
+        workspace_root,
+        work,
+        snapshot_revision,
+    )
+    graph = _validated_snapshot_graph(workspace_root, work, snapshot)
+    return ConcordLoadedRecordGraph(
+        graph,
+        snapshot.snapshot_revision,
+        _sha(snapshot_bytes),
+    )
 
 def list_work_snapshots(
     workspace_root: str | Path, work: ModuleWorkRef
@@ -367,24 +437,17 @@ def load_current_record_graph(
 ) -> ConcordLoadedRecordGraph:
     load_work_marker(workspace_root, work)
     current = load_current_snapshot(workspace_root, work)
-    snapshot, _ = load_work_snapshot(workspace_root, work, current.snapshot_revision)
-    collections: dict[str, list[Record]] = {
-        d.graph_collection: [] for d in RECORD_DESCRIPTORS
-    }
-    for ref in snapshot.records:
-        record, _ = load_record_revision(
-            workspace_root, work, ref.record_kind, ref.record_id, ref.record_revision
-        )
-        collections[descriptor_for_kind(ref.record_kind).graph_collection].append(
-            record
-        )
-    graph = ConcordRecordGraph(
-        **cast(Any, {key: tuple(values) for key, values in collections.items()})
+    snapshot, snapshot_bytes = _load_snapshot_chain(
+        workspace_root,
+        work,
+        current.snapshot_revision,
     )
-    if len(graph.activities) != 1 or graph.activities[0].work_reference != work:
+    snapshot_sha256 = _sha(snapshot_bytes)
+    if snapshot_sha256 != current.snapshot_sha256:
         raise ConcordStorageIntegrityError(
-            "snapshot must contain exactly one matching Activity."
+            "current pointer snapshot digest mismatch."
         )
+    graph = _validated_snapshot_graph(workspace_root, work, snapshot)
     try:
         validate_record_graph(graph)
         requires_standards = (
@@ -409,20 +472,32 @@ def load_current_record_graph(
             f"current graph is invalid: {error}"
         ) from error
     return ConcordLoadedRecordGraph(
-        graph, current.snapshot_revision, current.snapshot_sha256
+        graph,
+        current.snapshot_revision,
+        snapshot_sha256,
     )
 
-
 def load_current_record(
-    workspace_root: str | Path, work: ModuleWorkRef, record_kind: str, record_id: str
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+    record_kind: str,
+    record_id: str,
 ) -> tuple[Record, ConcordRecordRevision]:
     current = load_current_snapshot(workspace_root, work)
-    snapshot, _ = load_work_snapshot(workspace_root, work, current.snapshot_revision)
+    snapshot, snapshot_bytes = _load_snapshot_chain(
+        workspace_root,
+        work,
+        current.snapshot_revision,
+    )
+    if _sha(snapshot_bytes) != current.snapshot_sha256:
+        raise ConcordStorageIntegrityError(
+            "current pointer snapshot digest mismatch."
+        )
     ref = next(
         (
-            r
-            for r in snapshot.records
-            if (r.record_kind, r.record_id) == (record_kind, record_id)
+            item
+            for item in snapshot.records
+            if (item.record_kind, item.record_id) == (record_kind, record_id)
         ),
         None,
     )
@@ -430,10 +505,25 @@ def load_current_record(
         raise ConcordStorageNotFoundError(
             f"record is not selected by current snapshot: {record_kind}:{record_id}"
         )
-    return load_record_revision(
-        workspace_root, work, record_kind, record_id, ref.record_revision
+    path = record_revision_path(
+        workspace_root,
+        work,
+        ref.record_kind,
+        ref.record_id,
+        ref.record_revision,
     )
-
+    data = read_canonical_bytes(path, missing=True)
+    if _sha(data) != ref.sha256:
+        raise ConcordStorageIntegrityError(
+            f"record digest mismatch for {ref.record_kind}:{ref.record_id}."
+        )
+    return _record_revision_from_bytes(
+        data,
+        work=work,
+        record_kind=ref.record_kind,
+        record_id=ref.record_id,
+        record_revision=ref.record_revision,
+    )
 
 def list_activity_work_refs(
     workspace_root: str | Path, class_id: str

--- a/concord/workflows/artifact_assembly.py
+++ b/concord/workflows/artifact_assembly.py
@@ -3,20 +3,25 @@
 from __future__ import annotations
 
 import hashlib
-import io
 import json
 import os
 import shutil
 import stat as stat_module
 import tempfile
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
 from pds_core.routes import safe_module_work_descendant
 from pds_core.routing_models import ModuleWorkRef
 
+from concord.artifact_rendering import (
+    ReturnedArtifactRenderIntegrityError,
+    VerifiedRetainedSource,
+    encode_returned_artifact_pdf,
+    render_retained_source_page,
+    validate_retained_source,
+)
 from concord.model_validation import ConcordRecordGraph
 from concord.models import ArtifactInstance, ArtifactPage, ScanReference
 from concord.storage import load_current_record_graph
@@ -175,123 +180,29 @@ def _assert_no_link_like_ancestors(path: Path, *, stop: Path) -> None:
         current = current.parent
 
 
-def _validate_retained_source(root: Path, scan: ScanReference) -> Path:
-    root_resolved = root.resolve(strict=True)
-    candidate = root / scan.retained_source_relative_path
-    _assert_no_link_like_ancestors(candidate, stop=root)
+def _validate_retained_source(
+    root: Path,
+    scan: ScanReference,
+) -> VerifiedRetainedSource:
     try:
-        resolved = candidate.resolve(strict=True)
-        resolved.relative_to(root_resolved)
-    except (OSError, RuntimeError, ValueError) as error:
-        raise ArtifactAssemblyIntegrityError(
-            "retained source is missing or outside the workspace."
-        ) from error
-    if _is_link_like(candidate) or not candidate.is_file():
-        raise ArtifactAssemblyIntegrityError(
-            "retained source must be an ordinary non-link file."
-        )
-    try:
-        digest = hashlib.sha256(candidate.read_bytes()).hexdigest()
-    except OSError as error:
-        raise ArtifactAssemblyIntegrityError(
-            "retained source could not be read."
-        ) from error
-    if digest != scan.retained_source_sha256:
-        raise ArtifactAssemblyIntegrityError(
-            "retained-source digest does not match the canonical Scan Reference."
-        )
-    return candidate
+        return validate_retained_source(root, scan)
+    except ReturnedArtifactRenderIntegrityError as error:
+        raise ArtifactAssemblyIntegrityError(str(error)) from error
 
-
-def _page_image(path: Path, source_page_number: int) -> Any:
-    suffix = path.suffix.lower()
+def _page_image(
+    source: VerifiedRetainedSource,
+    source_page_number: int,
+) -> Any:
     try:
-        from PIL import Image
-    except ImportError as error:  # pragma: no cover - dependency installation guard
-        raise ArtifactAssemblyIntegrityError(
-            "Pillow is required for returned-Artifact assembly."
-        ) from error
-
-    if suffix in _IMAGE_EXTENSIONS:
-        if source_page_number != 1:
-            raise ArtifactAssemblyIntegrityError(
-                "image retained sources contain only physical page 1."
-            )
-        try:
-            with Image.open(path) as image:
-                return image.convert("RGB").copy()
-        except (OSError, ValueError) as error:
-            raise ArtifactAssemblyIntegrityError(
-                "retained image could not be decoded."
-            ) from error
-
-    if suffix != ".pdf":
-        raise ArtifactAssemblyIntegrityError(
-            f"unsupported retained-source extension: {suffix}"
-        )
-    try:
-        import pypdfium2
-    except ImportError as error:  # pragma: no cover - dependency installation guard
-        raise ArtifactAssemblyIntegrityError(
-            "pypdfium2 is required for PDF returned-Artifact assembly."
-        ) from error
-    try:
-        document = pypdfium2.PdfDocument(str(path))
-    except Exception as error:
-        raise ArtifactAssemblyIntegrityError(
-            "retained PDF could not be opened."
-        ) from error
-    try:
-        page_count = len(document)
-        if source_page_number < 1 or source_page_number > page_count:
-            raise ArtifactAssemblyIntegrityError(
-                "Scan Reference physical page is outside the retained PDF."
-            )
-        page = document[source_page_number - 1]
-        return page.render(scale=2).to_pil().convert("RGB").copy()
-    except ArtifactAssemblyIntegrityError:
-        raise
-    except Exception as error:
-        raise ArtifactAssemblyIntegrityError(
-            "retained PDF physical page could not be rendered."
-        ) from error
-    finally:
-        document.close()
-
+        return render_retained_source_page(source, source_page_number)
+    except ReturnedArtifactRenderIntegrityError as error:
+        raise ArtifactAssemblyIntegrityError(str(error)) from error
 
 def _pdf_bytes(images: tuple[Any, ...], created_at: str) -> bytes:
-    if not images:
-        raise ArtifactAssemblyIntegrityError("assembly requires at least one page.")
     try:
-        canonical_time = datetime.fromisoformat(
-            created_at.replace("Z", "+00:00")
-        ).astimezone(timezone.utc).timetuple()
-    except ValueError as error:
-        raise ArtifactAssemblyIntegrityError(
-            "Artifact creation provenance has an invalid timestamp."
-        ) from error
-    output = io.BytesIO()
-    try:
-        images[0].save(
-            output,
-            "PDF",
-            save_all=True,
-            append_images=list(images[1:]),
-            resolution=150.0,
-            creationDate=canonical_time,
-            modDate=canonical_time,
-        )
-    except Exception as error:
-        raise ArtifactAssemblyIntegrityError(
-            "returned Artifact PDF could not be encoded."
-        ) from error
-    data = output.getvalue()
-    if not data.startswith(b"%PDF"):
-        raise ArtifactAssemblyIntegrityError(
-            "returned Artifact encoder did not produce PDF bytes."
-        )
-    return data
-
+        return encode_returned_artifact_pdf(images, created_at)
+    except ReturnedArtifactRenderIntegrityError as error:
+        raise ArtifactAssemblyIntegrityError(str(error)) from error
 
 def _selection_map(
     selections: tuple[AssemblyPageSelection, ...],

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,16 +50,18 @@ The repository now contains:
   Link, non-score disposition, and Score revision workflows; and
 * explicit Core Academic Work Registration, immutable Concord Academic Result
   Manifest generation, Publication Record supersession/withdrawal, publication
-  producer discovery, and Core academic-catalog reconciliation.
+  producer discovery, and Core academic-catalog reconciliation; and
+* a consumer-neutral canonical Academic Result Manifest reader plus a separately
+  authorization-gated, historical-snapshot-bound bounded Artifact reader.
 
 Implementation follows the v0.2.0 vertical-slice sequence tracked by
 [`Paper-Data-Suite/pds-concord#22`](https://github.com/Paper-Data-Suite/pds-concord/issues/22).
 The package baseline, foundational native models, persistence substrate, and
 teacher-local collaboration-context, PDS2 Artifact Page routing, returned Artifact
 assembly, Author/Subject, Review/Moderation, Criterion/Scale/Score, and academic
-publication workflows are complete. Concord declares separate routing and
-publication-producer entry points. Issue #32 adds the consumer-neutral reader;
-issue #33 owns the full installed Activity-to-publication acceptance.
+publication workflows and the issue #32 consumer-neutral readers are complete.
+Concord declares separate routing and publication-producer entry points. Issue #33
+owns the full installed Activity-to-publication-to-consumer acceptance path.
 
 ### 14. PDS2 Artifact Page integration
 
@@ -105,6 +107,15 @@ producer revisioning, privacy minimization, publication-producer compatibility,
 first publication, replay, supersession, withdrawal, catalog reconciliation,
 partial-success recovery, direct CLI/menu behavior, and the #32/#33/Meridian
 boundaries.
+
+### 19. Academic result consumer reader
+
+[`implementation/academic-result-reader.md`](implementation/academic-result-reader.md)
+
+Documents canonical immutable manifest reading, exact producer-native lookup,
+type-sensitive Scale values, authorization-before-I/O, historical snapshot
+binding, bounded Artifact PDF representations, retained-source integrity,
+privacy minimization, consumer ownership boundaries, and the #33 handoff.
 
 ### 10. Native model implementation
 
@@ -371,9 +382,8 @@ Where a conceptual contract depends on Core identity, routing, or provenance, it
 
 Implementation documents describe the native model layer, canonical storage,
 collaboration-context workflows, routing, Artifact management, Review,
-Moderation, Criterion/Scale/Score recording, and CLI/menu contracts that are now
-implemented. Later implementation documents will cover publication and consumer
-integration as those issues land.
+Moderation, Criterion/Scale/Score recording, publication, consumer-neutral
+manifest/Artifact reading, and CLI/menu contracts that are now implemented.
 
 Implementation convenience must not silently change the domain semantics established here.
 

--- a/docs/implementation/academic-result-reader.md
+++ b/docs/implementation/academic-result-reader.md
@@ -1,0 +1,325 @@
+# Academic result consumer reader
+
+Issue #32 adds Concord's stable consumer-neutral interpretation surface for
+`concord_academic_result_manifest_v1` and a separate authorization-gated reader
+for Concord-owned Artifact evidence.
+
+The split is deliberate:
+
+```text
+verified immutable manifest bytes
+-> concord.academic_result_reader
+-> validated Concord public models and exact lookups
+-> downstream policy
+```
+
+and, only after a separate Artifact authorization decision:
+
+```text
+validated Concord manifest
+-> represented Concord Artifact evidence
+-> deployment-owned authorization gate
+-> exact historical Concord snapshot
+-> retained-source integrity verification
+-> bounded producer-approved PDF representation
+```
+
+The reader does not discover publications, choose a publication revision,
+calculate Grades or proficiency, choose the "best" Score, or create portfolio
+policy. Core, Meridian, Vitrine, and the deployment retain those responsibilities.
+
+## Public modules
+
+The stable import surfaces are:
+
+```python
+import concord.academic_result_reader
+import concord.academic_result_artifacts
+```
+
+No top-level `concord` re-export and no new entry point are introduced.
+
+`concord.academic_result_reader` is pure. It performs no workspace, filesystem,
+Core registry, catalog, publication, or authorization I/O.
+
+`concord.academic_result_artifacts` is the explicit Artifact I/O boundary. It
+may inspect Concord native state and Core-retained scan bytes only after an
+external authorization gate returns `allowed`.
+
+The internal `concord.artifact_rendering` module contains the shared retained-
+source verification and deterministic PDF rendering primitives used by both the
+consumer reader and the teacher returned-Artifact assembly workflow. It is not a
+consumer-policy surface.
+
+## Canonical manifest reader
+
+The main reader is:
+
+```python
+read_academic_result_manifest(value: bytes) -> AcademicResultManifest
+```
+
+It accepts exact immutable `bytes`, delegates decoding and whole-manifest
+validation to Concord's authoritative manifest contract, serializes the restored
+model through the same canonical serializer, and requires exact byte equality.
+
+Semantically equivalent but noncanonical JSON is rejected. This includes
+alternate whitespace, key order, newline handling, trailing whitespace, and
+alternate timestamp text.
+
+Core remains responsible for verifying the Publication Record's manifest path
+and SHA-256 binding before those bytes reach this API.
+
+Public model validation is exposed separately:
+
+```python
+validate_academic_result_manifest(manifest) -> AcademicResultManifest
+```
+
+It delegates to the authoritative whole-manifest validator and returns the same
+immutable model on success.
+
+## Exact lookup surface
+
+The reader exposes exact producer-native lookups for:
+
+```text
+Criterion Set
+Criterion
+Scoring Scale
+Scale level
+Score
+Score Evidence Link
+Moderation
+Score Evidence Links for one Score
+Scores for one exact target
+```
+
+The helpers never choose an official, latest, best, or grading-selected Score.
+Tuple-valued relationship helpers preserve manifest order.
+
+Scale-value lookup is type-sensitive. These JSON scalars remain distinct:
+
+```text
+1
+1.0
+"1"
+true
+```
+
+A consumer must not replace Concord's Scale lookup with ordinary Python scalar
+equality.
+
+`ScoreProjection.current_state` describes producer supersession state only. It
+is not Meridian attempt-selection or grading policy.
+
+Group targets remain Group targets. A Group Score is never expanded into
+individual student Scores. Non-score dispositions retain `value = None` and are
+never converted to numeric zero.
+
+## Reader errors
+
+The manifest reader defines:
+
+```text
+ConcordAcademicResultReaderError
+ConcordAcademicResultReaderValidationError
+ConcordAcademicResultReaderDecodeError
+ConcordAcademicResultReaderNotFoundError
+```
+
+Validation failures cover invalid public input and noncanonical bytes. Decode
+failures cover malformed or semantically invalid manifest bytes. Exact valid
+identifiers that are absent raise the public not-found error.
+
+Routine reader errors do not expose raw manifest content or private producer
+notes.
+
+## Artifact authorization contract
+
+Artifact access is separate from manifest/result authorization.
+
+The deployment provides an implementation of:
+
+```python
+AcademicResultArtifactAuthorizationGate
+```
+
+Concord supplies a request containing only manifest-derived public identity:
+
+```text
+work
+record-set identity and revision
+source snapshot revision
+Score identity
+Score Evidence Link identity
+represented Evidence Reference
+purpose
+```
+
+The gate returns one of:
+
+```text
+allowed
+denied
+unresolved
+```
+
+Only `allowed` permits native workspace I/O. `denied`, `unresolved`, and gate
+exceptions fail closed. Concord does not define a role matrix or decide who is
+entitled to an Artifact.
+
+External ScoreForm, Quillan, or other producer evidence cannot enter the
+Concord Artifact resolver. The represented evidence must be Concord-owned and
+must be exactly one of:
+
+```text
+artifact_instance
+artifact_page
+```
+
+There is no public path, filename, Scan Reference, or arbitrary native-record
+selector.
+
+## Historical source binding
+
+Artifact resolution binds to:
+
+```text
+manifest.projection.source_snapshot_revision
+```
+
+It never substitutes the current Concord snapshot.
+
+The historical storage reader validates the immutable snapshot predecessor
+chain, selected record digests, and native graph structure without consulting
+`current.json`. The native Score Evidence Link is then reprojected and must
+agree exactly with the represented public manifest link before Artifact bytes
+are considered.
+
+This preserves old published manifests even after current Concord state has
+advanced.
+
+## Bounded Artifact representations
+
+The current producer-approved representation is:
+
+```text
+returned_artifact_pdf
+```
+
+For `artifact_page`, the reader returns exactly the represented physical page.
+A multi-page retained scan therefore yields one bounded PDF page, not the whole
+source scan.
+
+For `artifact_instance`, the reader returns the Artifact's canonical ordered
+`return_expected` pages only.
+
+If a required Artifact Page has no returned occurrence, the representation is
+unavailable. If it has more than one returned Scan Reference, the read is
+ambiguous and fails closed. The public API deliberately offers no Scan
+Reference selector and never chooses by timestamp, filename, ID, filesystem
+order, or recency.
+
+## Retained-source integrity
+
+The neutral rendering layer verifies:
+
+```text
+workspace containment
+link/symlink/reparse safety
+ordinary-file status
+canonical retained-source SHA-256
+supported image/PDF media
+physical page bounds
+safe decoding
+```
+
+Retained source bytes are read once, verified, and those exact immutable bytes
+are rendered. This prevents a file replacement between digest verification and
+decoding from changing the returned representation.
+
+Returned bytes are deterministic PDF bytes. The public result reports the
+representation SHA-256 and byte size. That digest is distinct from the Core
+Publication manifest digest and from the retained source digest.
+
+The consumer read creates no durable assembly, derivative manifest, native
+record, Core record, catalog row, or current-snapshot change.
+
+## Public Artifact metadata
+
+The result contains bounded producer-approved metadata for the exact historical
+Artifact, including:
+
+```text
+Artifact identity/category/session/group
+ordered Artifact Page identity and logical page number
+producer privacy classification
+current-as-of-snapshot Artifact Author associations
+current-as-of-snapshot Artifact Subject associations
+```
+
+Author and Subject remain independent relationships. The reader does not infer:
+
+```text
+Author == Subject
+Subject == Score target
+Group member == Author
+Group member == Subject
+recorder_for_group == individual owner
+```
+
+Superseded Author/Subject associations remain historical native state and are
+not exposed as current attribution. Unrelated Artifact attribution records are
+excluded.
+
+The public projection does not expose native provenance notes, privacy reasons,
+Role Assignment internals, route fallback text, Scan Reference IDs, source scan
+IDs, retained-source paths, retained-source digests, source filenames, QR
+payloads, Score rationale, Moderation rationale, or raw retained scan bytes.
+
+## Artifact errors
+
+The Artifact reader defines public failures for validation, authorization,
+not-found historical state, unavailable evidence, ambiguous evidence, and
+integrity failures.
+
+Public messages are intentionally privacy-safe and do not include canonical
+workspace paths, retained filenames, Scan Reference IDs, or deployment policy
+text. Internal filesystem/rendering/authorization exceptions are not retained
+as inspectable exception chains at the public API boundary.
+
+## Consumer boundaries
+
+Concord remains the producer-native interpretation authority. It does not import
+Meridian, Vitrine, ScoreForm, Quillan, or Portia to implement these readers.
+
+Meridian may use the manifest reader to build its own producer adapter and owns
+Grade eligibility, reassessment selection, proficiency/mastery policy, Grade
+calculation, Academic Period policy, weighting, and reporting.
+
+Vitrine may use the reader and separately authorized Artifact representation as
+source material and owns portfolio candidate, selection, placement, snapshot,
+copying, and disclosure policy.
+
+Core remains authoritative for publication discovery, canonical Publication
+Records and Withdrawals, producer compatibility, manifest path/digest
+verification, and the academic catalog.
+
+## Installed acceptance boundary
+
+Issue #32's isolated-wheel smoke verifies that:
+
+```text
+concord.academic_result_reader imports from the built wheel
+concord.academic_result_artifacts imports from the built wheel
+canonical manifest bytes round-trip through the reader
+type-sensitive Scale lookup is preserved
+exact Score/target lookup is preserved
+reader imports and pure reads do not create a workspace
+no sibling PDS package is required
+```
+
+The full clean-wheel chain from Activity creation through publication, Core
+verification, Concord consumer read, Artifact authorization/read,
+supersession/withdrawal, and audit remains assigned to Issue #33.

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -27,6 +27,7 @@ PROPOSED_CHAIN = (
     "The examples also validate the proposed academic-result publication chain"
 )
 PUBLICATION_DOC = ROOT / "docs" / "implementation" / "academic-result-publication.md"
+READER_DOC = ROOT / "docs" / "implementation" / "academic-result-reader.md"
 STALE_PUBLICATION_PHRASES = (
     "still does **not** publish academic results",
     "publication remains absent until issue #31",
@@ -44,6 +45,17 @@ REQUIRED_PUBLICATION_DOC_PHRASES = (
     "Issue #32",
     "Issue #33",
     "Meridian",
+)
+REQUIRED_READER_DOC_PHRASES = (
+    "concord.academic_result_reader",
+    "concord.academic_result_artifacts",
+    "read_academic_result_manifest",
+    "AcademicResultArtifactAuthorizationGate",
+    "source_snapshot_revision",
+    "returned_artifact_pdf",
+    "Issue #33",
+    "Meridian",
+    "Vitrine",
 )
 
 
@@ -128,6 +140,16 @@ def check_documentation() -> None:
             if phrase not in publication_doc:
                 failures.append(
                     "Publication implementation document is missing required "
+                    f"contract wording {phrase!r}."
+                )
+    if not READER_DOC.is_file():
+        failures.append("Academic result consumer reader document is missing.")
+    else:
+        reader_doc = READER_DOC.read_text(encoding="utf-8")
+        for phrase in REQUIRED_READER_DOC_PHRASES:
+            if phrase not in reader_doc:
+                failures.append(
+                    "Consumer reader implementation document is missing required "
                     f"contract wording {phrase!r}."
                 )
     publication_active_text = "\n".join(

--- a/scripts/check_package.py
+++ b/scripts/check_package.py
@@ -103,7 +103,14 @@ def validate_wheel(path: str | Path) -> None:
         raise PackageValidationError(
             "The Concord publication-producer entry point must occur exactly once."
         )
-    required = {"concord/__init__.py", "concord/cli.py", "concord/py.typed"}
+    required = {
+        "concord/__init__.py",
+        "concord/academic_result_artifacts.py",
+        "concord/academic_result_reader.py",
+        "concord/artifact_rendering.py",
+        "concord/cli.py",
+        "concord/py.typed",
+    }
     if not required.issubset(names):
         raise PackageValidationError("Wheel is missing intended Concord package files.")
     if not any(name.endswith(".dist-info/licenses/LICENSE") for name in names):

--- a/scripts/smoke_test_wheel.py
+++ b/scripts/smoke_test_wheel.py
@@ -606,6 +606,224 @@ def _workflow_smoke_code() -> str:
     )
 
 
+def _reader_smoke_code() -> str:
+    return textwrap.dedent(
+        """
+        import sys
+        from datetime import datetime, timezone
+
+        from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef
+
+        from concord.academic_result_artifacts import (
+            AcademicResultArtifactAuthorizationDecision,
+            AuthorizedAcademicResultArtifact,
+            read_authorized_academic_result_artifact,
+        )
+        from concord.academic_result_manifest import (
+            ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+            ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+            AcademicResultManifest,
+            ActivityContextProjection,
+            CriterionProjection,
+            CriterionSetProjection,
+            ManifestProjection,
+            ManifestRecordSet,
+            PrivacyProjection,
+            PublicActor,
+            ScaleLevelProjection,
+            ScoreProjection,
+            ScoringScaleProjection,
+            TargetReferenceProjection,
+            academic_result_manifest_to_bytes,
+            with_semantic_projection_digest,
+        )
+        from concord.academic_result_reader import (
+            list_academic_result_scores_for_target,
+            lookup_academic_result_criterion,
+            lookup_academic_result_scale_level,
+            lookup_academic_result_score,
+            lookup_academic_result_scoring_scale,
+            read_academic_result_manifest,
+            validate_academic_result_manifest,
+        )
+
+        actor = PublicActor(
+            actor_kind="authorized_adult",
+            actor_id="teacher-smoke",
+            owning_system="concord",
+        )
+        work = ModuleWorkRef("concord", "class-smoke", "activity-smoke")
+        target = TargetReferenceProjection(
+            target_kind="concord_group",
+            target_id="group-smoke",
+            owning_system="concord",
+            contract_version=None,
+        )
+        criterion_set = CriterionSetProjection(
+            criterion_set_id="set-smoke",
+            lineage_id="set-lineage-smoke",
+            revision=1,
+            criterion_set_kind="local",
+            scope="activity_specific",
+            criterion_ids=("criterion-smoke",),
+            status="active",
+            supersedes_criterion_set_id=None,
+            standards_profile_id=None,
+        )
+        criterion = CriterionProjection(
+            criterion_id="criterion-smoke",
+            criterion_set_id="set-smoke",
+            key="collaboration",
+            label="Collaboration",
+            definition="Synthetic installed reader criterion.",
+            criterion_kind="local",
+            supported_target_kinds=("concord_group",),
+            status="active",
+            standard_id=None,
+            alignment_standard_ids=(),
+            default_scoring_scale_id="scale-smoke",
+        )
+        scale = ScoringScaleProjection(
+            scoring_scale_id="scale-smoke",
+            lineage_id="scale-lineage-smoke",
+            name="Type-sensitive smoke scale",
+            revision=1,
+            scale_type="teacher_defined",
+            levels=(
+                ScaleLevelProjection(
+                    value=1,
+                    label="Integer",
+                    meaning="Integer one.",
+                    position=None,
+                    description=None,
+                ),
+                ScaleLevelProjection(
+                    value=1.0,
+                    label="Float",
+                    meaning="Float one.",
+                    position=None,
+                    description=None,
+                ),
+                ScaleLevelProjection(
+                    value="1",
+                    label="Text",
+                    meaning="Text one.",
+                    position=None,
+                    description=None,
+                ),
+                ScaleLevelProjection(
+                    value=True,
+                    label="Boolean",
+                    meaning="Boolean true.",
+                    position=None,
+                    description=None,
+                ),
+            ),
+            status="active",
+            supersedes_scoring_scale_id=None,
+        )
+        score = ScoreProjection(
+            score_record_id="score-smoke",
+            activity_id="activity-smoke",
+            session_id=None,
+            target_reference=target,
+            criterion_id="criterion-smoke",
+            score_kind="local",
+            standard_id=None,
+            scoring_scale_id="scale-smoke",
+            disposition="scored",
+            value=True,
+            basis="professional_judgment",
+            scorer=actor,
+            scored_at=datetime(2026, 8, 15, 17, 0, tzinfo=timezone.utc),
+            moderation_complete=True,
+            status_reason=None,
+            supersedes_score_record_id=None,
+            current_state="current",
+        )
+        candidate = AcademicResultManifest(
+            record_type=ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+            contract_version=ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+            producer_module_id="concord",
+            generated_at=datetime(2026, 8, 15, 17, 5, tzinfo=timezone.utc),
+            record_set=ManifestRecordSet("academic_results", 1),
+            work=work,
+            source_activity=ModuleRecordRef(
+                module_id="concord",
+                record_kind="activity",
+                record_id="activity-smoke",
+                contract_version="concord_activity_v1",
+            ),
+            projection=ManifestProjection(
+                source_snapshot_revision=1,
+                projection_digest_algorithm="sha256",
+                projection_digest="0" * 64,
+                generated_by=actor,
+                revision_reason="initial",
+            ),
+            activity_context=ActivityContextProjection(
+                activity_id="activity-smoke",
+                class_id="class-smoke",
+                title="Synthetic installed reader Activity",
+                scoring_orientation="local_criteria_only",
+                standards_profile_id=None,
+                focus_standard_ids=(),
+                criterion_set_ids=("set-smoke",),
+            ),
+            criterion_sets=(criterion_set,),
+            criteria=(criterion,),
+            scoring_scales=(scale,),
+            scores=(score,),
+            score_evidence_links=(),
+            moderation_records=(),
+            standards_result_projection=(),
+            privacy=PrivacyProjection(
+                classification="teacher_restricted",
+                audience_references=(),
+                policy_reference=None,
+                inherited_from=None,
+            ),
+        )
+        manifest = with_semantic_projection_digest(candidate)
+        raw = academic_result_manifest_to_bytes(manifest)
+        restored = read_academic_result_manifest(raw)
+        assert restored == manifest
+        assert validate_academic_result_manifest(restored) is restored
+        assert lookup_academic_result_criterion(
+            restored, "criterion-smoke"
+        ) == criterion
+        assert lookup_academic_result_scoring_scale(
+            restored, "scale-smoke"
+        ) == scale
+        assert lookup_academic_result_scale_level(
+            restored, "scale-smoke", 1
+        ).label == "Integer"
+        assert lookup_academic_result_scale_level(
+            restored, "scale-smoke", 1.0
+        ).label == "Float"
+        assert lookup_academic_result_scale_level(
+            restored, "scale-smoke", "1"
+        ).label == "Text"
+        assert lookup_academic_result_scale_level(
+            restored, "scale-smoke", True
+        ).label == "Boolean"
+        assert lookup_academic_result_score(restored, "score-smoke") == score
+        assert list_academic_result_scores_for_target(restored, target) == (score,)
+
+        decision = AcademicResultArtifactAuthorizationDecision("allowed")
+        assert decision.status == "allowed"
+        assert AuthorizedAcademicResultArtifact.__module__ == (
+            "concord.academic_result_artifacts"
+        )
+        assert callable(read_authorized_academic_result_artifact)
+
+        forbidden = {"scoreform", "quillan", "portia", "meridian", "vitrine"}
+        loaded = {name.split(".")[0].lower() for name in sys.modules}
+        assert forbidden.isdisjoint(loaded)
+        """
+    )
+
+
 def smoke_test(concord_wheel: Path, core_wheel: Path) -> None:
     """Install exact local wheels and exercise read-only, menu, and workflow paths."""
     with tempfile.TemporaryDirectory(prefix="pds-concord-smoke-") as raw_temp:
@@ -724,6 +942,14 @@ def smoke_test(concord_wheel: Path, core_wheel: Path) -> None:
         if profile_workspace.exists():
             raise RuntimeError(
                 "Publication-profile discovery unexpectedly created a workspace."
+            )
+
+        reader_workspace = root / "reader-workspace"
+        reader_env = {"PDS_WORKSPACE_ROOT": str(reader_workspace)}
+        _run([str(python), "-c", _reader_smoke_code()], outside, env=reader_env)
+        if reader_workspace.exists():
+            raise RuntimeError(
+                "Public reader smoke unexpectedly created a workspace."
             )
 
         absent_workspace = root / "read-only-workspace"

--- a/tests/fixtures/native_records/standards_activity.json
+++ b/tests/fixtures/native_records/standards_activity.json
@@ -1,5 +1,12 @@
 {
   "expected_issue_codes": [],
+  "artifact_reader_proof": {
+    "artifact_instance_link_id": "link-1",
+    "artifact_page_link_id": "link-page-1",
+    "type_sensitive_scale_id": "scale-typed",
+    "retained_source_relative_path": "scans/source/2026-08-15/standards-page-1.png",
+    "retained_source_sha256": "ff3c226a214c3fc7720355c52e0b713be0c4effdfaed85b78a5ae7f2444b31a5"
+  },
   "semantic_proof": {
     "author_id": "participant-1",
     "subject_id": "participant-2",
@@ -38,7 +45,7 @@
       {"score_record_id": "score-group-nonscore", "current_state": "current", "disposition": "not_observed", "value_present": false}
     ],
     "standards_result_score_ids": ["score-standard-1", "score-standard-2"],
-    "moderation_record_ids": ["moderation-1"],
+    "moderation_record_ids": ["moderation-1", "moderation-page-1"],
     "external_evidence_lineage_examples": [
       {
         "owning_system": "scoreform",
@@ -111,11 +118,15 @@
     },
     {
       "record_kind": "criterion",
-      "body": {"criterion_id": "criterion-local", "criterion_set_id": "criterion-set-1", "key": "collaboration", "label": "Collaboration", "definition": "Coordinates the assigned work.", "criterion_kind": "local", "alignment_standard_ids": [], "supported_target_kinds": ["concord_group"], "default_scoring_scale_id": "scale-1", "status": "active", "created_provenance": {"actor": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "timestamp": "2026-08-04T12:00:00-04:00", "source_kind": "manual"}}
+      "body": {"criterion_id": "criterion-local", "criterion_set_id": "criterion-set-1", "key": "collaboration", "label": "Collaboration", "definition": "Coordinates the assigned work.", "criterion_kind": "local", "alignment_standard_ids": [], "supported_target_kinds": ["concord_group"], "default_scoring_scale_id": "scale-typed", "status": "active", "created_provenance": {"actor": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "timestamp": "2026-08-04T12:00:00-04:00", "source_kind": "manual"}}
     },
     {
       "record_kind": "scoring_scale",
       "body": {"scoring_scale_id": "scale-1", "lineage_id": "scale-lineage", "name": "Four-level scale", "revision": 1, "scale_type": "ordinal", "levels": [{"value": 1, "label": "Beginning", "meaning": "Beginning evidence", "position": 1}, {"value": 2, "label": "Developing", "meaning": "Developing evidence", "position": 2}, {"value": 3, "label": "Secure", "meaning": "Secure evidence", "position": 3}, {"value": 4, "label": "Extending", "meaning": "Extending evidence", "position": 4}], "status": "active", "created_provenance": {"actor": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "timestamp": "2026-08-04T12:00:00-04:00", "source_kind": "manual"}}
+    },
+    {
+      "record_kind": "scoring_scale",
+      "body": {"scoring_scale_id": "scale-typed", "lineage_id": "scale-lineage-typed", "name": "Type-sensitive synthetic scale", "revision": 1, "scale_type": "teacher_defined", "levels": [{"value": 1, "label": "Integer one", "meaning": "Exact integer one."}, {"value": 1.0, "label": "Float one", "meaning": "Exact float one."}, {"value": "1", "label": "Text one", "meaning": "Exact string one."}, {"value": true, "label": "Boolean true", "meaning": "Exact boolean true."}], "status": "active", "created_provenance": {"actor": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "timestamp": "2026-08-04T12:00:00-04:00", "source_kind": "manual"}}
     },
     {
       "record_kind": "group_membership",
@@ -146,6 +157,10 @@
       "body": {"artifact_page_id": "page-1", "artifact_instance_id": "artifact-1", "page_number": 1, "page_kind": "primary", "return_expected": true, "route_required": true, "page_status": "returned", "created_provenance": {"actor": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "timestamp": "2026-08-04T12:00:00-04:00", "source_kind": "manual"}, "expected_page_count": 1, "route_id": "route-1", "human_fallback": "Synthetic activity, page 1"}
     },
     {
+      "record_kind": "scan_reference",
+      "body": {"scan_reference_id": "scan-reference-1", "activity_id": "standards-activity", "artifact_page_id": "page-1", "route_id": "route-1", "source_scan_id": "synthetic-scan-1", "source_page_number": 1, "retained_source_relative_path": "scans/source/2026-08-15/standards-page-1.png", "retained_source_sha256": "ff3c226a214c3fc7720355c52e0b713be0c4effdfaed85b78a5ae7f2444b31a5", "created_provenance": {"actor": {"actor_kind": "system", "actor_id": "concord-scan-test", "owning_system": "concord"}, "timestamp": "2026-08-05T12:10:00-04:00", "source_kind": "routed"}}
+    },
+    {
       "record_kind": "artifact_author",
       "body": {"artifact_author_id": "author-1", "artifact_instance_id": "artifact-1", "author_reference": {"participant_kind": "core_student", "participant_id": "participant-1", "owning_system": "core"}, "authorship_mode": "recorder_for_group", "attribution_status": "confirmed", "attribution_source": "teacher", "created_provenance": {"actor": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "timestamp": "2026-08-04T12:00:00-04:00", "source_kind": "manual"}, "represented_group_id": "group-1", "role_assignment_id": "role-1", "representation_status": "recorder_summary"}
     },
@@ -166,6 +181,10 @@
       "body": {"moderation_record_id": "moderation-1", "target_evidence_reference": {"evidence_kind": "artifact_instance", "owning_system": "concord", "record_id": "artifact-1", "subject_context": [{"subject_kind": "core_student", "subject_id": "participant-2", "owning_system": "core"}], "moderation_requirement": "required"}, "target_subject_references": [{"subject_kind": "core_student", "subject_id": "participant-2", "owning_system": "core"}], "moderator": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "moderated_at": "2026-08-05T12:15:00-04:00", "status": "accepted_with_qualification", "permitted_use": "support_named_subject", "rationale": "The individual observation is clearly identified.", "privacy_policy": {"classification": "teacher_restricted", "audience_references": []}, "qualification": "Use only the identified participant context."}
     },
     {
+      "record_kind": "moderation_record",
+      "body": {"moderation_record_id": "moderation-page-1", "target_evidence_reference": {"evidence_kind": "artifact_page", "owning_system": "concord", "record_id": "page-1", "subject_context": [{"subject_kind": "core_student", "subject_id": "participant-2", "owning_system": "core"}], "moderation_requirement": "required"}, "target_subject_references": [{"subject_kind": "core_student", "subject_id": "participant-2", "owning_system": "core"}], "moderator": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "moderated_at": "2026-08-05T12:16:00-04:00", "status": "accepted", "permitted_use": "support_named_subject", "rationale": "Synthetic page evidence was separately reviewed for the named participant.", "privacy_policy": {"classification": "teacher_restricted", "audience_references": []}}
+    },
+    {
       "record_kind": "score_record",
       "body": {"score_record_id": "score-standard-1", "activity_id": "standards-activity", "target_reference": {"target_kind": "core_student", "target_id": "participant-2", "owning_system": "core"}, "criterion_id": "criterion-standard", "score_kind": "standard_backed", "scoring_scale_id": "scale-1", "disposition": "scored", "basis": "linked_evidence", "scorer": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "scored_at": "2026-08-05T12:30:00-04:00", "moderation_complete": true, "privacy_policy": {"classification": "teacher_restricted", "audience_references": []}, "session_id": "session-1", "standard_id": "standard-1", "value": 3}
     },
@@ -174,12 +193,24 @@
       "body": {"score_evidence_link_id": "link-1", "score_record_id": "score-standard-1", "evidence_reference": {"evidence_kind": "artifact_instance", "owning_system": "concord", "record_id": "artifact-1", "subject_context": [{"subject_kind": "core_student", "subject_id": "participant-2", "owning_system": "core"}], "moderation_requirement": "required"}, "relevance_description": "The named participant observation supports this individual judgment.", "status": "active", "created_provenance": {"actor": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "timestamp": "2026-08-05T12:30:00-04:00", "source_kind": "manual"}, "subject_context": [{"subject_kind": "core_student", "subject_id": "participant-2", "owning_system": "core"}], "significance": "primary", "moderation_record_id": "moderation-1"}
     },
     {
-      "record_kind": "score_record",
-      "body": {"score_record_id": "score-group-1", "activity_id": "standards-activity", "target_reference": {"target_kind": "concord_group", "target_id": "group-1", "owning_system": "concord"}, "criterion_id": "criterion-local", "score_kind": "local", "scoring_scale_id": "scale-1", "disposition": "scored", "basis": "professional_judgment", "scorer": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "scored_at": "2026-08-05T12:35:00-04:00", "moderation_complete": true, "privacy_policy": {"classification": "group_and_teacher", "audience_references": []}, "value": 3, "rationale": "The judgment applies to the Group target only."}
+      "record_kind": "score_evidence_link",
+      "body": {"score_evidence_link_id": "link-page-1", "score_record_id": "score-standard-1", "evidence_reference": {"evidence_kind": "artifact_page", "owning_system": "concord", "record_id": "page-1", "subject_context": [{"subject_kind": "core_student", "subject_id": "participant-2", "owning_system": "core"}], "moderation_requirement": "required"}, "relevance_description": "The exact returned page corroborates the individual judgment.", "status": "active", "created_provenance": {"actor": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "timestamp": "2026-08-05T12:31:00-04:00", "source_kind": "manual"}, "subject_context": [{"subject_kind": "core_student", "subject_id": "participant-2", "owning_system": "core"}], "significance": "corroborating", "moderation_record_id": "moderation-page-1"}
+    },
+    {
+      "record_kind": "score_evidence_link",
+      "body": {"score_evidence_link_id": "link-scoreform-1", "score_record_id": "score-standard-1", "evidence_reference": {"evidence_kind": "scoreform_result", "owning_system": "scoreform", "record_id": "synthetic-scoreform-result-1", "contract_version": "synthetic_scoreform_result_v1", "immutable_source_version": "1", "subject_context": [{"subject_kind": "core_student", "subject_id": "participant-2", "owning_system": "core"}], "moderation_requirement": "not_required"}, "relevance_description": "Synthetic immutable ScoreForm lineage remains metadata only.", "status": "active", "created_provenance": {"actor": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "timestamp": "2026-08-05T12:32:00-04:00", "source_kind": "manual"}, "subject_context": [{"subject_kind": "core_student", "subject_id": "participant-2", "owning_system": "core"}], "significance": "corroborating"}
+    },
+    {
+      "record_kind": "score_evidence_link",
+      "body": {"score_evidence_link_id": "link-quillan-1", "score_record_id": "score-standard-1", "evidence_reference": {"evidence_kind": "quillan_response", "owning_system": "quillan", "record_id": "synthetic-quillan-response-1", "contract_version": "synthetic_quillan_response_v1", "immutable_source_version": "1", "subject_context": [{"subject_kind": "core_student", "subject_id": "participant-2", "owning_system": "core"}], "moderation_requirement": "not_required"}, "relevance_description": "Synthetic immutable Quillan lineage remains metadata only.", "status": "active", "created_provenance": {"actor": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "timestamp": "2026-08-05T12:33:00-04:00", "source_kind": "manual"}, "subject_context": [{"subject_kind": "core_student", "subject_id": "participant-2", "owning_system": "core"}], "significance": "contextual"}
     },
     {
       "record_kind": "score_record",
-      "body": {"score_record_id": "score-group-nonscore", "activity_id": "standards-activity", "target_reference": {"target_kind": "concord_group", "target_id": "group-1", "owning_system": "concord"}, "criterion_id": "criterion-local", "score_kind": "local", "scoring_scale_id": "scale-1", "disposition": "not_observed", "basis": "professional_judgment", "scorer": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "scored_at": "2026-08-05T12:40:00-04:00", "moderation_complete": true, "privacy_policy": {"classification": "teacher_restricted", "audience_references": []}, "rationale": "No separate observation existed for this context.", "status_reason": {"reason_code": "not_observed", "recorded_by": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "recorded_at": "2026-08-05T12:40:00-04:00", "note": "No separate observation existed for this context."}}
+      "body": {"score_record_id": "score-group-1", "activity_id": "standards-activity", "target_reference": {"target_kind": "concord_group", "target_id": "group-1", "owning_system": "concord"}, "criterion_id": "criterion-local", "score_kind": "local", "scoring_scale_id": "scale-typed", "disposition": "scored", "basis": "professional_judgment", "scorer": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "scored_at": "2026-08-05T12:35:00-04:00", "moderation_complete": true, "privacy_policy": {"classification": "group_and_teacher", "audience_references": []}, "value": true, "rationale": "The judgment applies to the Group target only."}
+    },
+    {
+      "record_kind": "score_record",
+      "body": {"score_record_id": "score-group-nonscore", "activity_id": "standards-activity", "target_reference": {"target_kind": "concord_group", "target_id": "group-1", "owning_system": "concord"}, "criterion_id": "criterion-local", "score_kind": "local", "scoring_scale_id": "scale-typed", "disposition": "not_observed", "basis": "professional_judgment", "scorer": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "scored_at": "2026-08-05T12:40:00-04:00", "moderation_complete": true, "privacy_policy": {"classification": "teacher_restricted", "audience_references": []}, "rationale": "No separate observation existed for this context.", "status_reason": {"reason_code": "not_observed", "recorded_by": {"actor_kind": "authorized_adult", "actor_id": "actor-1", "owning_system": "core"}, "recorded_at": "2026-08-05T12:40:00-04:00", "note": "No separate observation existed for this context."}}
     },
     {
       "record_kind": "score_record",

--- a/tests/test_academic_result_artifact_contract_issue32.py
+++ b/tests/test_academic_result_artifact_contract_issue32.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import FrozenInstanceError
+
+import pytest
+from pds_core.routing_models import ModuleWorkRef
+
+import concord.academic_result_artifacts as artifacts_module
+import concord.artifact_rendering as rendering_module
+from concord.academic_result_artifacts import (
+    AcademicResultArtifactAuthorizationDecision,
+    AcademicResultArtifactAuthorizationRequest,
+    AcademicResultArtifactAuthorProjection,
+    AcademicResultArtifactPageProjection,
+    AcademicResultArtifactProjection,
+    AcademicResultArtifactSubjectProjection,
+    AcademicResultParticipantReferenceProjection,
+    AuthorizedAcademicResultArtifact,
+    ConcordAcademicResultArtifactValidationError,
+)
+from concord.academic_result_manifest import (
+    EvidenceReferenceProjection,
+    PublicActor,
+    RecordReferenceProjection,
+    SubjectReferenceProjection,
+)
+
+EXPECTED_PUBLIC = {
+    "AcademicResultArtifactAuthorizationDecision",
+    "AcademicResultArtifactAuthorizationGate",
+    "AcademicResultArtifactAuthorizationRequest",
+    "AcademicResultArtifactAuthorProjection",
+    "AcademicResultArtifactAuthorReference",
+    "AcademicResultArtifactPageProjection",
+    "AcademicResultArtifactProjection",
+    "AcademicResultArtifactRepresentation",
+    "AcademicResultArtifactSubjectProjection",
+    "AcademicResultParticipantReferenceProjection",
+    "ArtifactAuthorizationStatus",
+    "AuthorizedAcademicResultArtifact",
+    "ConcordAcademicResultArtifactAmbiguityError",
+    "ConcordAcademicResultArtifactAuthorizationError",
+    "ConcordAcademicResultArtifactError",
+    "ConcordAcademicResultArtifactIntegrityError",
+    "ConcordAcademicResultArtifactNotFoundError",
+    "ConcordAcademicResultArtifactUnavailableError",
+    "ConcordAcademicResultArtifactValidationError",
+    "read_authorized_academic_result_artifact",
+}
+
+
+def _work() -> ModuleWorkRef:
+    return ModuleWorkRef("concord", "class-1", "activity-1")
+
+
+def _student(subject_id: str) -> SubjectReferenceProjection:
+    return SubjectReferenceProjection(
+        subject_kind="core_student",
+        subject_id=subject_id,
+        owning_system="core",
+        contract_version=None,
+    )
+
+
+def _evidence(
+    kind: str = "artifact_instance",
+    record_id: str = "artifact-1",
+    owner: str = "concord",
+) -> EvidenceReferenceProjection:
+    return EvidenceReferenceProjection(
+        evidence_kind=kind,
+        owning_system=owner,
+        record_id=record_id,
+        contract_version=None,
+        source_publication_reference=None,
+        immutable_source_version=(None if owner == "concord" else "1"),
+        locator=None,
+        subject_context=(_student("student-subject"),),
+        moderation_requirement="not_required",
+    )
+
+
+def _artifact() -> AcademicResultArtifactProjection:
+    return AcademicResultArtifactProjection(
+        artifact_instance_id="artifact-1",
+        artifact_category="laboratory_record",
+        session_id="session-1",
+        group_id="group-1",
+        pages=(
+            AcademicResultArtifactPageProjection("page-1", 1),
+            AcademicResultArtifactPageProjection("page-2", 2),
+        ),
+        privacy_classification="group_and_teacher",
+    )
+
+
+def _author() -> AcademicResultArtifactAuthorProjection:
+    return AcademicResultArtifactAuthorProjection(
+        artifact_author_id="author-1",
+        artifact_instance_id="artifact-1",
+        author_reference=AcademicResultParticipantReferenceProjection(
+            participant_kind="core_student",
+            participant_id="student-author",
+            owning_system="core",
+        ),
+        authorship_mode="recorder_for_group",
+        attribution_status="confirmed",
+        represented_group_id="group-1",
+        representation_status="recorder_summary",
+    )
+
+
+def _subject_projection() -> AcademicResultArtifactSubjectProjection:
+    return AcademicResultArtifactSubjectProjection(
+        artifact_subject_id="subject-1",
+        artifact_instance_id="artifact-1",
+        subject_reference=_student("student-subject"),
+        subject_role="observed_participant",
+        confirmation_status="confirmed",
+        criterion_id="criterion-standard",
+    )
+
+
+def _request(
+    evidence: EvidenceReferenceProjection | None = None,
+) -> AcademicResultArtifactAuthorizationRequest:
+    return AcademicResultArtifactAuthorizationRequest(
+        work=_work(),
+        record_set_id="academic_results",
+        record_set_revision=2,
+        source_snapshot_revision=12,
+        score_record_id="score-1",
+        score_evidence_link_id="link-1",
+        evidence_reference=evidence or _evidence(),
+        purpose="authorized downstream Artifact review",
+    )
+
+
+def _result(
+    evidence: EvidenceReferenceProjection | None = None,
+) -> AuthorizedAcademicResultArtifact:
+    content = b"%PDF-1.7\nsynthetic\n%%EOF\n"
+    return AuthorizedAcademicResultArtifact(
+        representation="returned_artifact_pdf",
+        work=_work(),
+        record_set_revision=2,
+        source_snapshot_revision=12,
+        score_record_id="score-1",
+        score_evidence_link_id="link-1",
+        evidence_reference=evidence or _evidence(),
+        artifact=_artifact(),
+        authors=(_author(),),
+        subjects=(_subject_projection(),),
+        media_type="application/pdf",
+        sha256=hashlib.sha256(content).hexdigest(),
+        byte_size=len(content),
+        content=content,
+    )
+
+
+def test_public_artifact_contract_exports_exact_stable_surface() -> None:
+    assert set(artifacts_module.__all__) == EXPECTED_PUBLIC
+
+
+def test_authorization_request_is_manifest_derived_and_immutable() -> None:
+    request = _request()
+    assert request.work == _work()
+    assert request.record_set_id == "academic_results"
+    assert request.source_snapshot_revision == 12
+    assert request.evidence_reference.evidence_kind == "artifact_instance"
+    with pytest.raises(FrozenInstanceError):
+        request.purpose = "changed"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize("status", ["allowed", "denied", "unresolved"])
+def test_authorization_decision_accepts_only_closed_statuses(status: str) -> None:
+    decision = AcademicResultArtifactAuthorizationDecision(
+        status  # type: ignore[arg-type]
+    )
+    assert decision.status == status
+
+
+def test_authorization_decision_rejects_unknown_status() -> None:
+    with pytest.raises(ConcordAcademicResultArtifactValidationError):
+        AcademicResultArtifactAuthorizationDecision("maybe")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        _evidence("scoreform_result", "result-1", "scoreform"),
+        _evidence("quillan_response", "response-1", "quillan"),
+        _evidence("external_record", "external-1", "external"),
+        _evidence("teacher_rationale", "rationale-1", "concord"),
+    ],
+)
+def test_authorization_request_rejects_non_concord_artifact_evidence(
+    evidence: EvidenceReferenceProjection,
+) -> None:
+    with pytest.raises(ConcordAcademicResultArtifactValidationError):
+        _request(evidence)
+
+
+def test_authorization_request_rejects_wrong_work_or_record_set() -> None:
+    with pytest.raises(ConcordAcademicResultArtifactValidationError):
+        AcademicResultArtifactAuthorizationRequest(
+            work=ModuleWorkRef("other", "class-1", "activity-1"),
+            record_set_id="academic_results",
+            record_set_revision=1,
+            source_snapshot_revision=1,
+            score_record_id="score-1",
+            score_evidence_link_id="link-1",
+            evidence_reference=_evidence(),
+            purpose="review",
+        )
+    with pytest.raises(ConcordAcademicResultArtifactValidationError):
+        AcademicResultArtifactAuthorizationRequest(
+            work=_work(),
+            record_set_id="other_results",
+            record_set_revision=1,
+            source_snapshot_revision=1,
+            score_record_id="score-1",
+            score_evidence_link_id="link-1",
+            evidence_reference=_evidence(),
+            purpose="review",
+        )
+
+
+@pytest.mark.parametrize("purpose", ["", " leading", "trailing ", "line\nbreak"])
+def test_authorization_request_rejects_unsafe_purpose(purpose: str) -> None:
+    with pytest.raises(ConcordAcademicResultArtifactValidationError):
+        AcademicResultArtifactAuthorizationRequest(
+            work=_work(),
+            record_set_id="academic_results",
+            record_set_revision=1,
+            source_snapshot_revision=1,
+            score_record_id="score-1",
+            score_evidence_link_id="link-1",
+            evidence_reference=_evidence(),
+            purpose=purpose,
+        )
+
+
+def test_public_artifact_projection_preserves_only_bounded_identity_context() -> None:
+    artifact = _artifact()
+    assert artifact.artifact_instance_id == "artifact-1"
+    assert artifact.session_id == "session-1"
+    assert artifact.group_id == "group-1"
+    assert tuple(page.artifact_page_id for page in artifact.pages) == (
+        "page-1",
+        "page-2",
+    )
+    assert not hasattr(artifact, "route_id")
+    assert not hasattr(artifact, "retained_source_relative_path")
+    assert not hasattr(artifact, "retained_source_sha256")
+    assert not hasattr(artifact, "created_provenance")
+
+
+def test_author_and_subject_are_distinct_public_relationships() -> None:
+    author = _author()
+    subject = _subject_projection()
+    assert isinstance(
+        author.author_reference,
+        AcademicResultParticipantReferenceProjection,
+    )
+    assert author.author_reference.participant_id == "student-author"
+    assert subject.subject_reference.subject_id == "student-subject"
+    assert (
+        author.author_reference.participant_id
+        != subject.subject_reference.subject_id
+    )
+    assert author.represented_group_id == "group-1"
+    assert not hasattr(author, "role_assignment_id")
+    assert not hasattr(subject, "assignment_source")
+    assert not hasattr(subject, "privacy_policy")
+
+
+def test_unknown_author_does_not_invent_identity_or_group_context() -> None:
+    unknown = AcademicResultArtifactAuthorProjection(
+        artifact_author_id="author-unknown",
+        artifact_instance_id="artifact-1",
+        author_reference=None,
+        authorship_mode="unknown",
+        attribution_status="unknown",
+        represented_group_id=None,
+        representation_status=None,
+    )
+    assert unknown.author_reference is None
+    with pytest.raises(ConcordAcademicResultArtifactValidationError):
+        AcademicResultArtifactAuthorProjection(
+            artifact_author_id="author-unknown",
+            artifact_instance_id="artifact-1",
+            author_reference=AcademicResultParticipantReferenceProjection(
+                "core_student", "student-1", "core"
+            ),
+            authorship_mode="unknown",
+            attribution_status="unknown",
+            represented_group_id=None,
+            representation_status=None,
+        )
+
+
+def test_author_reference_supports_public_actor_and_record_without_labels() -> None:
+    actor = AcademicResultArtifactAuthorProjection(
+        artifact_author_id="author-adult",
+        artifact_instance_id="artifact-1",
+        author_reference=PublicActor("authorized_adult", "teacher-1", "core"),
+        authorship_mode="teacher_author",
+        attribution_status="confirmed",
+        represented_group_id=None,
+        representation_status=None,
+    )
+    record = AcademicResultArtifactAuthorProjection(
+        artifact_author_id="author-record",
+        artifact_instance_id="artifact-1",
+        author_reference=RecordReferenceProjection(
+            module_id="concord",
+            record_kind="group",
+            record_id="group-1",
+            contract_version=None,
+        ),
+        authorship_mode="collective_group_author",
+        attribution_status="confirmed",
+        represented_group_id="group-1",
+        representation_status="unanimous_position",
+    )
+    assert isinstance(actor.author_reference, PublicActor)
+    assert isinstance(record.author_reference, RecordReferenceProjection)
+
+
+def test_authorized_result_binds_exact_pdf_bytes_and_public_relationships() -> None:
+    result = _result()
+    assert result.media_type == "application/pdf"
+    assert result.byte_size == len(result.content)
+    assert result.sha256 == hashlib.sha256(result.content).hexdigest()
+    assert (
+        result.authors[0].artifact_instance_id
+        == result.artifact.artifact_instance_id
+    )
+    assert (
+        result.subjects[0].artifact_instance_id
+        == result.artifact.artifact_instance_id
+    )
+    assert not hasattr(result, "path")
+    assert not hasattr(result, "retained_source_relative_path")
+
+
+def test_authorized_result_supports_exact_artifact_page_evidence() -> None:
+    result = _result(_evidence("artifact_page", "page-2", "concord"))
+    assert result.evidence_reference.record_id == "page-2"
+
+
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        _evidence("artifact_instance", "artifact-other", "concord"),
+        _evidence("artifact_page", "page-other", "concord"),
+    ],
+)
+def test_authorized_result_rejects_evidence_identity_mismatch(
+    evidence: EvidenceReferenceProjection,
+) -> None:
+    with pytest.raises(ConcordAcademicResultArtifactValidationError):
+        _result(evidence)
+
+
+def test_authorized_result_rejects_digest_size_media_or_mutable_bytes() -> None:
+    good = _result()
+    common = dict(
+        representation=good.representation,
+        work=good.work,
+        record_set_revision=good.record_set_revision,
+        source_snapshot_revision=good.source_snapshot_revision,
+        score_record_id=good.score_record_id,
+        score_evidence_link_id=good.score_evidence_link_id,
+        evidence_reference=good.evidence_reference,
+        artifact=good.artifact,
+        authors=good.authors,
+        subjects=good.subjects,
+    )
+    with pytest.raises(ConcordAcademicResultArtifactValidationError):
+        AuthorizedAcademicResultArtifact(
+            **common,
+            media_type="application/pdf",
+            sha256="0" * 64,
+            byte_size=good.byte_size,
+            content=good.content,
+        )
+    with pytest.raises(ConcordAcademicResultArtifactValidationError):
+        AuthorizedAcademicResultArtifact(
+            **common,
+            media_type="application/pdf",
+            sha256=good.sha256,
+            byte_size=good.byte_size + 1,
+            content=good.content,
+        )
+    with pytest.raises(ConcordAcademicResultArtifactValidationError):
+        AuthorizedAcademicResultArtifact(
+            **common,
+            media_type="text/plain",
+            sha256=good.sha256,
+            byte_size=good.byte_size,
+            content=good.content,
+        )
+    with pytest.raises(ConcordAcademicResultArtifactValidationError):
+        AuthorizedAcademicResultArtifact(
+            **common,
+            media_type="application/pdf",
+            sha256=good.sha256,
+            byte_size=good.byte_size,
+            content=bytearray(good.content),  # type: ignore[arg-type]
+        )
+
+
+def test_public_artifact_module_has_no_consumer_or_registry_dependency() -> None:
+    source = artifacts_module.__file__
+    assert source is not None
+    text = open(source, encoding="utf-8").read().lower()  # noqa: PTH123
+    for forbidden in (
+        "import meridian",
+        "import vitrine",
+        "import scoreform",
+        "import quillan",
+        "import portia",
+        "concord.workflows",
+        "registry_services",
+        "academic_catalog",
+        "publication_storage",
+    ):
+        assert forbidden not in text
+    assert "load_current_snapshot" not in text
+    assert "load_current_record_graph" not in text
+
+
+def test_neutral_artifact_rendering_layer_has_no_workflow_dependency() -> None:
+    source = rendering_module.__file__
+    assert source is not None
+    text = open(source, encoding="utf-8").read().lower()  # noqa: PTH123
+    assert "concord.workflows" not in text
+    assert "registry_services" not in text
+    assert "academic_catalog" not in text
+    assert "publication_storage" not in text
+
+
+def test_public_contract_exposes_authorized_artifact_read_function() -> None:
+    assert callable(artifacts_module.read_authorized_academic_result_artifact)

--- a/tests/test_academic_result_artifact_resolution_issue32.py
+++ b/tests/test_academic_result_artifact_resolution_issue32.py
@@ -1,0 +1,1882 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef
+from pds_core.standards import (
+    StandardDefinition,
+    StandardsLibrary,
+    StandardsProfile,
+)
+from pds_core.workspace import ensure_workspace_root
+from PIL import Image
+
+import concord.academic_result_artifacts as artifacts_module
+import concord.artifact_rendering as artifact_rendering_module
+import concord.storage as storage_module
+from concord.academic_result_artifacts import (
+    AcademicResultArtifactAuthorizationDecision,
+    ConcordAcademicResultArtifactAmbiguityError,
+    ConcordAcademicResultArtifactAuthorizationError,
+    ConcordAcademicResultArtifactIntegrityError,
+    ConcordAcademicResultArtifactNotFoundError,
+    ConcordAcademicResultArtifactUnavailableError,
+    ConcordAcademicResultArtifactValidationError,
+)
+from concord.academic_result_manifest import (
+    ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+    ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+    AcademicResultManifest,
+    ActivityContextProjection,
+    CriterionProjection,
+    CriterionSetProjection,
+    EvidenceReferenceProjection,
+    ManifestProjection,
+    ManifestRecordSet,
+    PrivacyProjection,
+    PublicActor,
+    ScaleLevelProjection,
+    ScoreEvidenceLinkProjection,
+    ScoreProjection,
+    ScoringScaleProjection,
+    TargetReferenceProjection,
+    with_semantic_projection_digest,
+)
+from concord.academic_result_manifest_generation import (
+    GenerateAcademicResultManifestRequest,
+    generate_academic_result_manifest,
+)
+from concord.academic_result_reader import lookup_academic_result_scale_level
+from concord.academic_work_registration import register_concord_academic_work
+from concord.model_conversion import record_from_dict, record_to_dict
+from concord.model_validation import ConcordRecordGraph
+from concord.models import (
+    Activity,
+    ActorReference,
+    ArtifactAuthor,
+    ArtifactInstance,
+    ArtifactPage,
+    ArtifactSubject,
+    EvidenceReference,
+    ParticipantReference,
+    PrivacyPolicy,
+    Provenance,
+    ScanReference,
+    ScoreEvidenceLink,
+    ScoreRecord,
+    ScoreTargetReference,
+    Session,
+    SubjectReference,
+)
+from concord.storage import (
+    commit_record_batch,
+    load_record_graph_at_snapshot,
+)
+from concord.storage_errors import ConcordStorageNotFoundError
+from concord.storage_models import ConcordLoadedRecordGraph
+from concord.storage_paths import record_revision_path
+from concord.storage_serialization import serialize
+from concord.workflows.models import WorkflowActor
+
+STANDARDS_FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "native_records"
+    / "standards_activity.json"
+)
+EVIDENCE_ONLY_FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "native_records"
+    / "evidence_only_activity.json"
+)
+REPRESENTATIVE_SOURCE_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAFklEQVR4nGPUCKhgYGBg"
+    "YmBgYGBgAAALGgD0KRPd0QAAAABJRU5ErkJggg=="
+)
+
+
+def _timestamp() -> str:
+    return "2026-08-15T09:00:00-04:00"
+
+
+def _actor() -> ActorReference:
+    return ActorReference(
+        actor_kind="authorized_adult",
+        actor_id="teacher-1",
+        owning_system="core",
+    )
+
+
+def _provenance() -> Provenance:
+    return Provenance(
+        actor=_actor(),
+        timestamp=_timestamp(),
+        source_kind="manual",
+    )
+
+
+def _privacy() -> PrivacyPolicy:
+    return PrivacyPolicy(
+        classification="teacher_restricted",
+    )
+
+
+def _work() -> ModuleWorkRef:
+    return ModuleWorkRef(
+        module_id="concord",
+        class_id="class-1",
+        work_id="activity-1",
+    )
+
+
+def _native_evidence(kind: str = "artifact_instance") -> EvidenceReference:
+    return EvidenceReference(
+        evidence_kind=kind,
+        owning_system="concord",
+        record_id="artifact-1" if kind == "artifact_instance" else "page-1",
+        moderation_requirement="not_required",
+    )
+
+
+def _native_graph(kind: str = "artifact_instance") -> ConcordRecordGraph:
+    activity = Activity(
+        activity_id="activity-1",
+        class_reference=ModuleRecordRef(
+            module_id="core",
+            record_kind="class",
+            record_id="class-1",
+        ),
+        title="Synthetic local Activity",
+        activity_type="local:laboratory",
+        scoring_orientation="local_criteria_only",
+        status="active",
+        created_provenance=_provenance(),
+    )
+    session = Session(
+        session_id="session-1",
+        activity_id="activity-1",
+        sequence=1,
+        status="active",
+        created_provenance=_provenance(),
+    )
+    artifact = ArtifactInstance(
+        artifact_instance_id="artifact-1",
+        template_version_id="template-1",
+        activity_id="activity-1",
+        artifact_category="laboratory_record",
+        generation_status="completed",
+        expected_return_status="returned_expected",
+        artifact_status="returned",
+        privacy_policy=_privacy(),
+        page_ids=("page-1", "page-2"),
+        created_provenance=_provenance(),
+        session_id="session-1",
+        group_id="group-1",
+    )
+    pages = (
+        ArtifactPage(
+            artifact_page_id="page-1",
+            artifact_instance_id="artifact-1",
+            page_number=1,
+            page_kind="primary",
+            return_expected=True,
+            route_required=False,
+            page_status="returned",
+            created_provenance=_provenance(),
+        ),
+        ArtifactPage(
+            artifact_page_id="page-2",
+            artifact_instance_id="artifact-1",
+            page_number=2,
+            page_kind="continuation",
+            return_expected=True,
+            route_required=False,
+            page_status="returned",
+            created_provenance=_provenance(),
+            continuation_of_page_id="page-1",
+        ),
+    )
+    author = ArtifactAuthor(
+        artifact_author_id="author-1",
+        artifact_instance_id="artifact-1",
+        author_reference=ParticipantReference(
+            participant_kind="core_student",
+            participant_id="student-author",
+            owning_system="core",
+        ),
+        authorship_mode="recorder_for_group",
+        attribution_status="confirmed",
+        attribution_source="teacher",
+        created_provenance=_provenance(),
+        represented_group_id="group-1",
+        representation_status="recorder_summary",
+    )
+    subject = ArtifactSubject(
+        artifact_subject_id="subject-1",
+        artifact_instance_id="artifact-1",
+        subject_reference=SubjectReference(
+            subject_kind="core_student",
+            subject_id="student-subject",
+            owning_system="core",
+        ),
+        subject_role="observed_participant",
+        confirmation_status="confirmed",
+        assignment_source="teacher",
+        created_provenance=_provenance(),
+    )
+    score = ScoreRecord(
+        score_record_id="score-1",
+        activity_id="activity-1",
+        target_reference=ScoreTargetReference(
+            target_kind="concord_artifact_instance",
+            target_id="artifact-1",
+            owning_system="concord",
+        ),
+        criterion_id="criterion-1",
+        score_kind="local",
+        scoring_scale_id="scale-1",
+        disposition="scored",
+        basis="linked_evidence",
+        scorer=_actor(),
+        scored_at=_timestamp(),
+        moderation_complete=True,
+        privacy_policy=_privacy(),
+        value="met",
+    )
+    link = ScoreEvidenceLink(
+        score_evidence_link_id="link-1",
+        score_record_id="score-1",
+        evidence_reference=_native_evidence(kind),
+        relevance_description="Exact synthetic Artifact evidence.",
+        status="active",
+        created_provenance=_provenance(),
+        significance="primary",
+    )
+    return ConcordRecordGraph(
+        activities=(activity,),
+        sessions=(session,),
+        artifact_instances=(artifact,),
+        artifact_pages=pages,
+        artifact_authors=(author,),
+        artifact_subjects=(subject,),
+        score_records=(score,),
+        score_evidence_links=(link,),
+    )
+
+
+def _public_evidence(kind: str = "artifact_instance") -> EvidenceReferenceProjection:
+    return EvidenceReferenceProjection(
+        evidence_kind=kind,
+        owning_system="concord",
+        record_id="artifact-1" if kind == "artifact_instance" else "page-1",
+        contract_version=None,
+        source_publication_reference=None,
+        immutable_source_version=None,
+        locator=None,
+        subject_context=(),
+        moderation_requirement="not_required",
+    )
+
+
+def _manifest(
+    kind: str = "artifact_instance", revision: int = 7
+) -> AcademicResultManifest:
+    public_actor = PublicActor(
+        actor_kind="authorized_adult",
+        actor_id="teacher-1",
+        owning_system="core",
+    )
+    work = _work()
+    criterion_set = CriterionSetProjection(
+        criterion_set_id="set-1",
+        lineage_id="set-lineage",
+        revision=1,
+        criterion_set_kind="local",
+        scope="activity_specific",
+        criterion_ids=("criterion-1",),
+        status="active",
+        supersedes_criterion_set_id=None,
+        standards_profile_id=None,
+    )
+    criterion = CriterionProjection(
+        criterion_id="criterion-1",
+        criterion_set_id="set-1",
+        key="local_result",
+        label="Local result",
+        definition="Synthetic local result criterion.",
+        criterion_kind="local",
+        supported_target_kinds=("concord_artifact_instance",),
+        status="active",
+        standard_id=None,
+        alignment_standard_ids=(),
+        default_scoring_scale_id="scale-1",
+    )
+    scale = ScoringScaleProjection(
+        scoring_scale_id="scale-1",
+        lineage_id="scale-lineage",
+        name="Synthetic result scale",
+        revision=1,
+        scale_type="teacher_defined",
+        levels=(
+            ScaleLevelProjection(
+                value="met",
+                label="Met",
+                meaning="Criterion met.",
+                position=None,
+                description=None,
+            ),
+        ),
+        status="active",
+        supersedes_scoring_scale_id=None,
+    )
+    score = ScoreProjection(
+        score_record_id="score-1",
+        activity_id="activity-1",
+        session_id=None,
+        target_reference=TargetReferenceProjection(
+            target_kind="concord_artifact_instance",
+            target_id="artifact-1",
+            owning_system="concord",
+            contract_version=None,
+        ),
+        criterion_id="criterion-1",
+        score_kind="local",
+        standard_id=None,
+        scoring_scale_id="scale-1",
+        disposition="scored",
+        value="met",
+        basis="linked_evidence",
+        scorer=public_actor,
+        scored_at=datetime(2026, 8, 15, 13, 0, tzinfo=timezone.utc),
+        moderation_complete=True,
+        status_reason=None,
+        supersedes_score_record_id=None,
+        current_state="current",
+    )
+    link = ScoreEvidenceLinkProjection(
+        score_evidence_link_id="link-1",
+        score_record_id="score-1",
+        evidence_reference=_public_evidence(kind),
+        evidence_locator=None,
+        subject_context=(),
+        relevance_description="Exact synthetic Artifact evidence.",
+        significance="primary",
+        moderation_record_id=None,
+        status="active",
+        supersedes_score_evidence_link_id=None,
+    )
+    candidate = AcademicResultManifest(
+        record_type=ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+        contract_version=ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+        producer_module_id="concord",
+        generated_at=datetime(2026, 8, 15, 13, 5, tzinfo=timezone.utc),
+        record_set=ManifestRecordSet("academic_results", 1),
+        work=work,
+        source_activity=ModuleRecordRef(
+            module_id="concord",
+            record_kind="activity",
+            record_id="activity-1",
+            contract_version="concord_activity_v1",
+        ),
+        projection=ManifestProjection(
+            source_snapshot_revision=revision,
+            projection_digest_algorithm="sha256",
+            projection_digest="0" * 64,
+            generated_by=public_actor,
+            revision_reason="initial",
+        ),
+        activity_context=ActivityContextProjection(
+            activity_id="activity-1",
+            class_id="class-1",
+            title="Synthetic local Activity",
+            scoring_orientation="local_criteria_only",
+            standards_profile_id=None,
+            focus_standard_ids=(),
+            criterion_set_ids=("set-1",),
+        ),
+        criterion_sets=(criterion_set,),
+        criteria=(criterion,),
+        scoring_scales=(scale,),
+        scores=(score,),
+        score_evidence_links=(link,),
+        moderation_records=(),
+        standards_result_projection=(),
+        privacy=PrivacyProjection(
+            classification="teacher_restricted",
+            audience_references=(),
+            policy_reference=None,
+            inherited_from=None,
+        ),
+    )
+    return with_semantic_projection_digest(candidate)
+
+
+class _Gate:
+    def __init__(self, status: str = "allowed") -> None:
+        self.status = status
+        self.requests = []
+
+    def authorize(self, request):
+        self.requests.append(request)
+        return AcademicResultArtifactAuthorizationDecision(self.status)
+
+
+def _loaded(
+    kind: str = "artifact_instance", revision: int = 7
+) -> ConcordLoadedRecordGraph:
+    return ConcordLoadedRecordGraph(
+        graph=_native_graph(kind),
+        snapshot_revision=revision,
+        snapshot_sha256="a" * 64,
+    )
+
+
+def test_historical_graph_loader_reads_exact_revision_without_current_pointer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    metadata = create_class_metadata(
+        "class-1",
+        "2026-2027",
+        created_at=datetime(2026, 8, 15, tzinfo=timezone.utc),
+    )
+    write_class_metadata_for_class(root, metadata)
+    fixture = json.loads(EVIDENCE_ONLY_FIXTURE.read_text(encoding="utf-8"))
+    activity = record_from_dict("activity", fixture["records"][0]["body"])
+    session = record_from_dict("session", fixture["records"][1]["body"])
+    assert isinstance(activity, Activity)
+    assert isinstance(session, Session)
+
+    commit_record_batch(
+        root,
+        activity.work_reference,
+        (activity, session),
+        expected_snapshot_revision=None,
+    )
+    changed = replace(session, notes="Synthetic snapshot two.")
+    commit_record_batch(
+        root,
+        activity.work_reference,
+        (changed,),
+        expected_snapshot_revision=1,
+    )
+
+    def forbidden_current(*_args, **_kwargs):
+        raise AssertionError("historical load must not consult current.json")
+
+    monkeypatch.setattr(storage_module, "load_current_snapshot", forbidden_current)
+    first = load_record_graph_at_snapshot(root, activity.work_reference, 1)
+    second = load_record_graph_at_snapshot(root, activity.work_reference, 2)
+
+    assert first.snapshot_revision == 1
+    assert first.graph.sessions == (session,)
+    assert second.snapshot_revision == 2
+    assert second.graph.sessions == (changed,)
+
+
+@pytest.mark.parametrize("status", ["denied", "unresolved"])
+def test_denied_or_unresolved_authorization_performs_no_native_io(
+    status: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def forbidden_loader(*_args, **_kwargs):
+        raise AssertionError("native I/O occurred before authorization")
+
+    monkeypatch.setattr(
+        artifacts_module,
+        "load_record_graph_at_snapshot",
+        forbidden_loader,
+    )
+    gate = _Gate(status)
+    with pytest.raises(ConcordAcademicResultArtifactAuthorizationError):
+        artifacts_module._resolve_authorized_academic_result_artifact_context(
+            "workspace-does-not-need-to-exist",
+            _manifest(),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=gate,
+        )
+    assert len(gate.requests) == 1
+    assert gate.requests[0].source_snapshot_revision == 7
+
+
+def test_gate_exception_fails_closed_before_native_io(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class BrokenGate:
+        def authorize(self, request):
+            raise RuntimeError("synthetic authorization outage")
+
+    def forbidden_loader(*_args, **_kwargs):
+        raise AssertionError("native I/O occurred after failed authorization")
+
+    monkeypatch.setattr(
+        artifacts_module,
+        "load_record_graph_at_snapshot",
+        forbidden_loader,
+    )
+    with pytest.raises(ConcordAcademicResultArtifactAuthorizationError):
+        artifacts_module._resolve_authorized_academic_result_artifact_context(
+            "workspace-does-not-need-to-exist",
+            _manifest(),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=BrokenGate(),
+        )
+
+
+def test_allowed_request_loads_only_manifest_historical_revision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+
+    def exact_loader(root, work, revision):
+        calls.append((root, work, revision))
+        return _loaded(revision=revision)
+
+    monkeypatch.setattr(
+        artifacts_module,
+        "load_record_graph_at_snapshot",
+        exact_loader,
+    )
+    gate = _Gate("allowed")
+    context = artifacts_module._resolve_authorized_academic_result_artifact_context(
+        "synthetic-root",
+        _manifest(revision=7),
+        "link-1",
+        purpose="consumer review",
+        authorization_gate=gate,
+    )
+
+    assert calls == [("synthetic-root", _work(), 7)]
+    assert context.loaded.snapshot_revision == 7
+    assert context.request.source_snapshot_revision == 7
+    assert context.artifact.artifact_instance_id == "artifact-1"
+    assert tuple(page.artifact_page_id for page in context.artifact.pages) == (
+        "page-1",
+        "page-2",
+    )
+
+
+def test_exact_historical_evidence_projection_must_match_manifest(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _native_graph()
+    changed_link = replace(
+        graph.score_evidence_links[0],
+        relevance_description="Different historical meaning.",
+    )
+    drifted = replace(graph, score_evidence_links=(changed_link,))
+    monkeypatch.setattr(
+        artifacts_module,
+        "load_record_graph_at_snapshot",
+        lambda *_args, **_kwargs: ConcordLoadedRecordGraph(
+            drifted, 7, "b" * 64
+        ),
+    )
+    with pytest.raises(
+        ConcordAcademicResultArtifactIntegrityError,
+        match="disagrees with the manifest projection",
+    ):
+        artifacts_module._resolve_authorized_academic_result_artifact_context(
+            "synthetic-root",
+            _manifest(),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=_Gate(),
+        )
+
+
+def test_missing_historical_score_or_link_fails_exactly_after_authorization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _native_graph()
+    without_score = replace(graph, score_records=())
+    monkeypatch.setattr(
+        artifacts_module,
+        "load_record_graph_at_snapshot",
+        lambda *_args, **_kwargs: ConcordLoadedRecordGraph(
+            without_score, 7, "c" * 64
+        ),
+    )
+    with pytest.raises(ConcordAcademicResultArtifactNotFoundError):
+        artifacts_module._resolve_authorized_academic_result_artifact_context(
+            "synthetic-root",
+            _manifest(),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=_Gate(),
+        )
+
+    without_link = replace(graph, score_evidence_links=())
+    monkeypatch.setattr(
+        artifacts_module,
+        "load_record_graph_at_snapshot",
+        lambda *_args, **_kwargs: ConcordLoadedRecordGraph(
+            without_link, 7, "d" * 64
+        ),
+    )
+    with pytest.raises(ConcordAcademicResultArtifactNotFoundError):
+        artifacts_module._resolve_authorized_academic_result_artifact_context(
+            "synthetic-root",
+            _manifest(),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=_Gate(),
+        )
+
+
+def test_artifact_page_evidence_resolves_exact_page_and_parent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        artifacts_module,
+        "load_record_graph_at_snapshot",
+        lambda *_args, **_kwargs: _loaded("artifact_page"),
+    )
+    context = artifacts_module._resolve_authorized_academic_result_artifact_context(
+        "synthetic-root",
+        _manifest("artifact_page"),
+        "link-1",
+        purpose="consumer review",
+        authorization_gate=_Gate(),
+    )
+    assert context.evidence_page is not None
+    assert context.evidence_page.artifact_page_id == "page-1"
+    assert context.artifact_instance.artifact_instance_id == "artifact-1"
+
+
+def test_author_and_subject_public_projections_remain_distinct(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        artifacts_module,
+        "load_record_graph_at_snapshot",
+        lambda *_args, **_kwargs: _loaded(),
+    )
+    context = artifacts_module._resolve_authorized_academic_result_artifact_context(
+        "synthetic-root",
+        _manifest(),
+        "link-1",
+        purpose="consumer review",
+        authorization_gate=_Gate(),
+    )
+    author_reference = context.authors[0].author_reference
+    assert author_reference is not None
+    assert hasattr(author_reference, "participant_id")
+    assert author_reference.participant_id == "student-author"
+    assert context.subjects[0].subject_reference.subject_id == "student-subject"
+    assert (
+        author_reference.participant_id
+        != context.subjects[0].subject_reference.subject_id
+    )
+
+
+def test_artifact_resolution_source_never_uses_current_snapshot_reader() -> None:
+    source = Path(artifacts_module.__file__).read_text(encoding="utf-8")
+    assert "load_current_snapshot" not in source
+    assert "load_current_record_graph" not in source
+    assert "registry_services" not in source
+    assert "academic_catalog" not in source
+
+
+
+def _routable_graph(kind: str = "artifact_instance") -> ConcordRecordGraph:
+    graph = _native_graph(kind)
+    pages = tuple(
+        replace(
+            page,
+            route_required=True,
+            route_id=f"route-{page.page_number}",
+            human_fallback=f"Synthetic route {page.page_number}",
+        )
+        for page in graph.artifact_pages
+    )
+    return replace(graph, artifact_pages=pages)
+
+
+def _retained_image_scan(
+    root: Path,
+    page: ArtifactPage,
+    *,
+    scan_reference_id: str,
+    source_scan_id: str,
+    filename: str,
+    color: tuple[int, int, int],
+) -> ScanReference:
+    path = root / "scans" / "source" / "2026-08-15" / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (60, 80), color).save(path)
+    assert page.route_id is not None
+    return ScanReference(
+        scan_reference_id=scan_reference_id,
+        activity_id="activity-1",
+        artifact_page_id=page.artifact_page_id,
+        route_id=page.route_id,
+        source_scan_id=source_scan_id,
+        source_page_number=1,
+        retained_source_relative_path=path.relative_to(root).as_posix(),
+        retained_source_sha256=hashlib.sha256(path.read_bytes()).hexdigest(),
+        created_provenance=_provenance(),
+    )
+
+
+def _retained_pdf_scan(
+    root: Path,
+    page: ArtifactPage,
+    *,
+    source_page_number: int,
+) -> ScanReference:
+    path = root / "scans" / "source" / "2026-08-15" / "multipage.pdf"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    first = Image.new("RGB", (60, 80), (255, 0, 0))
+    second = Image.new("RGB", (60, 80), (0, 255, 0))
+    try:
+        first.save(path, "PDF", save_all=True, append_images=[second])
+    finally:
+        first.close()
+        second.close()
+    assert page.route_id is not None
+    return ScanReference(
+        scan_reference_id="scan-ref-pdf",
+        activity_id="activity-1",
+        artifact_page_id=page.artifact_page_id,
+        route_id=page.route_id,
+        source_scan_id="source-pdf",
+        source_page_number=source_page_number,
+        retained_source_relative_path=path.relative_to(root).as_posix(),
+        retained_source_sha256=hashlib.sha256(path.read_bytes()).hexdigest(),
+        created_provenance=_provenance(),
+    )
+
+
+def _install_render_graph(
+    monkeypatch: pytest.MonkeyPatch,
+    graph: ConcordRecordGraph,
+) -> None:
+    monkeypatch.setattr(
+        artifacts_module,
+        "load_record_graph_at_snapshot",
+        lambda *_args, **_kwargs: ConcordLoadedRecordGraph(
+            graph=graph,
+            snapshot_revision=7,
+            snapshot_sha256="e" * 64,
+        ),
+    )
+
+
+def _pdf_page_count(content: bytes) -> int:
+    import pypdfium2
+
+    document = pypdfium2.PdfDocument(content)
+    try:
+        return len(document)
+    finally:
+        document.close()
+
+
+def _pdf_center_pixel(content: bytes) -> tuple[int, int, int]:
+    import pypdfium2
+
+    document = pypdfium2.PdfDocument(content)
+    try:
+        page = document[0]
+        try:
+            image = page.render(scale=1).to_pil().convert("RGB")
+            try:
+                return image.getpixel((image.width // 2, image.height // 2))
+            finally:
+                image.close()
+        finally:
+            page.close()
+    finally:
+        document.close()
+
+
+def test_authorized_artifact_instance_returns_deterministic_read_only_pdf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph()
+    page_one, page_two = graph.artifact_pages
+    scans = (
+        _retained_image_scan(
+            root,
+            page_one,
+            scan_reference_id="scan-ref-one",
+            source_scan_id="source-one",
+            filename="one.png",
+            color=(255, 0, 0),
+        ),
+        _retained_image_scan(
+            root,
+            page_two,
+            scan_reference_id="scan-ref-two",
+            source_scan_id="source-two",
+            filename="two.png",
+            color=(0, 255, 0),
+        ),
+    )
+    graph = replace(graph, scan_references=scans)
+    _install_render_graph(monkeypatch, graph)
+    before = tuple(sorted(path.relative_to(root) for path in root.rglob("*")))
+
+    first = artifacts_module.read_authorized_academic_result_artifact(
+        root,
+        _manifest(),
+        "link-1",
+        purpose="consumer review",
+        authorization_gate=_Gate(),
+    )
+    second = artifacts_module.read_authorized_academic_result_artifact(
+        root,
+        _manifest(),
+        "link-1",
+        purpose="consumer review",
+        authorization_gate=_Gate(),
+    )
+    after = tuple(sorted(path.relative_to(root) for path in root.rglob("*")))
+
+    assert first.content.startswith(b"%PDF")
+    assert first.media_type == "application/pdf"
+    assert first.sha256 == hashlib.sha256(first.content).hexdigest()
+    assert first.byte_size == len(first.content)
+    assert first.content == second.content
+    assert first.sha256 == second.sha256
+    assert _pdf_page_count(first.content) == 2
+    assert after == before
+    assert not any("assemblies" in path.parts for path in after)
+
+
+def test_artifact_page_reads_only_exact_physical_pdf_page(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph("artifact_page")
+    evidence_page = graph.artifact_pages[0]
+    scan = _retained_pdf_scan(root, evidence_page, source_page_number=2)
+    graph = replace(graph, scan_references=(scan,))
+    _install_render_graph(monkeypatch, graph)
+
+    result = artifacts_module.read_authorized_academic_result_artifact(
+        root,
+        _manifest("artifact_page"),
+        "link-1",
+        purpose="consumer review",
+        authorization_gate=_Gate(),
+    )
+
+    assert _pdf_page_count(result.content) == 1
+    red, green, blue = _pdf_center_pixel(result.content)
+    assert green > red + 100
+    assert green > blue + 100
+
+
+def test_artifact_instance_missing_returned_page_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph()
+    page_one = graph.artifact_pages[0]
+    scan = _retained_image_scan(
+        root,
+        page_one,
+        scan_reference_id="scan-ref-one",
+        source_scan_id="source-one",
+        filename="one.png",
+        color=(255, 0, 0),
+    )
+    graph = replace(graph, scan_references=(scan,))
+    _install_render_graph(monkeypatch, graph)
+
+    with pytest.raises(ConcordAcademicResultArtifactUnavailableError):
+        artifacts_module.read_authorized_academic_result_artifact(
+            root,
+            _manifest(),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=_Gate(),
+        )
+
+
+def test_multiple_returned_occurrences_fail_closed_without_scan_selector(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph("artifact_page")
+    page = graph.artifact_pages[0]
+    scans = (
+        _retained_image_scan(
+            root,
+            page,
+            scan_reference_id="scan-ref-one",
+            source_scan_id="source-one",
+            filename="one.png",
+            color=(255, 0, 0),
+        ),
+        _retained_image_scan(
+            root,
+            page,
+            scan_reference_id="scan-ref-two",
+            source_scan_id="source-two",
+            filename="two.png",
+            color=(0, 255, 0),
+        ),
+    )
+    graph = replace(graph, scan_references=scans)
+    _install_render_graph(monkeypatch, graph)
+
+    with pytest.raises(ConcordAcademicResultArtifactAmbiguityError) as caught:
+        artifacts_module.read_authorized_academic_result_artifact(
+            root,
+            _manifest("artifact_page"),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=_Gate(),
+        )
+    message = str(caught.value)
+    assert "scan-ref-one" not in message
+    assert "scan-ref-two" not in message
+
+
+def test_retained_source_digest_failure_maps_to_privacy_safe_integrity_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph("artifact_page")
+    page = graph.artifact_pages[0]
+    scan = _retained_image_scan(
+        root,
+        page,
+        scan_reference_id="scan-ref-one",
+        source_scan_id="source-one",
+        filename="private-source.png",
+        color=(10, 20, 30),
+    )
+    path = root / scan.retained_source_relative_path
+    path.write_bytes(b"tampered")
+    graph = replace(graph, scan_references=(scan,))
+    _install_render_graph(monkeypatch, graph)
+
+    with pytest.raises(ConcordAcademicResultArtifactIntegrityError) as caught:
+        artifacts_module.read_authorized_academic_result_artifact(
+            root,
+            _manifest("artifact_page"),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=_Gate(),
+        )
+    message = str(caught.value)
+    assert "private-source.png" not in message
+    assert str(root) not in message
+
+
+def test_non_return_expected_artifact_page_is_not_added_to_instance_pdf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph()
+    page_one, page_two = graph.artifact_pages
+    page_two = replace(page_two, return_expected=False)
+    scans = (
+        _retained_image_scan(
+            root,
+            page_one,
+            scan_reference_id="scan-ref-one",
+            source_scan_id="source-one",
+            filename="one.png",
+            color=(255, 0, 0),
+        ),
+        _retained_image_scan(
+            root,
+            page_two,
+            scan_reference_id="scan-ref-two",
+            source_scan_id="source-two",
+            filename="two.png",
+            color=(0, 255, 0),
+        ),
+    )
+    graph = replace(
+        graph,
+        artifact_pages=(page_one, page_two),
+        scan_references=scans,
+    )
+    _install_render_graph(monkeypatch, graph)
+
+    result = artifacts_module.read_authorized_academic_result_artifact(
+        root,
+        _manifest(),
+        "link-1",
+        purpose="consumer review",
+        authorization_gate=_Gate(),
+    )
+    assert _pdf_page_count(result.content) == 1
+
+
+def _external_evidence_manifest() -> AcademicResultManifest:
+    base = _manifest()
+    external_evidence = EvidenceReferenceProjection(
+        evidence_kind="scoreform_result",
+        owning_system="scoreform",
+        record_id="external-result-1",
+        contract_version="scoreform_result_v1",
+        source_publication_reference=None,
+        immutable_source_version="attempt-1",
+        locator=None,
+        subject_context=(),
+        moderation_requirement="not_required",
+    )
+    external_link = replace(
+        base.score_evidence_links[0],
+        evidence_reference=external_evidence,
+    )
+    candidate = replace(
+        base,
+        score_evidence_links=(external_link,),
+        projection=replace(
+            base.projection,
+            projection_digest="0" * 64,
+        ),
+    )
+    return with_semantic_projection_digest(candidate)
+
+
+def test_external_evidence_is_rejected_before_gate_or_native_io(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ForbiddenGate:
+        def authorize(self, request):
+            raise AssertionError("external evidence must not reach authorization")
+
+    def forbidden_loader(*_args, **_kwargs):
+        raise AssertionError("external evidence must not reach native I/O")
+
+    monkeypatch.setattr(
+        artifacts_module,
+        "load_record_graph_at_snapshot",
+        forbidden_loader,
+    )
+    with pytest.raises(ConcordAcademicResultArtifactValidationError):
+        artifacts_module.read_authorized_academic_result_artifact(
+            "workspace-does-not-need-to-exist",
+            _external_evidence_manifest(),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=ForbiddenGate(),
+        )
+
+
+def test_public_projection_excludes_superseded_and_unrelated_attribution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph = _native_graph()
+    predecessor_author = graph.artifact_authors[0]
+    current_author = replace(
+        predecessor_author,
+        artifact_author_id="author-2",
+        author_reference=ParticipantReference(
+            participant_kind="core_student",
+            participant_id="student-current-author",
+            owning_system="core",
+        ),
+        supersedes_artifact_author_id=predecessor_author.artifact_author_id,
+    )
+    unrelated_author = replace(
+        predecessor_author,
+        artifact_author_id="author-unrelated",
+        artifact_instance_id="artifact-unrelated",
+        author_reference=ParticipantReference(
+            participant_kind="core_student",
+            participant_id="student-unrelated-author",
+            owning_system="core",
+        ),
+    )
+    predecessor_subject = graph.artifact_subjects[0]
+    current_subject = replace(
+        predecessor_subject,
+        artifact_subject_id="subject-2",
+        subject_reference=SubjectReference(
+            subject_kind="core_student",
+            subject_id="student-current-subject",
+            owning_system="core",
+        ),
+        supersedes_artifact_subject_id=predecessor_subject.artifact_subject_id,
+    )
+    unrelated_subject = replace(
+        predecessor_subject,
+        artifact_subject_id="subject-unrelated",
+        artifact_instance_id="artifact-unrelated",
+        subject_reference=SubjectReference(
+            subject_kind="core_student",
+            subject_id="student-unrelated-subject",
+            owning_system="core",
+        ),
+    )
+    graph = replace(
+        graph,
+        artifact_authors=(
+            predecessor_author,
+            current_author,
+            unrelated_author,
+        ),
+        artifact_subjects=(
+            predecessor_subject,
+            current_subject,
+            unrelated_subject,
+        ),
+    )
+    monkeypatch.setattr(
+        artifacts_module,
+        "load_record_graph_at_snapshot",
+        lambda *_args, **_kwargs: ConcordLoadedRecordGraph(
+            graph=graph,
+            snapshot_revision=7,
+            snapshot_sha256="f" * 64,
+        ),
+    )
+
+    context = artifacts_module._resolve_authorized_academic_result_artifact_context(
+        "synthetic-root",
+        _manifest(),
+        "link-1",
+        purpose="consumer review",
+        authorization_gate=_Gate(),
+    )
+
+    assert tuple(item.artifact_author_id for item in context.authors) == ("author-2",)
+    assert tuple(
+        item.artifact_subject_id for item in context.subjects
+    ) == ("subject-2",)
+    author_reference = context.authors[0].author_reference
+    assert author_reference is not None
+    assert hasattr(author_reference, "participant_id")
+    assert author_reference.participant_id == "student-current-author"
+    assert context.subjects[0].subject_reference.subject_id == "student-current-subject"
+    assert context.authors[0].authorship_mode == "recorder_for_group"
+    assert context.authors[0].represented_group_id == "group-1"
+
+
+def _file_bytes_snapshot(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_authorized_read_leaves_every_existing_workspace_file_byte_identical(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph()
+    scans = tuple(
+        _retained_image_scan(
+            root,
+            page,
+            scan_reference_id=f"scan-ref-{page.page_number}",
+            source_scan_id=f"source-{page.page_number}",
+            filename=f"page-{page.page_number}.png",
+            color=(100 * page.page_number, 10, 20),
+        )
+        for page in graph.artifact_pages
+    )
+    graph = replace(graph, scan_references=scans)
+    _install_render_graph(monkeypatch, graph)
+    before = _file_bytes_snapshot(root)
+
+    artifacts_module.read_authorized_academic_result_artifact(
+        root,
+        _manifest(),
+        "link-1",
+        purpose="consumer review",
+        authorization_gate=_Gate(),
+    )
+
+    assert _file_bytes_snapshot(root) == before
+
+
+def test_verified_retained_bytes_are_the_exact_bytes_passed_to_renderer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph("artifact_page")
+    page = graph.artifact_pages[0]
+    scan = _retained_image_scan(
+        root,
+        page,
+        scan_reference_id="scan-ref-one",
+        source_scan_id="source-one",
+        filename="verified.png",
+        color=(255, 0, 0),
+    )
+    graph = replace(graph, scan_references=(scan,))
+    _install_render_graph(monkeypatch, graph)
+    source_path = root / scan.retained_source_relative_path
+    expected_source_bytes = source_path.read_bytes()
+
+    rendered_source_bytes: list[bytes] = []
+    original_render = artifact_rendering_module.render_retained_source_page
+
+    def record_rendered_source(source, source_page_number):
+        rendered_source_bytes.append(source.content)
+        return original_render(source, source_page_number)
+
+    monkeypatch.setattr(
+        artifact_rendering_module,
+        "render_retained_source_page",
+        record_rendered_source,
+    )
+
+    original_read_bytes = Path.read_bytes
+
+    def forbid_retained_path_reread(path: Path) -> bytes:
+        if path == source_path:
+            raise AssertionError(
+                "retained source must not be reopened through Path.read_bytes"
+            )
+        return original_read_bytes(path)
+
+    monkeypatch.setattr(Path, "read_bytes", forbid_retained_path_reread)
+
+    result = artifacts_module.read_authorized_academic_result_artifact(
+        root,
+        _manifest("artifact_page"),
+        "link-1",
+        purpose="consumer review",
+        authorization_gate=_Gate(),
+    )
+
+    assert rendered_source_bytes == [expected_source_bytes]
+    red, green, blue = _pdf_center_pixel(result.content)
+    assert red > green + 100
+    assert red > blue + 100
+
+
+def test_missing_historical_storage_error_does_not_expose_internal_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def secret_loader(*_args, **_kwargs):
+        raise ConcordStorageNotFoundError(
+            r"canonical object not found: C:\private\concord\state\7.json"
+        )
+
+    monkeypatch.setattr(
+        artifacts_module,
+        "load_record_graph_at_snapshot",
+        secret_loader,
+    )
+    with pytest.raises(ConcordAcademicResultArtifactNotFoundError) as caught:
+        artifacts_module._resolve_authorized_academic_result_artifact_context(
+            "synthetic-root",
+            _manifest(),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=_Gate(),
+        )
+
+    assert "private" not in str(caught.value).lower()
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+def test_missing_retained_source_public_error_has_no_private_exception_chain(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph("artifact_page")
+    page = graph.artifact_pages[0]
+    scan = _retained_image_scan(
+        root,
+        page,
+        scan_reference_id="scan-ref-one",
+        source_scan_id="source-one",
+        filename="private-missing.png",
+        color=(10, 20, 30),
+    )
+    source_path = root / scan.retained_source_relative_path
+    source_path.unlink()
+    graph = replace(graph, scan_references=(scan,))
+    _install_render_graph(monkeypatch, graph)
+
+    with pytest.raises(ConcordAcademicResultArtifactIntegrityError) as caught:
+        artifacts_module.read_authorized_academic_result_artifact(
+            root,
+            _manifest("artifact_page"),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=_Gate(),
+        )
+
+    assert "private-missing.png" not in str(caught.value)
+    assert str(root) not in str(caught.value)
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+def test_artifact_page_source_page_out_of_bounds_is_integrity_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph("artifact_page")
+    page = graph.artifact_pages[0]
+    scan = _retained_pdf_scan(root, page, source_page_number=3)
+    graph = replace(graph, scan_references=(scan,))
+    _install_render_graph(monkeypatch, graph)
+
+    with pytest.raises(ConcordAcademicResultArtifactIntegrityError):
+        artifacts_module.read_authorized_academic_result_artifact(
+            root,
+            _manifest("artifact_page"),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=_Gate(),
+        )
+
+
+def test_retained_source_symlink_is_rejected_without_path_disclosure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph("artifact_page")
+    page = graph.artifact_pages[0]
+
+    outside = tmp_path / "outside.png"
+    Image.new("RGB", (60, 80), (20, 30, 40)).save(outside)
+    link = root / "scans" / "source" / "2026-08-15" / "linked.png"
+    link.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        link.symlink_to(outside)
+    except (OSError, NotImplementedError) as error:
+        pytest.skip(f"filesystem cannot create source symlink: {error}")
+
+    assert page.route_id is not None
+    scan = ScanReference(
+        scan_reference_id="scan-ref-link",
+        activity_id="activity-1",
+        artifact_page_id=page.artifact_page_id,
+        route_id=page.route_id,
+        source_scan_id="source-link",
+        source_page_number=1,
+        retained_source_relative_path=link.relative_to(root).as_posix(),
+        retained_source_sha256=hashlib.sha256(outside.read_bytes()).hexdigest(),
+        created_provenance=_provenance(),
+    )
+    graph = replace(graph, scan_references=(scan,))
+    _install_render_graph(monkeypatch, graph)
+
+    with pytest.raises(ConcordAcademicResultArtifactIntegrityError) as caught:
+        artifacts_module.read_authorized_academic_result_artifact(
+            root,
+            _manifest("artifact_page"),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=_Gate(),
+        )
+
+    assert "linked.png" not in str(caught.value)
+    assert str(outside) not in str(caught.value)
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+def test_gate_exception_does_not_escape_deployment_policy_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class SecretGate:
+        def authorize(self, request):
+            raise RuntimeError("secret role-matrix detail")
+
+    monkeypatch.setattr(
+        artifacts_module,
+        "load_record_graph_at_snapshot",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("native I/O must not occur")
+        ),
+    )
+    with pytest.raises(ConcordAcademicResultArtifactAuthorizationError) as caught:
+        artifacts_module.read_authorized_academic_result_artifact(
+            "workspace-does-not-need-to-exist",
+            _manifest(),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=SecretGate(),
+        )
+
+    assert "secret role-matrix detail" not in str(caught.value)
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+def _issue32_standards_library() -> StandardsLibrary:
+    return StandardsLibrary(
+        standards=(
+            StandardDefinition(
+                standard_id="standard-1",
+                code="SYN.1",
+                source="synthetic",
+                short_name="Synthetic standard",
+                description="Privacy-safe standard used only by tests.",
+                available_modules=("concord",),
+            ),
+        ),
+        profiles=(
+            StandardsProfile(
+                profile_id="profile-1",
+                standards=("standard-1",),
+                title="Synthetic standards profile",
+            ),
+        ),
+    )
+
+
+def _workspace_file_bytes(root: Path) -> dict[str, bytes]:
+    return {
+        path.relative_to(root).as_posix(): path.read_bytes()
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_historical_graph_parses_the_exact_digest_verified_record_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    metadata = create_class_metadata(
+        "class-1",
+        "2026-2027",
+        created_at=datetime(2026, 8, 15, tzinfo=timezone.utc),
+    )
+    write_class_metadata_for_class(root, metadata)
+    fixture = json.loads(EVIDENCE_ONLY_FIXTURE.read_text(encoding="utf-8"))
+    activity = record_from_dict("activity", fixture["records"][0]["body"])
+    session = record_from_dict("session", fixture["records"][1]["body"])
+    assert isinstance(activity, Activity)
+    assert isinstance(session, Session)
+    commit_record_batch(
+        root,
+        activity.work_reference,
+        (activity, session),
+        expected_snapshot_revision=None,
+    )
+
+    target = record_revision_path(
+        root,
+        activity.work_reference,
+        "session",
+        session.session_id,
+        1,
+    )
+    _, envelope = storage_module.load_record_revision(
+        root,
+        activity.work_reference,
+        "session",
+        session.session_id,
+        1,
+    )
+    replacement = replace(session, notes="Unbound replacement record.")
+    replacement_bytes = serialize(
+        replace(envelope, body=record_to_dict(replacement))
+    )
+    original_reader = storage_module.read_canonical_bytes
+    swapped = False
+
+    def interposed_reader(path: Path, *, missing: bool = False) -> bytes:
+        nonlocal swapped
+        data = original_reader(path, missing=missing)
+        if Path(path) == target and not swapped:
+            swapped = True
+            target.write_bytes(replacement_bytes)
+        return data
+
+    monkeypatch.setattr(
+        storage_module,
+        "read_canonical_bytes",
+        interposed_reader,
+    )
+    loaded = load_record_graph_at_snapshot(root, activity.work_reference, 1)
+
+    assert swapped
+    assert loaded.snapshot_revision == 1
+    assert loaded.graph.sessions == (session,)
+    assert loaded.graph.sessions != (replacement,)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX openat race regression")
+def test_retained_source_swap_to_symlink_immediately_before_open_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph("artifact_page")
+    page = graph.artifact_pages[0]
+    scan = _retained_image_scan(
+        root,
+        page,
+        scan_reference_id="scan-ref-race",
+        source_scan_id="source-race",
+        filename="race.png",
+        color=(20, 30, 40),
+    )
+    source = root / scan.retained_source_relative_path
+    outside = tmp_path / "outside.png"
+    outside.write_bytes(source.read_bytes())
+    graph = replace(graph, scan_references=(scan,))
+    _install_render_graph(monkeypatch, graph)
+
+    original_open = artifact_rendering_module.os.open
+    swapped = False
+
+    def interposed_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if (
+            not swapped
+            and dir_fd is not None
+            and path == source.name
+            and flags & getattr(os, "O_NOFOLLOW", 0)
+        ):
+            source.unlink()
+            try:
+                source.symlink_to(outside)
+            except (OSError, NotImplementedError) as error:
+                pytest.skip(f"filesystem cannot create race symlink: {error}")
+            swapped = True
+        if dir_fd is None:
+            return original_open(path, flags, mode)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(artifact_rendering_module.os, "open", interposed_open)
+    with pytest.raises(ConcordAcademicResultArtifactIntegrityError) as caught:
+        artifacts_module.read_authorized_academic_result_artifact(
+            root,
+            _manifest("artifact_page"),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=_Gate(),
+        )
+
+    assert swapped
+    assert source.name not in str(caught.value)
+    assert str(outside) not in str(caught.value)
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX root no-follow race regression")
+def test_retained_workspace_root_swap_to_symlink_before_root_open_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph("artifact_page")
+    page = graph.artifact_pages[0]
+    scan = _retained_image_scan(
+        root,
+        page,
+        scan_reference_id="scan-ref-root-race",
+        source_scan_id="source-root-race",
+        filename="root-race.png",
+        color=(20, 30, 40),
+    )
+    graph = replace(graph, scan_references=(scan,))
+    _install_render_graph(monkeypatch, graph)
+
+    moved_root = tmp_path / "workspace-original"
+    original_open = artifact_rendering_module.os.open
+    root_component = Path(os.path.abspath(root)).name
+    swapped = False
+
+    def interposed_open(path, flags, mode=0o777, *, dir_fd=None):
+        nonlocal swapped
+        if (
+            not swapped
+            and dir_fd is not None
+            and path == root_component
+            and flags & getattr(os, "O_DIRECTORY", 0)
+            and flags & getattr(os, "O_NOFOLLOW", 0)
+        ):
+            root.rename(moved_root)
+            try:
+                root.symlink_to(moved_root, target_is_directory=True)
+            except (OSError, NotImplementedError) as error:
+                moved_root.rename(root)
+                pytest.skip(f"filesystem cannot create root race symlink: {error}")
+            swapped = True
+        if dir_fd is None:
+            return original_open(path, flags, mode)
+        return original_open(path, flags, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(artifact_rendering_module.os, "open", interposed_open)
+    with pytest.raises(ConcordAcademicResultArtifactIntegrityError) as caught:
+        artifacts_module.read_authorized_academic_result_artifact(
+            root,
+            _manifest("artifact_page"),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=_Gate(),
+        )
+
+    assert swapped
+    assert str(root) not in str(caught.value)
+    assert str(moved_root) not in str(caught.value)
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows root reparse regression")
+def test_retained_workspace_root_junction_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import subprocess
+
+    real_root = tmp_path / "workspace-real"
+    real_root.mkdir()
+    graph = _routable_graph("artifact_page")
+    page = graph.artifact_pages[0]
+    scan = _retained_image_scan(
+        real_root,
+        page,
+        scan_reference_id="scan-ref-root-junction",
+        source_scan_id="source-root-junction",
+        filename="root-junction.png",
+        color=(20, 30, 40),
+    )
+    graph = replace(graph, scan_references=(scan,))
+    _install_render_graph(monkeypatch, graph)
+
+    junction = tmp_path / "workspace"
+    created = subprocess.run(
+        ["cmd", "/d", "/c", "mklink", "/J", str(junction), str(real_root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if created.returncode != 0:
+        pytest.skip("filesystem cannot create a Windows directory junction")
+    try:
+        with pytest.raises(ConcordAcademicResultArtifactIntegrityError) as caught:
+            artifacts_module.read_authorized_academic_result_artifact(
+                junction,
+                _manifest("artifact_page"),
+                "link-1",
+                purpose="consumer review",
+                authorization_gate=_Gate(),
+            )
+    finally:
+        subprocess.run(
+            ["cmd", "/d", "/c", "rmdir", str(junction)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    assert str(junction) not in str(caught.value)
+    assert str(real_root) not in str(caught.value)
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+def test_pillow_decompression_bomb_is_sanitized_as_public_integrity_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root = tmp_path / "workspace"
+    root.mkdir()
+    graph = _routable_graph("artifact_page")
+    page = graph.artifact_pages[0]
+    scan = _retained_image_scan(
+        root,
+        page,
+        scan_reference_id="scan-ref-bomb",
+        source_scan_id="source-bomb",
+        filename="bomb.png",
+        color=(20, 30, 40),
+    )
+    graph = replace(graph, scan_references=(scan,))
+    _install_render_graph(monkeypatch, graph)
+
+    def bomb(*_args, **_kwargs):
+        raise Image.DecompressionBombError("private decoder dimensions")
+
+    monkeypatch.setattr(Image, "open", bomb)
+    with pytest.raises(ConcordAcademicResultArtifactIntegrityError) as caught:
+        artifacts_module.read_authorized_academic_result_artifact(
+            root,
+            _manifest("artifact_page"),
+            "link-1",
+            purpose="consumer review",
+            authorization_gate=_Gate(),
+        )
+
+    assert "private decoder dimensions" not in str(caught.value)
+    assert caught.value.__cause__ is None
+    assert caught.value.__context__ is None
+
+
+def test_representative_fixture_generates_and_reads_bounded_artifact_evidence(
+    tmp_path: Path,
+) -> None:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata(
+            "class-1",
+            "2026-2027",
+            created_at=datetime(2026, 8, 15, tzinfo=timezone.utc),
+        ),
+    )
+    fixture = json.loads(STANDARDS_FIXTURE.read_text(encoding="utf-8"))
+    records = tuple(
+        record_from_dict(item["record_kind"], item["body"])
+        for item in fixture["records"]
+    )
+    activity = next(item for item in records if isinstance(item, Activity))
+    assert activity.activity_id == "standards-activity"
+
+    proof = fixture["artifact_reader_proof"]
+    assert isinstance(proof, dict)
+    retained = root.joinpath(*proof["retained_source_relative_path"].split("/"))
+    retained.parent.mkdir(parents=True, exist_ok=True)
+    retained_bytes = base64.b64decode(REPRESENTATIVE_SOURCE_BASE64)
+    retained.write_bytes(retained_bytes)
+    assert hashlib.sha256(retained_bytes).hexdigest() == proof["retained_source_sha256"]
+
+    standards_library = _issue32_standards_library()
+    committed = commit_record_batch(
+        root,
+        activity.work_reference,
+        records,
+        expected_snapshot_revision=None,
+        standards_library=standards_library,
+    )
+    assert committed.snapshot_revision == 1
+    register_concord_academic_work(
+        root,
+        "class-1",
+        "standards-activity",
+        academic_intent="summative",
+        lifecycle="active",
+    )
+    generated = generate_academic_result_manifest(
+        GenerateAcademicResultManifestRequest(
+            class_id="class-1",
+            activity_id="standards-activity",
+            expected_snapshot_revision=1,
+            actor=WorkflowActor(actor_id="actor-1"),
+            revision_reason="initial",
+        ),
+        workspace_root=root,
+        standards_library=standards_library,
+        clock=lambda: datetime(2026, 8, 15, 18, 0, tzinfo=timezone.utc),
+    )
+    manifest = generated.manifest
+    assert manifest.projection.source_snapshot_revision == 1
+    assert {
+        item.evidence_reference.owning_system
+        for item in manifest.score_evidence_links
+    } >= {"concord", "scoreform", "quillan"}
+    typed_scale_id = proof["type_sensitive_scale_id"]
+    for value, value_type in (
+        (1, int),
+        (1.0, float),
+        ("1", str),
+        (True, bool),
+    ):
+        level = lookup_academic_result_scale_level(
+            manifest,
+            typed_scale_id,
+            value,
+        )
+        assert type(level.value) is value_type
+
+    session = next(item for item in records if isinstance(item, Session))
+    changed_session = replace(session, notes="Synthetic current snapshot two.")
+    advanced = commit_record_batch(
+        root,
+        activity.work_reference,
+        (changed_session,),
+        expected_snapshot_revision=1,
+        standards_library=standards_library,
+    )
+    assert advanced.snapshot_revision == 2
+    before = _workspace_file_bytes(root)
+
+    instance_result = artifacts_module.read_authorized_academic_result_artifact(
+        root,
+        manifest,
+        proof["artifact_instance_link_id"],
+        purpose="consumer review",
+        authorization_gate=_Gate(),
+    )
+    page_result = artifacts_module.read_authorized_academic_result_artifact(
+        root,
+        manifest,
+        proof["artifact_page_link_id"],
+        purpose="consumer review",
+        authorization_gate=_Gate(),
+    )
+
+    assert instance_result.source_snapshot_revision == 1
+    assert page_result.source_snapshot_revision == 1
+    assert instance_result.content.startswith(b"%PDF")
+    assert page_result.content.startswith(b"%PDF")
+    assert instance_result.content != retained_bytes
+    assert page_result.content != retained_bytes
+    assert _pdf_page_count(instance_result.content) == 1
+    assert _pdf_page_count(page_result.content) == 1
+    assert instance_result.artifact.artifact_instance_id == "artifact-1"
+    assert page_result.artifact.artifact_instance_id == "artifact-1"
+    assert instance_result.authors[0].author_reference is not None
+    assert (
+        instance_result.authors[0].author_reference.participant_id
+        == fixture["semantic_proof"]["author_id"]
+    )
+    assert instance_result.subjects[0].subject_reference.subject_id == (
+        fixture["semantic_proof"]["subject_id"]
+    )
+    assert (
+        instance_result.authors[0].author_reference.participant_id
+        != instance_result.subjects[0].subject_reference.subject_id
+    )
+    assert instance_result.artifact.group_id == "group-1"
+    assert not hasattr(instance_result.artifact, "retained_source_relative_path")
+    assert not hasattr(instance_result.artifact, "retained_source_sha256")
+    assert _workspace_file_bytes(root) == before

--- a/tests/test_academic_result_reader_issue32.py
+++ b/tests/test_academic_result_reader_issue32.py
@@ -1,0 +1,565 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef
+
+import concord.academic_result_reader as reader_module
+from concord.academic_result_manifest import (
+    ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+    ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+    AcademicResultManifest,
+    ActivityContextProjection,
+    CorePublicationReferenceProjection,
+    CriterionProjection,
+    CriterionSetProjection,
+    EvidenceLocatorProjection,
+    EvidenceReferenceProjection,
+    ManifestProjection,
+    ManifestRecordSet,
+    ModerationProjection,
+    PrivacyProjection,
+    PublicActor,
+    ScaleLevelProjection,
+    ScoreEvidenceLinkProjection,
+    ScoreProjection,
+    ScoringScaleProjection,
+    StandardsResultProjection,
+    SubjectReferenceProjection,
+    TargetReferenceProjection,
+    academic_result_manifest_to_bytes,
+    academic_result_manifest_to_dict,
+    with_semantic_projection_digest,
+)
+from concord.academic_result_reader import (
+    ConcordAcademicResultReaderDecodeError,
+    ConcordAcademicResultReaderNotFoundError,
+    ConcordAcademicResultReaderValidationError,
+    list_academic_result_score_evidence_links,
+    list_academic_result_scores_for_target,
+    lookup_academic_result_criterion,
+    lookup_academic_result_criterion_set,
+    lookup_academic_result_moderation,
+    lookup_academic_result_scale_level,
+    lookup_academic_result_score,
+    lookup_academic_result_score_evidence_link,
+    lookup_academic_result_scoring_scale,
+    read_academic_result_manifest,
+    validate_academic_result_manifest,
+)
+
+EXPECTED_PUBLIC = {
+    "AcademicResultManifest",
+    "ConcordAcademicResultReaderDecodeError",
+    "ConcordAcademicResultReaderError",
+    "ConcordAcademicResultReaderNotFoundError",
+    "ConcordAcademicResultReaderValidationError",
+    "CriterionProjection",
+    "CriterionSetProjection",
+    "JsonScalar",
+    "ModerationProjection",
+    "ScaleLevelProjection",
+    "ScoreEvidenceLinkProjection",
+    "ScoreProjection",
+    "ScoringScaleProjection",
+    "TargetReferenceProjection",
+    "list_academic_result_score_evidence_links",
+    "list_academic_result_scores_for_target",
+    "lookup_academic_result_criterion",
+    "lookup_academic_result_criterion_set",
+    "lookup_academic_result_moderation",
+    "lookup_academic_result_scale_level",
+    "lookup_academic_result_score",
+    "lookup_academic_result_score_evidence_link",
+    "lookup_academic_result_scoring_scale",
+    "read_academic_result_manifest",
+    "validate_academic_result_manifest",
+}
+
+
+def _time(hour: int) -> datetime:
+    return datetime(2026, 8, 15, hour, 0, tzinfo=timezone.utc)
+
+
+def _actor() -> PublicActor:
+    return PublicActor(
+        actor_kind="authorized_adult",
+        actor_id="teacher-1",
+        owning_system="concord",
+    )
+
+
+def _manifest() -> AcademicResultManifest:
+    work = ModuleWorkRef("concord", "class-1", "activity-1")
+    source = ModuleRecordRef(
+        module_id="concord",
+        record_kind="activity",
+        record_id="activity-1",
+        contract_version="concord_activity_v1",
+    )
+    teacher = _actor()
+    student = SubjectReferenceProjection(
+        subject_kind="core_student",
+        subject_id="student-1",
+        owning_system="core",
+        contract_version=None,
+    )
+    external = EvidenceReferenceProjection(
+        evidence_kind="scoreform_result",
+        owning_system="scoreform",
+        record_id="result-1",
+        contract_version="scoreform_result_v1",
+        source_publication_reference=CorePublicationReferenceProjection(
+            publication_id="pub_" + ("a" * 32),
+            publication_schema_version="1",
+        ),
+        immutable_source_version=None,
+        locator=EvidenceLocatorProjection(
+            page_number=1,
+            source_page_index=0,
+            section_label="Question 1",
+            row_label=None,
+            column_label=None,
+            participant_label=None,
+            session_id="session-1",
+        ),
+        subject_context=(student,),
+        moderation_requirement="required",
+    )
+    local_set = CriterionSetProjection(
+        criterion_set_id="set-local",
+        lineage_id="lineage-local",
+        revision=1,
+        criterion_set_kind="local",
+        scope="activity_specific",
+        criterion_ids=("criterion-local",),
+        status="active",
+        supersedes_criterion_set_id=None,
+        standards_profile_id=None,
+    )
+    standard_set = CriterionSetProjection(
+        criterion_set_id="set-standard",
+        lineage_id="lineage-standard",
+        revision=1,
+        criterion_set_kind="standard_backed",
+        scope="activity_specific",
+        criterion_ids=("criterion-standard",),
+        status="active",
+        supersedes_criterion_set_id=None,
+        standards_profile_id="profile-1",
+    )
+    local_criterion = CriterionProjection(
+        criterion_id="criterion-local",
+        criterion_set_id="set-local",
+        key="collaboration",
+        label="Collaboration",
+        definition="Demonstrates effective collaborative practice.",
+        criterion_kind="local",
+        supported_target_kinds=("concord_group",),
+        status="active",
+        standard_id=None,
+        alignment_standard_ids=(),
+        default_scoring_scale_id="scale-local",
+    )
+    standard_criterion = CriterionProjection(
+        criterion_id="criterion-standard",
+        criterion_set_id="set-standard",
+        key="analysis",
+        label="Analysis",
+        definition="Uses evidence to support analysis.",
+        criterion_kind="standard_backed",
+        supported_target_kinds=("core_student",),
+        status="active",
+        standard_id="standard-1",
+        alignment_standard_ids=(),
+        default_scoring_scale_id="scale-standard",
+    )
+    local_scale = ScoringScaleProjection(
+        scoring_scale_id="scale-local",
+        lineage_id="scale-lineage-local",
+        name="Typed local scale",
+        revision=1,
+        scale_type="teacher_defined",
+        levels=(
+            ScaleLevelProjection(1, "Integer", "Integer one.", None, None),
+            ScaleLevelProjection(1.0, "Float", "Float one.", None, None),
+            ScaleLevelProjection("1", "Text", "Text one.", None, None),
+            ScaleLevelProjection(True, "Boolean", "Boolean true.", None, None),
+        ),
+        status="active",
+        supersedes_scoring_scale_id=None,
+    )
+    standard_scale = ScoringScaleProjection(
+        scoring_scale_id="scale-standard",
+        lineage_id="scale-lineage-standard",
+        name="Standards scale",
+        revision=1,
+        scale_type="ordinal",
+        levels=(
+            ScaleLevelProjection(
+                "developing", "Developing", "Developing evidence.", 1, None
+            ),
+            ScaleLevelProjection(
+                "meets", "Meets", "Meets the criterion.", 2, None
+            ),
+        ),
+        status="active",
+        supersedes_scoring_scale_id=None,
+    )
+    group_target = TargetReferenceProjection(
+        target_kind="concord_group",
+        target_id="group-1",
+        owning_system="concord",
+        contract_version=None,
+    )
+    local_score = ScoreProjection(
+        score_record_id="score-local",
+        activity_id="activity-1",
+        session_id=None,
+        target_reference=group_target,
+        criterion_id="criterion-local",
+        score_kind="local",
+        standard_id=None,
+        scoring_scale_id="scale-local",
+        disposition="scored",
+        value=True,
+        basis="professional_judgment",
+        scorer=teacher,
+        scored_at=_time(13),
+        moderation_complete=True,
+        status_reason=None,
+        supersedes_score_record_id=None,
+        current_state="current",
+    )
+    standard_score = ScoreProjection(
+        score_record_id="score-standard",
+        activity_id="activity-1",
+        session_id="session-1",
+        target_reference=TargetReferenceProjection(
+            target_kind="core_student",
+            target_id="student-1",
+            owning_system="core",
+            contract_version=None,
+        ),
+        criterion_id="criterion-standard",
+        score_kind="standard_backed",
+        standard_id="standard-1",
+        scoring_scale_id="scale-standard",
+        disposition="scored",
+        value="meets",
+        basis="linked_evidence",
+        scorer=teacher,
+        scored_at=_time(13),
+        moderation_complete=True,
+        status_reason=None,
+        supersedes_score_record_id=None,
+        current_state="current",
+    )
+    moderation = ModerationProjection(
+        moderation_record_id="moderation-1",
+        target_evidence_reference=external,
+        target_subject_references=(student,),
+        status="accepted",
+        permitted_use="support_named_subject",
+        qualification=None,
+        supersedes_moderation_record_id=None,
+        current_state="current",
+    )
+    link = ScoreEvidenceLinkProjection(
+        score_evidence_link_id="link-1",
+        score_record_id="score-standard",
+        evidence_reference=external,
+        evidence_locator=external.locator,
+        subject_context=(student,),
+        relevance_description="Direct evidence for the selected criterion.",
+        significance="primary",
+        moderation_record_id="moderation-1",
+        status="active",
+        supersedes_score_evidence_link_id=None,
+    )
+    manifest = AcademicResultManifest(
+        record_type=ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+        contract_version=ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+        producer_module_id="concord",
+        generated_at=_time(14),
+        record_set=ManifestRecordSet("academic_results", 1),
+        work=work,
+        source_activity=source,
+        projection=ManifestProjection(
+            source_snapshot_revision=12,
+            projection_digest_algorithm="sha256",
+            projection_digest="0" * 64,
+            generated_by=teacher,
+            revision_reason="initial",
+        ),
+        activity_context=ActivityContextProjection(
+            activity_id="activity-1",
+            class_id="class-1",
+            title="Synthetic Collaborative Activity",
+            scoring_orientation="mixed",
+            standards_profile_id="profile-1",
+            focus_standard_ids=("standard-1",),
+            criterion_set_ids=("set-standard", "set-local"),
+        ),
+        criterion_sets=(local_set, standard_set),
+        criteria=(local_criterion, standard_criterion),
+        scoring_scales=(local_scale, standard_scale),
+        scores=(local_score, standard_score),
+        score_evidence_links=(link,),
+        moderation_records=(moderation,),
+        standards_result_projection=(
+            StandardsResultProjection("score-standard", "standard-1"),
+        ),
+        privacy=PrivacyProjection(
+            classification="teacher_and_subjects",
+            audience_references=(student,),
+            policy_reference=None,
+            inherited_from=None,
+        ),
+    )
+    return with_semantic_projection_digest(manifest)
+
+
+def _bytes() -> bytes:
+    return academic_result_manifest_to_bytes(_manifest())
+
+
+def test_public_reader_exports_exact_stable_surface() -> None:
+    assert set(reader_module.__all__) == EXPECTED_PUBLIC
+    assert reader_module.AcademicResultManifest is AcademicResultManifest
+
+
+def test_exact_canonical_manifest_reads_and_model_validation_is_identity() -> None:
+    manifest = _manifest()
+    restored = read_academic_result_manifest(
+        academic_result_manifest_to_bytes(manifest)
+    )
+    assert restored == manifest
+    assert validate_academic_result_manifest(restored) is restored
+
+    with pytest.raises(ConcordAcademicResultReaderValidationError):
+        validate_academic_result_manifest(object())  # type: ignore[arg-type]
+
+
+def test_reader_requires_exact_immutable_bytes_type() -> None:
+    with pytest.raises(
+        ConcordAcademicResultReaderValidationError, match="immutable bytes"
+    ):
+        read_academic_result_manifest("not bytes")  # type: ignore[arg-type]
+    with pytest.raises(
+        ConcordAcademicResultReaderValidationError, match="immutable bytes"
+    ):
+        read_academic_result_manifest(bytearray(_bytes()))  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        b"not json\n",
+        b"\xff\n",
+        b'{"record_type":"a","record_type":"b"}\n',
+        b'{"number":NaN}\n',
+    ],
+)
+def test_decode_failures_are_normalized_without_payload_leak(raw: bytes) -> None:
+    with pytest.raises(
+        ConcordAcademicResultReaderDecodeError, match="bytes are invalid"
+    ) as caught:
+        read_academic_result_manifest(raw)
+    assert str(caught.value) == "Academic-result manifest bytes are invalid."
+
+
+def test_semantic_invalid_bytes_are_decode_failures_without_value_leak() -> None:
+    data = academic_result_manifest_to_dict(_manifest())
+    data["producer_module_id"] = "private-producer-value"
+    raw = (
+        json.dumps(
+            data,
+            ensure_ascii=False,
+            allow_nan=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n"
+    ).encode("utf-8")
+
+    with pytest.raises(ConcordAcademicResultReaderDecodeError) as caught:
+        read_academic_result_manifest(raw)
+    assert "private-producer-value" not in str(caught.value)
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda raw: (
+            json.dumps(
+                json.loads(raw),
+                ensure_ascii=False,
+                allow_nan=False,
+                sort_keys=True,
+                indent=2,
+            )
+            + "\n"
+        ).encode("utf-8"),
+        lambda raw: (
+            json.dumps(
+                dict(reversed(list(json.loads(raw).items()))),
+                ensure_ascii=False,
+                allow_nan=False,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode("utf-8"),
+        lambda raw: raw.removesuffix(b"\n"),
+        lambda raw: raw.removesuffix(b"\n") + b" \n",
+        lambda raw: raw.replace(b".000000Z", b"Z", 1),
+    ],
+    ids=[
+        "alternate-whitespace",
+        "alternate-key-order",
+        "missing-final-newline",
+        "trailing-whitespace",
+        "timestamp-rendering",
+    ],
+)
+def test_semantically_equivalent_noncanonical_bytes_fail_validation(mutation) -> None:
+    with pytest.raises(
+        ConcordAcademicResultReaderValidationError, match="not canonical"
+    ):
+        read_academic_result_manifest(mutation(_bytes()))
+
+
+def test_exact_contract_lookups_return_embedded_objects() -> None:
+    manifest = _manifest()
+
+    assert lookup_academic_result_criterion_set(manifest, "set-local") is (
+        manifest.criterion_sets[0]
+    )
+    assert lookup_academic_result_criterion(manifest, "criterion-standard") is (
+        manifest.criteria[1]
+    )
+    assert lookup_academic_result_scoring_scale(manifest, "scale-local") is (
+        manifest.scoring_scales[0]
+    )
+    assert lookup_academic_result_score(manifest, "score-standard") is (
+        manifest.scores[1]
+    )
+    assert lookup_academic_result_score_evidence_link(manifest, "link-1") is (
+        manifest.score_evidence_links[0]
+    )
+    assert lookup_academic_result_moderation(manifest, "moderation-1") is (
+        manifest.moderation_records[0]
+    )
+
+
+def test_type_sensitive_scale_lookup_does_not_coerce_equal_looking_values() -> None:
+    manifest = _manifest()
+    expected_types = (int, float, str, bool)
+    values = (1, 1.0, "1", True)
+
+    for value, expected_type in zip(values, expected_types, strict=True):
+        level = lookup_academic_result_scale_level(
+            manifest,
+            "scale-local",
+            value,
+        )
+        assert type(level.value) is expected_type
+        assert type(level.value) is type(value)
+
+    with pytest.raises(ConcordAcademicResultReaderNotFoundError):
+        lookup_academic_result_scale_level(manifest, "scale-standard", 1)
+    with pytest.raises(ConcordAcademicResultReaderValidationError):
+        lookup_academic_result_scale_level(
+            manifest,
+            "scale-local",
+            float("nan"),
+        )
+
+
+def test_relation_lists_preserve_manifest_semantics_without_selection() -> None:
+    manifest = _manifest()
+    standard_links = list_academic_result_score_evidence_links(
+        manifest,
+        "score-standard",
+    )
+    local_links = list_academic_result_score_evidence_links(
+        manifest,
+        "score-local",
+    )
+    group_scores = list_academic_result_scores_for_target(
+        manifest,
+        manifest.scores[0].target_reference,
+    )
+
+    assert standard_links == (manifest.score_evidence_links[0],)
+    assert local_links == ()
+    assert group_scores == (manifest.scores[0],)
+    assert group_scores[0].target_reference.target_kind == "concord_group"
+    assert group_scores[0].value is True
+
+
+def test_missing_and_malformed_lookups_fail_privacy_safely() -> None:
+    manifest = _manifest()
+    secret = "missing-private-id"
+
+    with pytest.raises(ConcordAcademicResultReaderNotFoundError) as caught:
+        lookup_academic_result_score(manifest, secret)
+    assert secret not in str(caught.value)
+
+    for lookup in (
+        lookup_academic_result_criterion_set,
+        lookup_academic_result_criterion,
+        lookup_academic_result_scoring_scale,
+        lookup_academic_result_score,
+        lookup_academic_result_score_evidence_link,
+        lookup_academic_result_moderation,
+    ):
+        with pytest.raises(ConcordAcademicResultReaderValidationError):
+            lookup(manifest, "../unsafe")
+
+    with pytest.raises(ConcordAcademicResultReaderValidationError):
+        list_academic_result_scores_for_target(
+            manifest,
+            object(),  # type: ignore[arg-type]
+        )
+
+
+def test_reader_source_has_no_workspace_registry_catalog_or_consumer_boundary() -> None:
+    source = Path("concord/academic_result_reader.py").read_text(encoding="utf-8")
+    lowered = source.lower()
+    for forbidden in (
+        "meridian",
+        "vitrine",
+        "scoreform",
+        "quillan",
+        "portia",
+        "academic_result_manifest_generation",
+        "academic_result_publication",
+        "academic_work_registration",
+        "concord.storage",
+        "concord.workflows",
+        "publication_storage",
+        "academic_catalog",
+        "registry_services",
+    ):
+        assert forbidden not in lowered
+    assert "open(" not in source
+    assert "Path(" not in source
+
+
+def test_reader_public_functions_do_not_print(capsys) -> None:
+    manifest = read_academic_result_manifest(_bytes())
+    lookup_academic_result_criterion_set(manifest, "set-local")
+    lookup_academic_result_criterion(manifest, "criterion-local")
+    lookup_academic_result_scoring_scale(manifest, "scale-local")
+    lookup_academic_result_scale_level(manifest, "scale-local", True)
+    lookup_academic_result_score(manifest, "score-local")
+    list_academic_result_score_evidence_links(manifest, "score-local")
+    list_academic_result_scores_for_target(
+        manifest,
+        manifest.scores[0].target_reference,
+    )
+    assert capsys.readouterr() == ("", "")

--- a/tests/test_native_record_fixtures.py
+++ b/tests/test_native_record_fixtures.py
@@ -119,6 +119,7 @@ def test_integrated_fixture_is_a_valid_record_graph() -> None:
         "responsibility_assignment": "responsibility_assignments",
         "artifact_instance": "artifact_instances",
         "artifact_page": "artifact_pages",
+        "scan_reference": "scan_references",
         "artifact_author": "artifact_authors",
         "artifact_subject": "artifact_subjects",
         "artifact_review": "artifact_reviews",
@@ -144,3 +145,46 @@ def test_integrated_fixture_is_a_valid_record_graph() -> None:
         **{name: tuple(values) for name, values in collections.items()}
     )
     assert collect_record_graph_issues(graph) == ()
+
+def test_integrated_fixture_declares_issue32_artifact_reader_proof() -> None:
+    fixture = _load(FIXTURES / "standards_activity.json")
+    proof = fixture["artifact_reader_proof"]
+    assert isinstance(proof, dict)
+    assert proof["artifact_instance_link_id"] == "link-1"
+    assert proof["artifact_page_link_id"] == "link-page-1"
+    moderation_ids = {
+        item["body"]["moderation_record_id"]
+        for item in fixture["records"]
+        if isinstance(item, dict)
+        and item.get("record_kind") == "moderation_record"
+    }
+    assert "moderation-page-1" in moderation_ids
+    assert proof["type_sensitive_scale_id"] == "scale-typed"
+    assert proof["retained_source_relative_path"] == (
+        "scans/source/2026-08-15/standards-page-1.png"
+    )
+    assert len(proof["retained_source_sha256"]) == 64
+
+    records = fixture["records"]
+    assert isinstance(records, list)
+    kinds = [item["record_kind"] for item in records if isinstance(item, dict)]
+    assert "scan_reference" in kinds
+    links = [
+        item["body"]
+        for item in records
+        if isinstance(item, dict) and item.get("record_kind") == "score_evidence_link"
+    ]
+    assert {item["score_evidence_link_id"] for item in links} >= {
+        "link-1",
+        "link-page-1",
+        "link-scoreform-1",
+        "link-quillan-1",
+    }
+    scales = [
+        item["body"]
+        for item in records
+        if isinstance(item, dict) and item.get("record_kind") == "scoring_scale"
+    ]
+    typed = next(item for item in scales if item["scoring_scale_id"] == "scale-typed")
+    values = [level["value"] for level in typed["levels"]]
+    assert [type(value) for value in values] == [int, float, str, bool]

--- a/tests/test_workflow_artifact_assembly.py
+++ b/tests/test_workflow_artifact_assembly.py
@@ -632,7 +632,7 @@ def test_retained_source_symlink_is_rejected_when_supported(tmp_path: Path) -> N
         backup.rename(original)
         pytest.skip(f"filesystem cannot create a source symlink: {error}")
     loaded = load_current_record_graph(root, _work())
-    with pytest.raises(ArtifactAssemblyIntegrityError, match="link-like"):
+    with pytest.raises(ArtifactAssemblyIntegrityError):
         assemble_returned_artifact(
             AssembleArtifactRequest(
                 class_id="class-1",


### PR DESCRIPTION
## Summary

Implements #32 by exposing Concord's consumer-neutral Academic Result Manifest reader and a separate authorization-gated Artifact reader.

The implementation provides:

- a pure `concord.academic_result_reader` surface for canonical Concord Academic Result Manifest v1 bytes, whole-manifest validation, and exact producer-native lookups;
- a separate `concord.academic_result_artifacts` I/O boundary for authorized Concord Artifact evidence;
- exact type-sensitive Scoring Scale lookup preserving distinctions among values such as `1`, `1.0`, `"1"`, and `true`;
- exact Score, evidence-link, Moderation, Criterion, Criterion Set, Scale, and target lookup without downstream grading or portfolio policy;
- exact historical snapshot resolution from the manifest's `source_snapshot_revision`;
- bounded Artifact Page and Artifact Instance PDF representations;
- privacy-minimized public Author and Subject projections;
- a neutral retained-source rendering/integrity layer shared with the existing teacher Artifact assembly workflow;
- representative source-tree integration through `standards_activity.json`;
- documentation, package checks, and installed-wheel reader smoke coverage.

## Architectural boundaries

The implementation preserves the intended dependency direction:

- Concord remains authoritative for Concord manifest semantics, Scores, evidence, Moderation, Artifact identity, Author/Subject relationships, historical native state, retained-source lineage, and producer-approved Artifact projections.
- Core remains authoritative for publication discovery, Publication Records, manifest SHA-256 verification, catalog state, and shared routing/workspace primitives.
- Deployment/application code remains responsible for Artifact authorization.
- Concord does not import Meridian, Vitrine, ScoreForm, Quillan, or Portia.
- The reader does not choose an official/latest/best Score, calculate grades, infer mastery/proficiency, select portfolio candidates, or perform Core publication discovery.
- Manifest authorization does not imply Artifact authorization.

## Integrity and privacy hardening

The Artifact path is fail-closed:

- authorization occurs before native/workspace I/O;
- denied or unresolved authorization does not reveal Artifact existence;
- historical graph records are parsed from the exact bytes whose SHA-256 is bound by the selected snapshot;
- no current-state fallback is used for historical manifests;
- Concord-owned Artifact evidence only is dereferenced;
- external ScoreForm/Quillan evidence remains metadata only;
- retained-source reads are anchored to verified OS handles rather than pathname check/reopen sequences;
- POSIX traverses the workspace root and retained-source path descriptor-relatively with no-follow semantics;
- Windows verifies the original workspace-root directory handle and rejects reparse roots/junctions before source access;
- the exact bytes read through the verified handle are the bytes SHA-256 checked and rendered;
- Artifact Page reads expose only the represented physical page;
- Artifact Instance reads expose only the ordered return-expected pages;
- ambiguous retained occurrences fail closed;
- public Artifact exceptions sanitize internal filesystem/decoder details and exception chaining;
- private provenance notes, routing details, Scan Reference identifiers/paths/digests, raw scan bytes, private Score rationale, and private Moderation rationale are not exposed.

## Representative integration

The existing `standards_activity.json` fixture now exercises the public reader path with:

- Artifact Instance and Artifact Page evidence;
- retained Scan Reference lineage;
- distinct Artifact Author and Artifact Subject identities;
- separately moderated Artifact Instance/Page evidence;
- ScoreForm and Quillan metadata-only evidence;
- type-sensitive Scale values;
- Group Score semantics;
- a non-score disposition;
- Score supersession/history.

The integration test commits the representative fixture through canonical Concord storage, generates a real Academic Result Manifest, advances current native state, then reads both Artifact evidence kinds from the older manifest's exact historical snapshot without mutating the workspace.

## Validation

Final official repository validation against released `pds-core 0.6.0`:

- 529 passed;
- 9 expected platform-capability skips;
- Ruff passed;
- strict Mypy passed;
- documentation checks passed;
- sdist and wheel build passed;
- Twine checks passed;
- package-content validation passed;
- isolated installed-wheel smoke passed;
- `git diff --check` passed.

The final focused Slice 8 gate also passed 70 tests with 4 expected platform skips. The Windows workspace-root junction regression ran successfully rather than skipping.

## Independent review

A final adversarial Codex review initially identified four integrity/integration findings. All four were repaired and independently re-reviewed:

- historical snapshot digest binding — resolved;
- retained-source TOCTOU and workspace-root trust — resolved;
- Pillow/public error-boundary normalization — resolved;
- representative-fixture integration — resolved.

Final Codex verdict: **APPROVE**, with no material regressions identified.

## Deferred scope

The complete installed Activity → native Score → registration → manifest → Core publication/catalog → consumer read → authorized Artifact lifecycle remains intentionally assigned to #33.

Closes #32