### PR TITLE
Audit and prepare Concord 0.2.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,9 @@ jobs:
       - name: Check documentation
         run: python scripts/check_documentation.py
 
+      - name: Verify release compatibility
+        run: python scripts/verify_release_compatibility.py
+
       - name: Build and validate distributions
         shell: pwsh
         run: |
@@ -130,6 +133,7 @@ jobs:
           $concordWheel = $wheels[0].FullName
 
           python scripts/check_package.py "$concordWheel"
+          python scripts/verify_release_artifacts.py "$dist"
           python scripts/smoke_test_wheel.py `
             "$concordWheel" `
             "$env:PDS_CORE_WHEEL"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,20 +6,19 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## 0.2.0 - 2026-08-16
+
+### Added
+
 - Clean-wheel installed producer acceptance against the authenticated Core
   0.6.0 wheel, covering the complete synthetic collaborative Activity,
   retained Artifact, Score/non-score, registration, two-revision publication,
   Core verification, authorized historical Artifact, withdrawal, registry
   audit, and immutable-history lifecycle.
-
-### Fixed
-
-- Canonicalize derived Concord capability ordering when verifying Core
-  Publication Records, including historical reload for supersession, so mixed
-  `criterion_scores`, `standards_ratings`, and `moderated_scores` manifests
-  agree with Core's canonical capability tuple.
-
-### Added
 
 - A pure `concord.academic_result_reader` facade for exact canonical Academic
   Result Manifest v1 bytes, whole-model validation, exact producer-native
@@ -104,4 +103,12 @@ All notable changes to this project will be documented in this file.
   collaboration workflow contract.
 - Bare `concord` and `python -m concord` now launch the teacher-facing menu;
   `--help` and `--version` remain direct and read-only.
+
+
+### Fixed
+
+- Canonicalize derived Concord capability ordering when verifying Core
+  Publication Records, including historical reload for supersession, so mixed
+  `criterion_scores`, `standards_ratings`, and `moderated_scores` manifests
+  agree with Core's canonical capability tuple.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # pds-concord
 
 Concord is the Paper Data Suite module for paper-first, human-reviewed evidence
-created during collaborative classroom Activities. The repository is in v0.2.0
-development against the released `pds-core` v0.6.0 integration baseline.
+created during collaborative classroom Activities. Version 0.2.0 is qualified
+against the released `pds-core` v0.6.0 integration baseline. Official release
+artifacts are distributed through GitHub Releases only after independent review,
+hosted CI, merge, and exact-main requalification.
 
 The package now includes the collaboration-context workflow required to create
 and manage Activities, Sessions, Groups, contextual Group Memberships, Roles,
@@ -26,8 +28,9 @@ also publishes explicitly registered Activity results as immutable
 and the derived academic catalog. Concord now also exposes a consumer-neutral
 canonical manifest reader and a separately authorization-gated, bounded Artifact
 reader. Concord does **not** calculate Grades or proficiency; Meridian owns
-downstream grading/reporting policy. The complete clean-wheel producer-to-consumer
-acceptance path remains assigned to issue #33.
+downstream grading/reporting policy. The complete clean-wheel
+producer-to-consumer acceptance path established by issue #33 is part of the
+authoritative release qualification.
 
 ## Requirements and installation
 
@@ -42,6 +45,21 @@ python scripts/verify_core_wheel.py path\to\pds_core-0.6.0-py3-none-any.whl
 python -m pip install path\to\pds_core-0.6.0-py3-none-any.whl
 python -m pip install -e ".[dev]"
 ```
+
+An official v0.2.0 installation uses the authenticated Core wheel and the
+Concord wheel from the corresponding GitHub Release:
+
+```powershell
+python scripts/verify_core_wheel.py path\to\pds_core-0.6.0-py3-none-any.whl
+python -m pip install path\to\pds_core-0.6.0-py3-none-any.whl
+python -m pip install path\to\pds_concord-0.2.0-py3-none-any.whl
+python -m pip check
+concord --version
+```
+
+The Concord wheel and checksum file are distributed through the v0.2.0 GitHub
+Release and must be authenticated against its published `SHA256SUMS.txt`. Before
+those release assets exist, use the source-installation procedure above.
 
 ## Teacher menu
 
@@ -195,4 +213,8 @@ The implementation sequence is tracked by
 [umbrella issue #22](https://github.com/Paper-Data-Suite/pds-concord/issues/22).
 See the [documentation index](docs/README.md), the
 [accepted ADR index](docs/decisions/README.md), and the
-[foundation review](docs/design/foundation-review.md) for governing design.
+[foundation review](docs/design/foundation-review.md) for governing design. The
+[release audit](docs/v0.2.0-release-audit.md),
+[compatibility freeze](docs/v0.2.0-release-compatibility.md), and
+[four-phase release checklist](docs/release_checklist.md) record the v0.2.0
+release boundary.

--- a/RELEASE_NOTES_v0.2.0.md
+++ b/RELEASE_NOTES_v0.2.0.md
@@ -1,0 +1,37 @@
+# pds-concord 0.2.0
+
+Concord 0.2.0 delivers the first executable teacher-local collaborative
+Activity vertical slice on the released PDS Core 0.6 baseline.
+
+The release includes:
+
+- Activity and explicit Session workflows;
+- contextual Group, Membership, Role, and Responsibility history;
+- PDS2 non-student and multi-subject page routing;
+- returned Artifact assembly from exact retained-source lineage;
+- independent Artifact Author and Subject attribution;
+- explicit human Review and evidence Moderation;
+- teacher-controlled Criterion Sets, native Scoring Scales, criterion Scores,
+  non-score dispositions, evidence links, and Score revision history;
+- Core Academic Work Registration for collaborative Activities;
+- immutable, versioned Academic Result Manifest publication through Core,
+  including supersession, withdrawal, catalog reconciliation, and audit;
+- a consumer-neutral public manifest reader;
+- a separate authorization-gated historical Artifact reader; and
+- clean-wheel installed producer acceptance through the complete two-revision
+  lifecycle against authenticated `pds-core 0.6.0`.
+
+The frozen consumer handoff is intended for Meridian issue #23. Concord retains
+producer-native Group/student targets, local/standard-backed Scores, native
+Scale values, non-score states, Score history, and Moderation meaning; it does
+not calculate Grade or proficiency and does not choose consumer-preferred
+Scores.
+
+Group Planning (manual, random, similar-signal, and mixed-signal), Core
+`grouping_signal_set_v1`, Meridian grouping-signal export, Template and Packet
+Definitions/composition, a starter handout library, and broader packet-oriented
+teacher UI remain explicit v0.3.0 work.
+
+Distribution is through verified GitHub Release wheel/sdist assets rather than
+PyPI or another package index. Release-asset SHA-256 values are recorded from
+the exact qualified release commit and published alongside those assets.

--- a/concord/_version.py
+++ b/concord/_version.py
@@ -1,3 +1,3 @@
 """Authoritative Concord package version."""
 
-__version__ = "0.2.0.dev0"
+__version__ = "0.2.0"

--- a/concord/cli_app/parser.py
+++ b/concord/cli_app/parser.py
@@ -1507,7 +1507,7 @@ def build_parser() -> argparse.ArgumentParser:
         prog="concord",
         description=(
             "Concord is the Paper Data Suite module for paper-first collaborative "
-            "classroom evidence. The complete Activity workflow is being built as "
+            "classroom evidence. The complete Activity workflow is available through "
             "a shared direct-command and teacher-menu surface."
         ),
     )

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,9 +14,10 @@ Concord is the Paper Data Suite module responsible for paper-first evidence gene
 ## Current Status
 
 The architecture and conceptual-contract phase is complete. The skeptical
-foundation review concluded with the verdict `APPROVED WITH NONBLOCKING FOLLOW-UP`,
-and v0.2.0 implementation is now active against the released `pds-core` v0.6.0
-integration baseline.
+foundation review concluded with the verdict `APPROVED WITH NONBLOCKING FOLLOW-UP`.
+The v0.2.0 vertical slice and issue #33 installed acceptance are complete.
+Issue #34 governs the release audit, compatibility freeze, qualification, and
+release closeout against the released `pds-core` v0.6.0 integration baseline.
 
 The repository now contains:
 
@@ -66,6 +67,37 @@ publication workflows and the issue #32 consumer-neutral readers are complete.
 Concord declares separate routing and publication-producer entry points. The
 issue #33 full installed Activity-to-publication-to-consumer acceptance path is
 complete; issue #34 owns final release audit and closeout.
+
+### 21. v0.2.0 release audit
+
+[`v0.2.0-release-audit.md`](v0.2.0-release-audit.md)
+
+Records the implementation evidence and result for every accepted ADR, the #22
+exit-condition audit, privacy/policy observations, and deliberately deferred
+surfaces.
+
+### 22. v0.2.0 release compatibility
+
+[`v0.2.0-release-compatibility.md`](v0.2.0-release-compatibility.md)
+
+Freezes the exact distribution, Core range, Academic Work/Activity/manifest
+contracts, producer profile, reader, and separate Artifact authorization
+boundary expected by downstream consumers.
+
+### 23. Release checklist
+
+[`release_checklist.md`](release_checklist.md)
+
+Separates release-preparation PR work, exact post-merge qualification,
+tag/GitHub Release publication, and fresh-download verification.
+
+### Future v0.3.0 Group Planning / Template / Packet plan
+
+[`pds-group-planning-interoperability-development-plan.md`](pds-group-planning-interoperability-development-plan.md)
+
+This remains future v0.3.0 planning. It is not current v0.2.0 implementation
+and does not add production models, a Meridian dependency, or packet-oriented
+teacher UI in issue #34.
 
 ### 14. PDS2 Artifact Page integration
 
@@ -432,14 +464,13 @@ Concord consumes shared Core infrastructure and links to sibling modules without
 
 Simple Activities remain simple. Milestones, Work Items, dependencies, Events, subteams, Contribution Claims, Attachments, and similar structures are added only when the Activity requires them.
 
-## Active Implementation Phase
+## v0.2.0 Release-Closeout Contract
 
-The conceptual contracts and their representative validation are complete. The
-package/released-Core baseline, domain records, persistence, and teacher-local
-collaboration workflows are implemented. Work now continues through umbrella
-issue #22 with routing, Artifact management, Review and Moderation, scoring,
-publication, consumer compatibility, installed acceptance, and final release
-audit.
+The complete v0.2.0 teacher-local vertical slice and installed producer
+acceptance are implemented. Issue #34 governs the release audit, compatibility
+freeze, packaging qualification, exact-main qualification, release publication,
+and post-release verification. Tagging and GitHub Release publication occur
+only after review, hosted CI, merge, and exact-main requalification.
 
 Each implementation issue must preserve the accepted contract ownership,
 read-only import behavior, exact compatibility declarations, privacy-safe test

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -1,0 +1,63 @@
+# Concord v0.2.0 release checklist
+
+The qualification Core artifact is
+`pds_core-0.6.0-py3-none-any.whl`, SHA-256
+`be28c061b38463ef59ebc328ed1aa443767fe7f2c626babb769c2d8e5932f308`.
+No phase publishes to PyPI or another package index.
+
+## Phase A — release-preparation branch and PR
+
+- [x] start from reconciled post-#33 `main`
+- [x] authenticate the exact Core 0.6.0 wheel
+- [x] record the clean pre-edit authoritative baseline
+- [x] audit all 15 ADRs and the #22 exit conditions
+- [x] freeze consumer-facing contracts and promote source version to `0.2.0`
+- [x] add compatibility and exact wheel+sdist release validators
+- [ ] focused issue #34 tests pass
+- [ ] authoritative validator passes with `--allow-dirty`
+- [ ] release-preparation diff receives independent review
+- [ ] hosted Ubuntu/Windows, Python 3.11–3.14 CI passes
+- [ ] PR is squash-merged
+
+Tagging, release publication, authoritative hashes, and download verification
+cannot be completed on the release-preparation branch.
+
+## Phase B — post-merge exact-main qualification
+
+- [ ] reconcile local `main` and require `main == origin/main`
+- [ ] require a clean tree and record the exact merged commit
+- [ ] rerun the authoritative validator without `--allow-dirty`
+- [ ] build exactly `pds_concord-0.2.0-py3-none-any.whl` and
+  `pds_concord-0.2.0.tar.gz` from that commit
+- [ ] pass Twine, ordinary wheel validation, release artifact validation,
+  installed smoke, and #33 producer acceptance
+- [ ] compute `SHA256SUMS.txt` from these exact final artifacts
+- [ ] independently review the commit, filenames, and hashes
+
+Expected final assets are:
+
+```text
+pds_concord-0.2.0-py3-none-any.whl
+pds_concord-0.2.0.tar.gz
+SHA256SUMS.txt
+```
+
+## Phase C — tag and GitHub Release publication
+
+- [ ] create annotated or accepted project tag `v0.2.0` at the exact qualified commit
+- [ ] push the tag without rewriting an existing tag
+- [ ] create the GitHub Release from `v0.2.0` using `RELEASE_NOTES_v0.2.0.md`
+- [ ] upload the exact wheel, sdist, and `SHA256SUMS.txt`
+- [ ] verify uploaded asset hashes match Phase B
+- [ ] do not publish to a package index
+
+## Phase D — post-release fresh-download verification
+
+- [ ] download Core 0.6.0 and Concord 0.2.0 assets into a fresh directory
+- [ ] authenticate both wheels and the published Concord checksum file
+- [ ] install noneditably into a fresh virtual environment outside the checkout
+- [ ] run `pip check`, installed metadata/version/CLI checks, routing and
+  publication discovery, public reader import, and Artifact-boundary import
+- [ ] rerun the bounded installed smoke and #33 lifecycle when practical
+- [ ] record Meridian #23 handoff identities
+- [ ] only then close issue #34, umbrella #22, and the milestone

--- a/docs/v0.2.0-release-audit.md
+++ b/docs/v0.2.0-release-audit.md
@@ -1,0 +1,70 @@
+# Concord v0.2.0 implementation and ADR release audit
+
+**Audit date:** 2026-08-17
+**Release candidate version:** `pds-concord 0.2.0`
+**Qualification baseline:** released `pds-core 0.6.0`
+
+This is an audit of the implemented teacher-local collaborative Activity slice,
+not a claim that every optional concept in the conceptual architecture is part
+of v0.2.0. Evidence includes the native models and guarded storage, workflow
+services, public publication/reader modules, focused tests, and the clean-wheel
+installed lifecycle in `scripts/verify_installed_producer_acceptance.py`.
+
+## ADR results
+
+| ADR | v0.2.0 applicability and concrete evidence | Result | Deliberately deferred surface |
+| --- | --- | --- | --- |
+| 0001 — Concord Module Boundaries | Concord owns native collaboration/evidence records in `concord/models`, uses Core workspace/routing/publication APIs in `pds_module.py` and `pds_publication.py`, and has no sibling runtime dependency/import. Protected by `test_core_baseline.py`, `test_package_metadata.py`, and the release compatibility audit. | CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.2.0 | Concord Template/Packet definition workflows and future reporting modules. |
+| 0002 — Paper-First, Human-Reviewed Evidence | `artifact_page.py`, `scan_intake.py`, `artifact_review.py`, and `moderation.py` implement deterministic page handling followed by explicit human Review/Moderation; Scores require an explicit teacher action. Covered by PDS2, Artifact Review, and Score workflow suites. | CONFORMS | Automated handwriting/behavior interpretation remains prohibited. |
+| 0003 — Activities Require Explicit Sessions | Activity creation atomically creates its first durable Session; Session identity, ordering, lifecycle, and later additions are validated by `test_workflow_activity_session.py`. | CONFORMS | Optional markers/milestones remain outside this slice. |
+| 0004 — Contextual Groups, Memberships, and Roles | Separate immutable Group, Membership, and Role records retain Session context and supersession. `test_workflow_groups_assignments.py` proves reassignment history and prevents Group/student identity collapse. | CONFORMS | Manual/random/signal-based Group Planning is v0.3.0 work. |
+| 0005 — Separate Artifact Authors and Subjects | `models/artifacts.py`, `artifact_attribution.py`, and the public Artifact projection retain independent zero-to-many Authors and Subjects. Issue #29 cross-case/graph tests cover unknown, collective, multi-subject, correction, and Score-target separation. | CONFORMS | No deferred surface needed by the v0.2.0 Artifact slice. |
+| 0006 — Distinguish Roles, Responsibilities, Tasks, and Contributions | Role and Responsibility assignments are separate, contextual, historical records; neither creates authorship or a Score. Workflow and graph tests prove that boundary. | CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.2.0 | Work Items, task dependencies, contribution claims, and project-management surfaces. |
+| 0007 — Preserve Source Evidence and History | Core-retained source references, immutable native revisions/snapshots, Artifact assembly lineage, corrections, Score supersession, manifest revisions, and historical reads are covered by storage, Artifact, publication, and #33 immutability tests. | CONFORMS | None. |
+| 0008 — Separate Review, Moderation, Scoring, Grading, and Reporting | Distinct record/workflow modules preserve Review, Moderation, and Score semantics. No Grade/proficiency calculation exists; private rationale is omitted from the public manifest. Covered by `test_workflow_artifact_review.py`, `test_workflow_moderation.py`, and issue #31/#32 tests. | CONFORMS | Grade, reporting, proficiency, and consumer selection policy belong downstream. |
+| 0009 — Many-to-Many Evidence-to-Score Relationships | Durable `ScoreEvidenceLink` records independently connect exact Scores and Evidence References; neither subject nor evidence ownership becomes a Score target. Covered by issue #30 graph/CLI/menu tests and manifest projection tests. | CONFORMS | None. |
+| 0010 — Exceptional Evidence States Are Not Low Scores | Score validation requires `value is None` for every non-score disposition and an exact typed Scale value for `scored`; tests cover zero/type sensitivity and non-score persistence/publication. | CONFORMS | Downstream aggregation of dispositions is policy outside Concord. |
+| 0011 — Link External Artifacts Without Managing Source Systems | Evidence/record/publication references retain owning-system identity and immutable locators without importing or controlling external systems. Cross-producer verification fails closed. | CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.2.0 | Broader Attachment/External Reference authoring and source-system integrations. |
+| 0012 — Link ScoreForm and Quillan Without Duplication | Generic owning-system references and Core Publication verification permit links without runtime dependencies or copied workflows; package and release audits reject sibling dependencies/imports. | CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.2.0 | Teacher-facing ScoreForm/Quillan link-management workflows. |
+| 0013 — Keep Activity-Specific Structures Optional | The v0.2.0 model requires only Activity plus Session; Group, Role, Responsibility, Artifact, Review, Moderation, Criteria, and Scores appear only when used. Tests exercise sparse and richer graphs. | CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.2.0 | Activity Markers, Work Items, Events, Contributions, Templates, and Packets. |
+| 0014 — Make Standards-Based Scoring the Primary Concord Scoring Model | Standard-backed Scores retain exact student target, Focus Standard, Criterion, and native Scale; local Criteria/Scores remain explicitly local. Group Scores remain Group-target records. Issue #30 and #31 manifest tests cover both paths. | CONFORMS | Concord does not map native Scales to universal proficiency. |
+| 0015 — Publish Versioned Concord Academic Result Manifests Through the Core Registry | Explicit Academic Work Registration, canonical immutable manifest revisions, content-derived capabilities, Core Publication Records, supersession, withdrawal, reader, catalog audit, and historical verification are implemented and exercised by issue #31–#33 suites. | CONFORMS | Meridian projection and selection/reporting policy remain downstream. |
+
+Summary: **10 CONFORMS**, **5 CONFORMS — DEFERRED SURFACE NOT REQUIRED BY
+v0.2.0**, **0 BLOCKERS**.
+
+## Milestone #22 exit-condition audit
+
+- **Installable:** the wheel and sdist build from a clean copied source tree;
+  Twine, ordinary wheel inspection, isolated noneditable installation, and
+  installed provenance checks are part of the authoritative validator.
+- **Collaborative Activity:** the same native services support Activity,
+  explicit Session, Group, Membership, Role, Responsibility, PDS2 return,
+  Artifact assembly/attribution/review, Moderation, and Score workflows. The
+  #33 harness exercises the complete installed lifecycle without duplicating it
+  here.
+- **PDS2 non-student/multi-subject support:** route identity is a neutral
+  `ModuleWorkRef`; route targets identify Artifact Pages, while explicit typed
+  Subjects may be Group, student, Session, Activity, or multiple subjects.
+- **Identity separation:** tests and validators preserve Author != Subject,
+  Subject != Score target, route target != Score target, Membership != Author or
+  Subject, Membership != individual Score, and Group Score != individual Score.
+- **Academic-result publication/consumption:** registration, two immutable
+  manifest/publication revisions, Core verification, public byte reader,
+  separately authorized Artifact read, withdrawal, final catalog, audit, and
+  historical verification pass from installed wheels.
+- **No Grade calculation:** Concord records producer-native criterion Scores and
+  non-score states only. It calculates no Grade, proficiency/mastery,
+  reassessment selection, or report/portfolio policy.
+
+## Privacy and policy observations
+
+Public manifests minimize display text and omit private Review/Moderation
+rationale, native paths, retained bytes, authorization reasons, and unpublished
+records. Manifest authorization does not authorize Artifact access: the latter
+requires `AcademicResultArtifactAuthorizationGate` before native workspace I/O.
+Historical native evidence, manifests, and Publication Records remain immutable.
+
+No release blocker was found. This audit does not claim the v0.3.0 Group
+Planning, Template, Packet, library, or broader packet-oriented UI work is
+implemented.

--- a/docs/v0.2.0-release-compatibility.md
+++ b/docs/v0.2.0-release-compatibility.md
@@ -1,0 +1,77 @@
+# Concord v0.2.0 release compatibility boundary
+
+This document freezes the external producer/reader identity qualified for
+Concord issue #34 and expected by Meridian issue #23.
+
+## Exact release identity
+
+| Boundary | Frozen value |
+| --- | --- |
+| Distribution | `pds-concord` |
+| Version | `0.2.0` |
+| Import package / producer module | `concord` |
+| Publication kind | `academic_result_set` |
+| Runtime Core dependency | `pds-core>=0.6,<0.7` |
+| Qualification Core | `pds-core 0.6.0` |
+| Requires-Python | `>=3.11` |
+| Qualification matrix | Python `3.11`–`3.14` on Ubuntu and Windows |
+| Academic Work contract / kind | `concord_academic_work_v1` / `collaborative_activity` |
+| Required source record | `module_id=concord`, `record_kind=activity`, `contract_version=concord_activity_v1`, `allows_missing_source_record=false` |
+| Manifest contract / record type | `concord_academic_result_manifest_v1` / `concord_academic_result_manifest` |
+| Record set | `academic_results` |
+| Maximum profile capabilities | `criterion_scores`, `moderated_scores`, `standards_ratings` |
+
+The exact Core qualification artifact is `pds_core-0.6.0-py3-none-any.whl`, SHA-256 `be28c061b38463ef59ebc328ed1aa443767fe7f2c626babb769c2d8e5932f308`.
+
+Concrete Publication Record capabilities remain content-derived. The producer
+profile lists the maximum supported vocabulary; it does not require every
+manifest to contain all three capabilities.
+
+## Discovery and public APIs
+
+- Routing entry point: `paper_data_suite.modules`,
+  `concord = concord.pds_module:get_module_profile`.
+- Publication entry point: `paper_data_suite.publication_producers`,
+  `concord = concord.pds_publication:get_publication_producer_profile`.
+- Public manifest reader: `concord.academic_result_reader`,
+  `read_academic_result_manifest(bytes)`.
+- Separate Artifact surface: `concord.academic_result_artifacts`, with
+  `AcademicResultArtifactAuthorizationGate` required by
+  `read_authorized_academic_result_artifact(...)`.
+
+The manifest reader consumes exact canonical immutable bytes, performs no
+workspace lookup or write, and exposes represented Score history without
+choosing latest, best, highest, or official evidence. Artifact bytes require a
+separate authorization decision and exact historical native snapshot.
+
+## Frozen semantic invariants
+
+```text
+Group Score != individual Score
+Group Membership != individual Score
+
+Artifact Author != Artifact Subject
+Artifact Subject != Score target
+route target != Score target
+
+local Score != standard-backed Score
+non-score disposition != zero
+native Scale != universal proficiency scale
+producer Score history != consumer selection policy
+
+Review != Moderation != Score != Grade
+Moderation != proficiency
+
+manifest authorization != Artifact authorization
+```
+
+A standard-backed Score retains the exact student target, Standard, Criterion,
+and native Scale. A local Criterion/Score remains local. Where the contract
+requires a non-score value, it remains `None`; no zero or minimum Scale level is
+synthesized. Private Review/Moderation rationale is not public manifest data.
+
+Dependency direction is `Concord -> Core`. Concord has no dependency on
+Meridian, and Meridian is not a producer API or compatibility layer. Once the
+frozen Concord contract above is released, any remaining generic
+representation mismatch belongs to Meridian issue #23 unless it demonstrates a
+genuine Concord producer defect.

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -29,6 +29,12 @@ PROPOSED_CHAIN = (
 PUBLICATION_DOC = ROOT / "docs" / "implementation" / "academic-result-publication.md"
 READER_DOC = ROOT / "docs" / "implementation" / "academic-result-reader.md"
 ACCEPTANCE_DOC = ROOT / "docs" / "implementation" / "installed-end-to-end-acceptance.md"
+RELEASE_DOCUMENTS = (
+    ROOT / "docs" / "v0.2.0-release-audit.md",
+    ROOT / "docs" / "v0.2.0-release-compatibility.md",
+    ROOT / "docs" / "release_checklist.md",
+)
+FUTURE_PLAN = ROOT / "docs" / "pds-group-planning-interoperability-development-plan.md"
 STALE_PUBLICATION_PHRASES = (
     "still does **not** publish academic results",
     "publication remains absent until issue #31",
@@ -140,6 +146,30 @@ def check_documentation() -> None:
     for phrase in STALE_ACTIVE_PHRASES:
         if phrase in active_text:
             failures.append(f"Stale active-status phrase remains: {phrase!r}")
+    docs_index = (ROOT / "docs" / "README.md").read_text(encoding="utf-8")
+    for release_document in RELEASE_DOCUMENTS:
+        if not release_document.is_file():
+            relative = release_document.relative_to(ROOT)
+            failures.append(
+                f"Required release document is missing: {relative}"
+            )
+        elif release_document.name not in docs_index:
+            failures.append(
+                f"Documentation index does not link {release_document.name}."
+            )
+    if not FUTURE_PLAN.is_file():
+        failures.append("Future v0.3.0 Group Planning plan is missing.")
+    else:
+        future_text = FUTURE_PLAN.read_text(encoding="utf-8")
+        if "v0.3.0" not in future_text or "future" not in future_text.lower():
+            failures.append(
+                "Group Planning interoperability plan must remain classified as "
+                "future v0.3.0 work."
+            )
+        if FUTURE_PLAN.name not in docs_index:
+            failures.append(
+                "Documentation index does not retain the future v0.3.0 plan."
+            )
     if not PUBLICATION_DOC.is_file():
         failures.append(
             "Academic result publication implementation document is missing."
@@ -188,9 +218,9 @@ def check_documentation() -> None:
     ).read_text(encoding="utf-8")
     if "Released Core baseline:** `pds-core` 0.6.0" not in integration:
         failures.append("Integration requirements do not identify Core v0.6.0.")
-    contracts = (
-        ROOT / "docs" / "design" / "conceptual-data-contracts.md"
-    ).read_text(encoding="utf-8")
+    contracts = (ROOT / "docs" / "design" / "conceptual-data-contracts.md").read_text(
+        encoding="utf-8"
+    )
     failures.extend(
         status_failures(
             contracts,

--- a/scripts/check_package.py
+++ b/scripts/check_package.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from packaging.requirements import Requirement
 
 EXPECTED_CORE_REQUIREMENT = Requirement("pds-core>=0.6,<0.7")
+EXPECTED_VERSION = "0.2.0"
 FORBIDDEN_PREFIXES = (
     "tests/",
     "pds_core/",
@@ -65,6 +66,8 @@ def validate_wheel(path: str | Path) -> None:
 
     if metadata["Name"] != "pds-concord":
         raise PackageValidationError("Distribution name must be pds-concord.")
+    if metadata["Version"] != EXPECTED_VERSION:
+        raise PackageValidationError(f"Version must be {EXPECTED_VERSION}.")
     if metadata["Requires-Python"] != ">=3.11":
         raise PackageValidationError("Requires-Python must be >=3.11.")
     requirements = [Requirement(item) for item in metadata.get_all("Requires-Dist", [])]

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -52,6 +52,7 @@ def validate(core_wheel: Path, *, allow_dirty: bool) -> None:
             [python, "-m", "ruff", "check", "."],
             [python, "-m", "mypy"],
             [python, "scripts/check_documentation.py"],
+            [python, "scripts/verify_release_compatibility.py"],
         ]
         for command in commands:
             print("+", subprocess.list2cmdline(command), flush=True)
@@ -80,6 +81,7 @@ def validate(core_wheel: Path, *, allow_dirty: bool) -> None:
         if len(wheels) != 1:
             raise RuntimeError("Expected exactly one built Concord wheel.")
         _run([python, "scripts/check_package.py", str(wheels[0])])
+        _run([python, "scripts/verify_release_artifacts.py", str(dist)])
         _run([python, "scripts/smoke_test_wheel.py", str(wheels[0]), str(core_wheel)])
     _run(["git", "diff", "--check"])
     if not allow_dirty:

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -1,0 +1,492 @@
+"""Validate the exact Concord v0.2.0 wheel and source distribution."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import configparser
+import stat
+import tarfile
+import tomllib
+import zipfile
+from email import policy
+from email.message import Message
+from email.parser import Parser
+from pathlib import Path, PurePosixPath
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.utils import canonicalize_name
+from packaging.version import InvalidVersion, Version
+
+RELEASE_VERSION = "0.2.0"
+EXPECTED_WHEEL = "pds_concord-0.2.0-py3-none-any.whl"
+EXPECTED_SDIST = "pds_concord-0.2.0.tar.gz"
+EXPECTED_DIST_INFO = "pds_concord-0.2.0.dist-info"
+EXPECTED_CORE_SPECIFIER = SpecifierSet(">=0.6,<0.7")
+EXPECTED_PYTHON_SPECIFIER = SpecifierSet(">=3.11")
+EXPECTED_ENTRY_POINTS = {
+    "console_scripts": {"concord": "concord.cli:main"},
+    "paper_data_suite.modules": {"concord": "concord.pds_module:get_module_profile"},
+    "paper_data_suite.publication_producers": {
+        "concord": "concord.pds_publication:get_publication_producer_profile"
+    },
+}
+REQUIRED_WHEEL_FILES = frozenset(
+    {
+        "concord/__init__.py",
+        "concord/_version.py",
+        "concord/pds_contract.py",
+        "concord/pds_module.py",
+        "concord/pds_publication.py",
+        "concord/academic_result_manifest.py",
+        "concord/academic_result_reader.py",
+        "concord/academic_result_artifacts.py",
+        "concord/artifact_rendering.py",
+        "concord/py.typed",
+    }
+)
+REQUIRED_SDIST_FILES = REQUIRED_WHEEL_FILES | frozenset({"pyproject.toml"})
+FORBIDDEN_PARTS = frozenset(
+    {
+        ".git",
+        ".venv",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        "__pycache__",
+        "build",
+        "dist",
+        "classes",
+        "local_outputs",
+        "scans",
+        "scans_inbox",
+        "credentials",
+    }
+)
+FORBIDDEN_SIBLING_PARTS = frozenset(
+    {
+        "pds_core",
+        "pds-core",
+        "scoreform",
+        "pds_scoreform",
+        "pds-scoreform",
+        "quillan",
+        "pds_quillan",
+        "pds-quillan",
+        "portia",
+        "pds_portia",
+        "pds-portia",
+        "meridian",
+        "pds_meridian",
+        "pds-meridian",
+        "vitrine",
+        "pds_vitrine",
+        "pds-vitrine",
+    }
+)
+FORBIDDEN_FILENAMES = frozenset(
+    {".env", "coverage.xml", "results.csv", "sha256sums.txt"}
+)
+FORBIDDEN_SUFFIXES = frozenset({".pyc", ".pyo", ".pem", ".key", ".p12"})
+SIBLING_DISTRIBUTIONS = frozenset(
+    {
+        "pds-scoreform",
+        "scoreform",
+        "pds-quillan",
+        "quillan",
+        "pds-portia",
+        "portia",
+        "pds-meridian",
+        "meridian",
+        "pds-vitrine",
+        "vitrine",
+    }
+)
+
+
+class ArtifactValidationError(RuntimeError):
+    """Raised when release artifacts violate the frozen boundary."""
+
+
+class _CaseSensitiveConfigParser(configparser.ConfigParser):
+    def optionxform(self, optionstr: str) -> str:
+        return optionstr
+
+
+def normalized_member(name: str) -> PurePosixPath:
+    """Normalize and reject absolute or parent-traversing archive members."""
+    member = PurePosixPath(name.replace("\\", "/"))
+    if member.is_absolute() or ".." in member.parts or not member.parts:
+        raise ArtifactValidationError(f"unsafe archive member: {name}")
+    if member.parts[0].endswith(":"):
+        raise ArtifactValidationError(f"unsafe archive member: {name}")
+    return member
+
+
+def validate_member_names(names: list[str]) -> None:
+    if len(names) != len(set(names)):
+        raise ArtifactValidationError("artifact contains duplicate member names")
+    for name in names:
+        member = normalized_member(name)
+        lowered_parts = {part.lower() for part in member.parts}
+        lowered_name = member.name.lower()
+        siblings = sorted(lowered_parts & FORBIDDEN_SIBLING_PARTS)
+        if siblings:
+            raise ArtifactValidationError(
+                f"artifact bundles Core/sibling package {siblings[0]}: {name}"
+            )
+        if lowered_parts & FORBIDDEN_PARTS:
+            raise ArtifactValidationError(f"forbidden build/workspace member: {name}")
+        if lowered_name in FORBIDDEN_FILENAMES:
+            raise ArtifactValidationError(
+                f"forbidden generated/credential member: {name}"
+            )
+        if member.suffix.lower() in FORBIDDEN_SUFFIXES:
+            raise ArtifactValidationError(f"forbidden cache/credential member: {name}")
+        if lowered_name.startswith("debug_") or lowered_name.endswith("_results.csv"):
+            raise ArtifactValidationError(f"forbidden generated member: {name}")
+
+
+def _single_metadata_value(message: Message, field: str, label: str) -> str:
+    values = message.get_all(field, [])
+    if len(values) != 1:
+        raise ArtifactValidationError(
+            f"{label} metadata must contain exactly one {field} field"
+        )
+    return str(values[0]).strip()
+
+
+def validate_requirements(values: list[str], label: str) -> None:
+    requirements: list[Requirement] = []
+    for value in values:
+        try:
+            requirements.append(Requirement(value))
+        except InvalidRequirement as error:
+            raise ArtifactValidationError(
+                f"{label} has invalid Requires-Dist: {value}"
+            ) from error
+    core = [
+        item
+        for item in requirements
+        if canonicalize_name(item.name) == canonicalize_name("pds-core")
+    ]
+    if len(core) != 1 or core[0].specifier != EXPECTED_CORE_SPECIFIER:
+        raise ArtifactValidationError(
+            f"{label} must require exactly pds-core>=0.6,<0.7"
+        )
+    if core[0].url is not None or core[0].marker is not None or core[0].extras:
+        raise ArtifactValidationError(
+            f"{label} pds-core requirement cannot use URL, marker, or extras"
+        )
+    siblings = sorted(
+        item.name
+        for item in requirements
+        if canonicalize_name(item.name)
+        in {canonicalize_name(name) for name in SIBLING_DISTRIBUTIONS}
+    )
+    if siblings:
+        raise ArtifactValidationError(
+            f"{label} has sibling runtime dependencies: " + ", ".join(siblings)
+        )
+
+
+def validate_package_metadata(text: str, label: str) -> None:
+    message = Parser(policy=policy.default).parsestr(text)
+    if canonicalize_name(
+        _single_metadata_value(message, "Name", label)
+    ) != canonicalize_name("pds-concord"):
+        raise ArtifactValidationError(f"{label} distribution name must be pds-concord")
+    raw_version = _single_metadata_value(message, "Version", label)
+    try:
+        if Version(raw_version) != Version(RELEASE_VERSION):
+            raise ArtifactValidationError(f"{label} version must be {RELEASE_VERSION}")
+    except InvalidVersion as error:
+        raise ArtifactValidationError(
+            f"{label} version is invalid: {raw_version}"
+        ) from error
+    raw_python = _single_metadata_value(message, "Requires-Python", label)
+    try:
+        python_specifier = SpecifierSet(raw_python)
+    except InvalidSpecifier as error:
+        raise ArtifactValidationError(
+            f"{label} Requires-Python is invalid: {raw_python}"
+        ) from error
+    if python_specifier != EXPECTED_PYTHON_SPECIFIER:
+        raise ArtifactValidationError(f"{label} Requires-Python must be exactly >=3.11")
+    validate_requirements(
+        [str(value) for value in message.get_all("Requires-Dist", [])], label
+    )
+
+
+def validate_entry_points(text: str, label: str) -> None:
+    parser = _CaseSensitiveConfigParser(interpolation=None, strict=True)
+    try:
+        parser.read_string(text)
+    except configparser.Error as error:
+        raise ArtifactValidationError(
+            f"{label} entry points are invalid: {error}"
+        ) from error
+    for group, expected in EXPECTED_ENTRY_POINTS.items():
+        if not parser.has_section(group):
+            raise ArtifactValidationError(
+                f"{label} is missing entry-point group {group}"
+            )
+        if dict(parser.items(group)) != expected:
+            raise ArtifactValidationError(f"{label} {group} entry points changed")
+
+
+
+def _project_table(data: dict[str, object], label: str) -> dict[str, object]:
+    project = data.get("project")
+    if not isinstance(project, dict):
+        raise ArtifactValidationError(f"{label} pyproject has no project table")
+    return project
+
+
+def validate_sdist_project(text: str, label: str = "sdist") -> None:
+    """Validate the source metadata that must reproduce the release package."""
+    try:
+        data = tomllib.loads(text)
+    except tomllib.TOMLDecodeError as error:
+        raise ArtifactValidationError(f"{label} pyproject is invalid TOML") from error
+
+    project = _project_table(data, label)
+    if canonicalize_name(str(project.get("name", ""))) != canonicalize_name(
+        "pds-concord"
+    ):
+        raise ArtifactValidationError(
+            f"{label} pyproject distribution name must be pds-concord"
+        )
+
+    raw_python = project.get("requires-python")
+    if not isinstance(raw_python, str):
+        raise ArtifactValidationError(
+            f"{label} pyproject Requires-Python must be a string"
+        )
+    try:
+        python_specifier = SpecifierSet(raw_python)
+    except InvalidSpecifier as error:
+        raise ArtifactValidationError(
+            f"{label} pyproject Requires-Python is invalid: {raw_python}"
+        ) from error
+    if python_specifier != EXPECTED_PYTHON_SPECIFIER:
+        raise ArtifactValidationError(
+            f"{label} pyproject Requires-Python must be exactly >=3.11"
+        )
+
+    raw_dependencies = project.get("dependencies")
+    if not isinstance(raw_dependencies, list) or not all(
+        isinstance(value, str) for value in raw_dependencies
+    ):
+        raise ArtifactValidationError(
+            f"{label} pyproject dependencies must be a string list"
+        )
+    validate_requirements(raw_dependencies, f"{label} pyproject")
+
+    scripts = project.get("scripts")
+    if scripts != EXPECTED_ENTRY_POINTS["console_scripts"]:
+        raise ArtifactValidationError(
+            f"{label} pyproject console script changed"
+        )
+
+    entry_points = project.get("entry-points")
+    if not isinstance(entry_points, dict):
+        raise ArtifactValidationError(
+            f"{label} pyproject has no project.entry-points table"
+        )
+    for group in (
+        "paper_data_suite.modules",
+        "paper_data_suite.publication_producers",
+    ):
+        if entry_points.get(group) != EXPECTED_ENTRY_POINTS[group]:
+            raise ArtifactValidationError(
+                f"{label} pyproject entry point changed: {group}"
+            )
+
+    if project.get("dynamic") != ["version"]:
+        raise ArtifactValidationError(
+            f"{label} pyproject must keep version as its only dynamic project field"
+        )
+    tool = data.get("tool")
+    setuptools = tool.get("setuptools") if isinstance(tool, dict) else None
+    dynamic = setuptools.get("dynamic") if isinstance(setuptools, dict) else None
+    version = dynamic.get("version") if isinstance(dynamic, dict) else None
+    if (
+        not isinstance(version, dict)
+        or version.get("attr") != "concord._version.__version__"
+    ):
+        raise ArtifactValidationError(
+            f"{label} pyproject version must resolve from "
+            "concord._version.__version__"
+        )
+
+
+def validate_version_source(text: str, label: str = "sdist") -> None:
+    """Require one exact package-version literal in the source distribution."""
+    try:
+        tree = ast.parse(text)
+    except SyntaxError as error:
+        raise ArtifactValidationError(
+            f"{label} concord/_version.py is invalid Python"
+        ) from error
+
+    values: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        value = node.value
+        if (
+            any(
+                isinstance(target, ast.Name) and target.id == "__version__"
+                for target in targets
+            )
+            and isinstance(value, ast.Constant)
+            and isinstance(value.value, str)
+        ):
+            values.append(value.value)
+    if values != [RELEASE_VERSION]:
+        raise ArtifactValidationError(
+            f"{label} must contain exactly one __version__ = "
+            f"{RELEASE_VERSION!r} literal"
+        )
+
+
+def _zip_member_is_symlink(info: zipfile.ZipInfo) -> bool:
+    mode = info.external_attr >> 16
+    return stat.S_ISLNK(mode)
+
+
+def validate_wheel(path: Path) -> None:
+    if path.name != EXPECTED_WHEEL:
+        raise ArtifactValidationError(f"wheel must be named {EXPECTED_WHEEL}")
+    try:
+        with zipfile.ZipFile(path) as archive:
+            infos = archive.infolist()
+            names = [info.filename for info in infos]
+            validate_member_names(names)
+            if archive.testzip() is not None:
+                raise ArtifactValidationError("wheel contains a corrupt ZIP member")
+            if any(_zip_member_is_symlink(info) for info in infos):
+                raise ArtifactValidationError("wheel contains a symbolic link")
+            allowed_roots = {"concord", EXPECTED_DIST_INFO}
+            for name in names:
+                root = normalized_member(name).parts[0]
+                if root not in allowed_roots:
+                    raise ArtifactValidationError(
+                        f"wheel contains a non-runtime package root: {name}"
+                    )
+            if not REQUIRED_WHEEL_FILES.issubset(names):
+                missing = sorted(REQUIRED_WHEEL_FILES - set(names))
+                raise ArtifactValidationError(
+                    "wheel is missing required public files: " + ", ".join(missing)
+                )
+            metadata_names = [
+                name for name in names if name.endswith(".dist-info/METADATA")
+            ]
+            entry_names = [
+                name for name in names if name.endswith(".dist-info/entry_points.txt")
+            ]
+            if len(metadata_names) != 1 or len(entry_names) != 1:
+                raise ArtifactValidationError(
+                    "wheel must contain one METADATA and one entry_points.txt"
+                )
+            validate_package_metadata(
+                archive.read(metadata_names[0]).decode("utf-8"), "wheel"
+            )
+            validate_entry_points(archive.read(entry_names[0]).decode("utf-8"), "wheel")
+    except zipfile.BadZipFile as error:
+        raise ArtifactValidationError("wheel is not a readable ZIP archive") from error
+
+
+def validate_sdist(path: Path) -> None:
+    if path.name != EXPECTED_SDIST:
+        raise ArtifactValidationError(f"sdist must be named {EXPECTED_SDIST}")
+    expected_root = f"pds_concord-{RELEASE_VERSION}"
+    try:
+        with tarfile.open(path, mode="r:gz") as archive:
+            members = archive.getmembers()
+            names = [member.name for member in members]
+            validate_member_names(names)
+            for member in members:
+                normalized = normalized_member(member.name)
+                if normalized.parts[0] != expected_root:
+                    raise ArtifactValidationError(
+                        f"sdist member is outside {expected_root}: {member.name}"
+                    )
+                if member.issym() or member.islnk():
+                    raise ArtifactValidationError(
+                        f"sdist contains a symbolic/hard link: {member.name}"
+                    )
+                if not (member.isfile() or member.isdir()):
+                    raise ArtifactValidationError(
+                        f"sdist contains an unsupported member type: {member.name}"
+                    )
+            relative_names = {
+                str(PurePosixPath(*normalized_member(name).parts[1:]))
+                for name in names
+                if len(normalized_member(name).parts) > 1
+            }
+            missing_sources = sorted(REQUIRED_SDIST_FILES - relative_names)
+            if missing_sources:
+                raise ArtifactValidationError(
+                    "sdist is missing required release source files: "
+                    + ", ".join(missing_sources)
+                )
+
+            metadata_name = f"{expected_root}/PKG-INFO"
+            pyproject_name = f"{expected_root}/pyproject.toml"
+            version_name = f"{expected_root}/concord/_version.py"
+            if metadata_name not in names:
+                raise ArtifactValidationError("sdist is missing PKG-INFO")
+
+            metadata_file = archive.extractfile(metadata_name)
+            pyproject_file = archive.extractfile(pyproject_name)
+            version_file = archive.extractfile(version_name)
+            if (
+                metadata_file is None
+                or pyproject_file is None
+                or version_file is None
+            ):
+                raise ArtifactValidationError("sdist release metadata is unreadable")
+
+            validate_package_metadata(metadata_file.read().decode("utf-8"), "sdist")
+            validate_sdist_project(pyproject_file.read().decode("utf-8"))
+            validate_version_source(version_file.read().decode("utf-8"))
+    except (tarfile.TarError, OSError) as error:
+        raise ArtifactValidationError(
+            "sdist is not a readable gzip tar archive"
+        ) from error
+
+
+def validate_release_artifacts(directory: Path) -> None:
+    if not directory.is_dir():
+        raise ArtifactValidationError(
+            f"release artifact directory does not exist: {directory}"
+        )
+    files = sorted(path.name for path in directory.iterdir() if path.is_file())
+    expected = sorted([EXPECTED_WHEEL, EXPECTED_SDIST])
+    if files != expected:
+        raise ArtifactValidationError(
+            f"release directory must contain exactly {expected!r}; found {files!r}"
+        )
+    validate_wheel(directory / EXPECTED_WHEEL)
+    validate_sdist(directory / EXPECTED_SDIST)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dist_directory", type=Path)
+    args = parser.parse_args()
+    try:
+        validate_release_artifacts(args.dist_directory)
+    except ArtifactValidationError as error:
+        print(f"Release artifact validation failed: {error}")
+        return 1
+    print(f"Validated exact {EXPECTED_WHEEL} and {EXPECTED_SDIST} release artifacts.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_release_compatibility.py
+++ b/scripts/verify_release_compatibility.py
@@ -1,0 +1,414 @@
+"""Verify the frozen Concord v0.2.0 release and consumer boundary."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+from packaging.requirements import Requirement
+from packaging.specifiers import SpecifierSet
+from packaging.utils import canonicalize_name
+
+import concord.academic_result_artifacts as artifacts
+import concord.academic_result_reader as reader
+from concord.pds_contract import (
+    ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+    ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+    CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+    CONCORD_ACADEMIC_WORK_CONTRACT_VERSION,
+    CONCORD_ACADEMIC_WORK_KIND,
+    CONCORD_ACTIVITY_CONTRACT_VERSION,
+    CONCORD_ACTIVITY_RECORD_KIND,
+    CONCORD_MODULE_ID,
+)
+from concord.pds_publication import get_publication_producer_profile
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE_VERSION = "0.2.0"
+EXPECTED_CORE_SPECIFIER = SpecifierSet(">=0.6,<0.7")
+EXPECTED_PYTHON_SPECIFIER = SpecifierSet(">=3.11")
+EXPECTED_CAPABILITIES = frozenset(
+    {"criterion_scores", "moderated_scores", "standards_ratings"}
+)
+SIBLING_DISTRIBUTIONS = frozenset(
+    {
+        "pds-scoreform",
+        "scoreform",
+        "pds-quillan",
+        "quillan",
+        "pds-portia",
+        "portia",
+        "pds-meridian",
+        "meridian",
+        "pds-vitrine",
+        "vitrine",
+    }
+)
+SIBLING_IMPORT_ROOTS = frozenset(
+    {
+        "scoreform",
+        "pds_scoreform",
+        "quillan",
+        "pds_quillan",
+        "portia",
+        "pds_portia",
+        "meridian",
+        "pds_meridian",
+        "vitrine",
+        "pds_vitrine",
+    }
+)
+
+
+class ReleaseCompatibilityError(RuntimeError):
+    """Raised when the v0.2.0 release boundary has drifted."""
+
+
+@dataclass(frozen=True, slots=True)
+class ReleaseContractValues:
+    module_id: str
+    work_contract: str
+    work_kind: str
+    activity_record_kind: str
+    activity_contract: str
+    manifest_contract: str
+    manifest_record_type: str
+    record_set_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProducerProfileValues:
+    module_id: str
+    core_schema_versions: frozenset[str]
+    work_contracts: frozenset[str]
+    support_row_count: int
+    publication_kind: str
+    manifest_contracts: frozenset[str]
+    capabilities: frozenset[str]
+    source_record_kind: str
+    source_contracts: frozenset[str]
+    source_allows_unversioned: bool
+    allows_missing_source_record: bool
+
+
+def _read(relative: str) -> str:
+    path = ROOT / relative
+    if not path.is_file():
+        raise ReleaseCompatibilityError(f"missing release file: {relative}")
+    return path.read_text(encoding="utf-8")
+
+
+def source_version_literals(source: str) -> tuple[str, ...]:
+    """Return literal assignments to ``__version__`` in Python source."""
+    tree = ast.parse(source)
+    values: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+            continue
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        value = node.value
+        if (
+            any(
+                isinstance(target, ast.Name) and target.id == "__version__"
+                for target in targets
+            )
+            and isinstance(value, ast.Constant)
+            and isinstance(value.value, str)
+        ):
+            values.append(value.value)
+    return tuple(values)
+
+
+def validate_release_metadata(project: Mapping[str, object], version: str) -> None:
+    """Validate release identity and dependency metadata from parsed TOML."""
+    if project.get("name") != "pds-concord":
+        raise ReleaseCompatibilityError("distribution name must be pds-concord")
+    if version != RELEASE_VERSION:
+        raise ReleaseCompatibilityError(f"source version must be {RELEASE_VERSION}")
+    if project.get("requires-python") != str(EXPECTED_PYTHON_SPECIFIER):
+        raise ReleaseCompatibilityError("Requires-Python must be exactly >=3.11")
+    raw_dependencies = project.get("dependencies")
+    if not isinstance(raw_dependencies, list) or not all(
+        isinstance(item, str) for item in raw_dependencies
+    ):
+        raise ReleaseCompatibilityError("project dependencies must be a string list")
+    dependencies = tuple(Requirement(item) for item in raw_dependencies)
+    core = tuple(
+        item
+        for item in dependencies
+        if canonicalize_name(item.name) == canonicalize_name("pds-core")
+    )
+    if len(core) != 1 or core[0].specifier != EXPECTED_CORE_SPECIFIER:
+        raise ReleaseCompatibilityError("Core requirement must be exactly >=0.6,<0.7")
+    if core[0].url is not None or core[0].marker is not None or core[0].extras:
+        raise ReleaseCompatibilityError(
+            "Core requirement cannot use URL, marker, or extras"
+        )
+    siblings = sorted(
+        item.name
+        for item in dependencies
+        if canonicalize_name(item.name)
+        in {canonicalize_name(name) for name in SIBLING_DISTRIBUTIONS}
+    )
+    if siblings:
+        raise ReleaseCompatibilityError(
+            "sibling runtime dependencies are forbidden: " + ", ".join(siblings)
+        )
+
+
+def validate_contract_values(values: ReleaseContractValues) -> None:
+    expected = ReleaseContractValues(
+        module_id="concord",
+        work_contract="concord_academic_work_v1",
+        work_kind="collaborative_activity",
+        activity_record_kind="activity",
+        activity_contract="concord_activity_v1",
+        manifest_contract="concord_academic_result_manifest_v1",
+        manifest_record_type="concord_academic_result_manifest",
+        record_set_id="academic_results",
+    )
+    if values != expected:
+        raise ReleaseCompatibilityError(
+            f"public Concord contract identity changed: {values!r}"
+        )
+
+
+def validate_profile_values(values: ProducerProfileValues) -> None:
+    expected = ProducerProfileValues(
+        module_id="concord",
+        core_schema_versions=frozenset({"1"}),
+        work_contracts=frozenset({"concord_academic_work_v1"}),
+        support_row_count=1,
+        publication_kind="academic_result_set",
+        manifest_contracts=frozenset({"concord_academic_result_manifest_v1"}),
+        capabilities=EXPECTED_CAPABILITIES,
+        source_record_kind="activity",
+        source_contracts=frozenset({"concord_activity_v1"}),
+        source_allows_unversioned=False,
+        allows_missing_source_record=False,
+    )
+    if values != expected:
+        raise ReleaseCompatibilityError(
+            f"publication producer profile changed: {values!r}"
+        )
+
+
+def _import_roots(tree: ast.AST) -> tuple[tuple[str, int], ...]:
+    imports: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imports.extend(
+                (alias.name.split(".", 1)[0], node.lineno) for alias in node.names
+            )
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            imports.append((node.module.split(".", 1)[0], node.lineno))
+    return tuple(imports)
+
+
+def _import_modules(tree: ast.AST) -> frozenset[str]:
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            modules.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            modules.add(node.module)
+    return frozenset(modules)
+
+
+def validate_sibling_import_isolation(root: Path = ROOT) -> None:
+    offenders: list[str] = []
+    for path in sorted((root / "concord").rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for imported, line in _import_roots(tree):
+            if imported in SIBLING_IMPORT_ROOTS:
+                offenders.append(f"{path.relative_to(root)}:{line} imports {imported}")
+    if offenders:
+        raise ReleaseCompatibilityError(
+            "production Concord imports sibling modules: " + "; ".join(offenders)
+        )
+
+
+def validate_reader_and_artifact_boundary() -> None:
+    reader_public = frozenset(getattr(reader, "__all__", ()))
+    required_reader = {
+        "read_academic_result_manifest",
+        "validate_academic_result_manifest",
+        "lookup_academic_result_score",
+        "list_academic_result_scores_for_target",
+    }
+    if not required_reader.issubset(reader_public):
+        raise ReleaseCompatibilityError("public manifest reader surface is incomplete")
+    forbidden_policy = (
+        "latest",
+        "highest",
+        "best",
+        "official",
+        "grade",
+        "proficiency",
+        "mastery",
+        "expand_group",
+    )
+    leaked = sorted(
+        name
+        for name in reader_public
+        if any(fragment in name.lower() for fragment in forbidden_policy)
+    )
+    if leaked:
+        raise ReleaseCompatibilityError(
+            "consumer selection/calculation policy leaked into reader API: "
+            + ", ".join(leaked)
+        )
+    if tuple(inspect.signature(reader.read_academic_result_manifest).parameters) != (
+        "value",
+    ):
+        raise ReleaseCompatibilityError("manifest byte reader signature changed")
+    reader_tree = ast.parse(
+        inspect.getsource(reader), filename=str(Path(reader.__file__ or ""))
+    )
+    forbidden_reader_imports = (
+        "concord.storage",
+        "concord.workflows",
+        "pds_core.workspace",
+    )
+    if any(
+        imported == prefix or imported.startswith(prefix + ".")
+        for imported in _import_modules(reader_tree)
+        for prefix in forbidden_reader_imports
+    ):
+        raise ReleaseCompatibilityError(
+            "public reader imports native storage/workspace"
+        )
+
+    artifact_public = frozenset(getattr(artifacts, "__all__", ()))
+    required_artifact = {
+        "AcademicResultArtifactAuthorizationGate",
+        "AcademicResultArtifactAuthorizationRequest",
+        "AcademicResultArtifactAuthorizationDecision",
+        "read_authorized_academic_result_artifact",
+    }
+    if not required_artifact.issubset(artifact_public):
+        raise ReleaseCompatibilityError(
+            "separate Artifact authorization API is incomplete"
+        )
+    parameters = inspect.signature(
+        artifacts.read_authorized_academic_result_artifact
+    ).parameters
+    if "authorization_gate" not in parameters or "workspace_root" not in parameters:
+        raise ReleaseCompatibilityError(
+            "Artifact read no longer requires its separate gate"
+        )
+    if "read_authorized_academic_result_artifact" in reader_public:
+        raise ReleaseCompatibilityError("Artifact read leaked into manifest reader API")
+
+
+def validate_structural_policy_absence(root: Path = ROOT) -> None:
+    """Reject bounded producer APIs that would cross release policy boundaries."""
+    forbidden_definitions = (
+        "calculate_grade",
+        "calculate_proficiency",
+        "calculate_mastery",
+        "select_latest_score",
+        "select_highest_score",
+        "select_best_score",
+        "select_official_score",
+        "expand_group_score",
+        "individualize_group_score",
+    )
+    offenders: list[str] = []
+    for path in sorted((root / "concord").rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and any(
+                node.name == name or node.name.startswith(name + "_")
+                for name in forbidden_definitions
+            ):
+                offenders.append(f"{path.relative_to(root)}:{node.lineno} {node.name}")
+    if offenders:
+        raise ReleaseCompatibilityError(
+            "forbidden grading/selection/group-expansion API exists: "
+            + "; ".join(offenders)
+        )
+
+
+def validate_release_compatibility() -> None:
+    project_data = tomllib.loads(_read("pyproject.toml"))
+    project = project_data.get("project")
+    if not isinstance(project, dict):
+        raise ReleaseCompatibilityError("pyproject.toml has no project table")
+    version_literals: list[str] = []
+    for path in sorted((ROOT / "concord").rglob("*.py")):
+        version_literals.extend(
+            source_version_literals(path.read_text(encoding="utf-8"))
+        )
+    if version_literals != [RELEASE_VERSION]:
+        raise ReleaseCompatibilityError(
+            "Concord must have exactly one authoritative 0.2.0 version literal"
+        )
+    validate_release_metadata(project, version_literals[0])
+    validate_sibling_import_isolation()
+    validate_contract_values(
+        ReleaseContractValues(
+            CONCORD_MODULE_ID,
+            CONCORD_ACADEMIC_WORK_CONTRACT_VERSION,
+            CONCORD_ACADEMIC_WORK_KIND,
+            CONCORD_ACTIVITY_RECORD_KIND,
+            CONCORD_ACTIVITY_CONTRACT_VERSION,
+            ACADEMIC_RESULT_MANIFEST_CONTRACT_VERSION,
+            ACADEMIC_RESULT_MANIFEST_RECORD_TYPE,
+            CONCORD_ACADEMIC_RESULT_RECORD_SET_ID,
+        )
+    )
+    profile = get_publication_producer_profile()
+    if len(profile.publication_contracts) != 1:
+        raise ReleaseCompatibilityError("Concord must expose exactly one support row")
+    support = profile.publication_contracts[0]
+    if len(support.source_record_contracts) != 1:
+        raise ReleaseCompatibilityError(
+            "Concord must require one Activity source contract"
+        )
+    source = support.source_record_contracts[0]
+    validate_profile_values(
+        ProducerProfileValues(
+            profile.module_id,
+            profile.supported_core_publication_schema_versions,
+            profile.supported_academic_work_contract_versions,
+            len(profile.publication_contracts),
+            support.publication_kind,
+            support.manifest_contract_versions,
+            support.supported_capabilities,
+            source.record_kind,
+            source.contract_versions,
+            source.allows_unversioned,
+            support.allows_missing_source_record,
+        )
+    )
+    validate_reader_and_artifact_boundary()
+    validate_structural_policy_absence()
+
+
+def main() -> int:
+    try:
+        validate_release_compatibility()
+    except (
+        OSError,
+        SyntaxError,
+        ValueError,
+        KeyError,
+        ReleaseCompatibilityError,
+    ) as error:
+        print(f"Release compatibility audit failed: {error}")
+        return 1
+    print(
+        "Concord v0.2.0 release compatibility passed: Core >=0.6,<0.7; "
+        "contracts/profile exact; reader consumer-neutral; Artifact gate separate; "
+        "sibling and grading/selection policy absent."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_artifacts_issue34.py
+++ b/tests/test_release_artifacts_issue34.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from scripts.verify_release_artifacts import (
+    EXPECTED_SDIST,
+    EXPECTED_WHEEL,
+    REQUIRED_SDIST_FILES,
+    REQUIRED_WHEEL_FILES,
+    ArtifactValidationError,
+    normalized_member,
+    validate_release_artifacts,
+    validate_sdist,
+    validate_wheel,
+)
+
+METADATA = """Metadata-Version: 2.4
+Name: pds-concord
+Version: 0.2.0
+Requires-Python: >=3.11
+Requires-Dist: pds-core<0.7,>=0.6
+
+Synthetic test package.
+"""
+ENTRY_POINTS = """[console_scripts]
+concord = concord.cli:main
+
+[paper_data_suite.modules]
+concord = concord.pds_module:get_module_profile
+
+[paper_data_suite.publication_producers]
+concord = concord.pds_publication:get_publication_producer_profile
+"""
+PYPROJECT = """[project]
+name = "pds-concord"
+dynamic = ["version"]
+requires-python = ">=3.11"
+dependencies = ["pds-core>=0.6,<0.7"]
+
+[project.scripts]
+concord = "concord.cli:main"
+
+[project.entry-points."paper_data_suite.modules"]
+concord = "concord.pds_module:get_module_profile"
+
+[project.entry-points."paper_data_suite.publication_producers"]
+concord = "concord.pds_publication:get_publication_producer_profile"
+
+[tool.setuptools.dynamic]
+version = { attr = "concord._version.__version__" }
+"""
+VERSION_SOURCE = '__version__ = "0.2.0"\n'
+
+
+def _write_wheel(
+    path: Path, *, omit: str | None = None, metadata: str = METADATA
+) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        for name in sorted(REQUIRED_WHEEL_FILES):
+            if name != omit:
+                archive.writestr(name, "")
+        archive.writestr("pds_concord-0.2.0.dist-info/METADATA", metadata)
+        archive.writestr("pds_concord-0.2.0.dist-info/entry_points.txt", ENTRY_POINTS)
+
+
+def _tar_file(archive: tarfile.TarFile, name: str, content: str) -> None:
+    raw = content.encode("utf-8")
+    info = tarfile.TarInfo(name)
+    info.size = len(raw)
+    archive.addfile(info, io.BytesIO(raw))
+
+
+def _write_sdist(
+    path: Path,
+    *,
+    omit: str | None = None,
+    metadata: str = METADATA,
+    pyproject: str = PYPROJECT,
+    version_source: str = VERSION_SOURCE,
+) -> None:
+    root = "pds_concord-0.2.0"
+    with tarfile.open(path, "w:gz") as archive:
+        _tar_file(archive, f"{root}/PKG-INFO", metadata)
+        for name in sorted(REQUIRED_SDIST_FILES):
+            if name == omit:
+                continue
+            content = ""
+            if name == "pyproject.toml":
+                content = pyproject
+            elif name == "concord/_version.py":
+                content = version_source
+            _tar_file(archive, f"{root}/{name}", content)
+
+
+def test_synthetic_release_artifacts_pass(tmp_path: Path) -> None:
+    _write_wheel(tmp_path / EXPECTED_WHEEL)
+    _write_sdist(tmp_path / EXPECTED_SDIST)
+    validate_release_artifacts(tmp_path)
+
+
+def test_release_directory_rejects_wrong_name_and_extra_artifact(
+    tmp_path: Path,
+) -> None:
+    _write_wheel(tmp_path / "pds_concord-0.2.1-py3-none-any.whl")
+    _write_sdist(tmp_path / EXPECTED_SDIST)
+    with pytest.raises(ArtifactValidationError):
+        validate_release_artifacts(tmp_path)
+
+    (tmp_path / "pds_concord-0.2.1-py3-none-any.whl").rename(tmp_path / EXPECTED_WHEEL)
+    (tmp_path / "unexpected.txt").write_text("unexpected", encoding="utf-8")
+    with pytest.raises(ArtifactValidationError):
+        validate_release_artifacts(tmp_path)
+
+
+def test_wheel_rejects_wrong_metadata_version(tmp_path: Path) -> None:
+    wrong = METADATA.replace("Version: 0.2.0", "Version: 0.2.1")
+    path = tmp_path / EXPECTED_WHEEL
+    _write_wheel(path, metadata=wrong)
+    with pytest.raises(ArtifactValidationError):
+        validate_wheel(path)
+
+
+def test_wheel_rejects_missing_required_public_module(tmp_path: Path) -> None:
+    path = tmp_path / EXPECTED_WHEEL
+    _write_wheel(path, omit="concord/academic_result_reader.py")
+    with pytest.raises(ArtifactValidationError):
+        validate_wheel(path)
+
+
+@pytest.mark.parametrize("name", ["../escape", "/absolute", "C:/absolute"])
+def test_dangerous_archive_member_is_rejected(name: str) -> None:
+    with pytest.raises(ArtifactValidationError):
+        normalized_member(name)
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        METADATA.replace(
+            "Requires-Dist: pds-core<0.7,>=0.6",
+            "Requires-Dist: pds-core<0.7,>=0.5",
+        ),
+        METADATA.replace(
+            "\n\nSynthetic test package.",
+            "\nRequires-Dist: pds-meridian>=0.1\n\nSynthetic test package.",
+        ),
+    ],
+)
+def test_wheel_rejects_core_and_sibling_dependency_drift(
+    tmp_path: Path,
+    metadata: str,
+) -> None:
+    path = tmp_path / EXPECTED_WHEEL
+    _write_wheel(path, metadata=metadata)
+    with pytest.raises(ArtifactValidationError):
+        validate_wheel(path)
+
+
+def test_sdist_rejects_missing_required_public_module(tmp_path: Path) -> None:
+    path = tmp_path / EXPECTED_SDIST
+    _write_sdist(path, omit="concord/academic_result_reader.py")
+    with pytest.raises(ArtifactValidationError):
+        validate_sdist(path)
+
+
+def test_sdist_rejects_source_metadata_drift(tmp_path: Path) -> None:
+    path = tmp_path / EXPECTED_SDIST
+    wrong = PYPROJECT.replace(
+        'concord = "concord.pds_module:get_module_profile"',
+        'concord = "concord.pds_module:wrong_profile"',
+    )
+    _write_sdist(path, pyproject=wrong)
+    with pytest.raises(ArtifactValidationError):
+        validate_sdist(path)
+
+
+def test_sdist_rejects_wrong_authoritative_version_source(tmp_path: Path) -> None:
+    path = tmp_path / EXPECTED_SDIST
+    _write_sdist(path, version_source='__version__ = "0.2.0.dev0"\n')
+    with pytest.raises(ArtifactValidationError):
+        validate_sdist(path)

--- a/tests/test_release_compatibility_issue34.py
+++ b/tests/test_release_compatibility_issue34.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from scripts.verify_release_compatibility import (
+    EXPECTED_CAPABILITIES,
+    ProducerProfileValues,
+    ReleaseCompatibilityError,
+    ReleaseContractValues,
+    validate_contract_values,
+    validate_profile_values,
+    validate_release_compatibility,
+    validate_release_metadata,
+)
+
+
+def _project(*, core: str = "pds-core>=0.6,<0.7") -> dict[str, object]:
+    return {
+        "name": "pds-concord",
+        "requires-python": ">=3.11",
+        "dependencies": [core, "Pillow>=11,<13"],
+    }
+
+
+def _contracts() -> ReleaseContractValues:
+    return ReleaseContractValues(
+        "concord",
+        "concord_academic_work_v1",
+        "collaborative_activity",
+        "activity",
+        "concord_activity_v1",
+        "concord_academic_result_manifest_v1",
+        "concord_academic_result_manifest",
+        "academic_results",
+    )
+
+
+def _profile() -> ProducerProfileValues:
+    return ProducerProfileValues(
+        "concord",
+        frozenset({"1"}),
+        frozenset({"concord_academic_work_v1"}),
+        1,
+        "academic_result_set",
+        frozenset({"concord_academic_result_manifest_v1"}),
+        EXPECTED_CAPABILITIES,
+        "activity",
+        frozenset({"concord_activity_v1"}),
+        False,
+        False,
+    )
+
+
+def test_live_release_compatibility_audit_passes() -> None:
+    validate_release_compatibility()
+
+
+@pytest.mark.parametrize(
+    ("version", "core", "extra"),
+    [
+        ("0.2.0.dev0", "pds-core>=0.6,<0.7", None),
+        ("0.2.0", "pds-core>=0.5,<0.7", None),
+        ("0.2.0", "pds-core>=0.6,<0.7", "pds-meridian>=0.1"),
+    ],
+)
+def test_release_metadata_rejects_version_core_and_sibling_drift(
+    version: str, core: str, extra: str | None
+) -> None:
+    project = _project(core=core)
+    if extra is not None:
+        dependencies = project["dependencies"]
+        assert isinstance(dependencies, list)
+        dependencies.append(extra)
+    with pytest.raises(ReleaseCompatibilityError):
+        validate_release_metadata(project, version)
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        replace(_contracts(), work_contract="concord_academic_work_v2"),
+        replace(_contracts(), record_set_id="results"),
+    ],
+)
+def test_public_contract_rejects_identity_and_record_set_drift(
+    changed: ReleaseContractValues,
+) -> None:
+    with pytest.raises(ReleaseCompatibilityError):
+        validate_contract_values(changed)
+
+
+@pytest.mark.parametrize(
+    "changed",
+    [
+        replace(_profile(), capabilities=frozenset({"criterion_scores"})),
+        replace(_profile(), source_record_kind="assignment"),
+        replace(_profile(), source_contracts=frozenset({"concord_activity_v2"})),
+        replace(_profile(), allows_missing_source_record=True),
+    ],
+)
+def test_profile_rejects_capability_and_activity_source_drift(
+    changed: ProducerProfileValues,
+) -> None:
+    with pytest.raises(ReleaseCompatibilityError):
+        validate_profile_values(changed)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -7,7 +7,7 @@ import concord
 
 
 def test_initial_version() -> None:
-    assert concord.__version__ == "0.2.0.dev0"
+    assert concord.__version__ == "0.2.0"
 
 
 def test_version_has_one_authoritative_literal() -> None:
@@ -26,4 +26,4 @@ def test_version_has_one_authoritative_literal() -> None:
                 and isinstance(node.value.value, str)
             ):
                 declarations.append((path, node.value.value))
-    assert declarations == [(root / "concord" / "_version.py", "0.2.0.dev0")]
+    assert declarations == [(root / "concord" / "_version.py", "0.2.0")]


### PR DESCRIPTION
## Summary

Prepare `pds-concord 0.2.0` for final release by conducting the v0.2.0 architecture and implementation audit, freezing the external Academic Result consumer contract, promoting the package from `0.2.0.dev0` to `0.2.0`, and adding deterministic release-compatibility and release-artifact qualification.

This PR implements the **release-preparation phase** of #34.

It does **not** complete #34. Final release qualification, tagging, GitHub Release publication, release-asset hashing, fresh-download verification, and milestone closeout occur only after this PR is merged and the exact reconciled `main` commit is requalified.

Related to #34 and umbrella #22.

## Starting point

```text
main:
e6b05d6d60a6ae2d390d241c8c7b6b03016d0fe0
```

Release-preparation commit:

```text
d02851b
Audit and prepare Concord 0.2.0 release
```

The branch is exactly one commit ahead of the starting `main` commit and contains 18 intended changed files.

## Release identity

Promotes the authoritative Concord version from:

```text
0.2.0.dev0
```

to:

```text
0.2.0
```

The package continues to have one authoritative version literal.

Qualification requires agreement among:

```text
concord._version.__version__
concord.__version__
built wheel metadata
installed distribution metadata
concord --version
python -m concord --version
```

## ADR and implementation audit

All 15 accepted Concord ADRs were audited against the implemented v0.2.0 slice.

Result:

```text
CONFORMS: 10
CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.2.0: 5
BLOCKERS: 0
```

The release audit distinguishes genuine conformance from intentionally deferred architecture rather than treating future packet/UI/planning concepts as missing v0.2.0 functionality.

Deferred surfaces include broader:

```text
Template / Packet workflows
task and contribution structures
external-integration surfaces
future Group Planning functionality
broader sibling-module integrations
```

No accepted ADR required revision.

## Frozen consumer contract

The release-preparation audit freezes the following external producer boundary:

```text
distribution:
    pds-concord

version:
    0.2.0

import package:
    concord

producer module:
    concord

publication kind:
    academic_result_set

Core dependency:
    pds-core>=0.6,<0.7

qualified Core release:
    pds-core 0.6.0

Academic Work contract:
    concord_academic_work_v1

Academic Work kind:
    collaborative_activity

required source record:
    module_id = concord
    record_kind = activity
    contract_version = concord_activity_v1
    allows_missing_source_record = false

manifest contract:
    concord_academic_result_manifest_v1

manifest record type:
    concord_academic_result_manifest

record set:
    academic_results

maximum producer-profile capabilities:
    criterion_scores
    moderated_scores
    standards_ratings

publication entry point:
    paper_data_suite.publication_producers
    concord = concord.pds_publication:get_publication_producer_profile

routing entry point:
    paper_data_suite.modules
    concord = concord.pds_module:get_module_profile

public manifest reader:
    concord.academic_result_reader.read_academic_result_manifest(bytes)

separately authorized Artifact surface:
    concord.academic_result_artifacts
```

Concrete Publication Record capabilities remain content-derived; the producer profile defines the maximum supported capability vocabulary.

## Preserved semantic boundaries

The release audit explicitly freezes:

```text
Group Score != individual Score
Group Membership != individual Score

Artifact Author != Artifact Subject
Artifact Subject != Score target
route target != Score target

local Score != standard-backed Score

non-score disposition != zero

native Scoring Scale != universal proficiency scale

producer Score history != consumer selection policy

Review != Moderation != Score != Grade

Moderation != proficiency

manifest authorization != Artifact authorization

Concord -> Core
Concord -X-> Meridian
```

No Meridian-specific producer shim, Grade logic, proficiency calculation, automatic Score selection, or Group-to-student Score expansion was added.

## Release tooling

### `scripts/verify_release_compatibility.py`

Adds a deterministic release-contract audit covering:

- distribution/version identity;
- exact Core dependency range;
- Python requirement;
- sibling PDS runtime isolation;
- frozen Academic Work and source-record contracts;
- manifest and record-set identities;
- exact producer-profile capabilities;
- consumer-neutral public reader boundary;
- separate Artifact authorization boundary;
- absence of Meridian/Grade/proficiency/Score-selection policy.

This is intentionally **not** another producer lifecycle.

### `scripts/verify_release_artifacts.py`

Adds final wheel + sdist validation requiring exactly:

```text
pds_concord-0.2.0-py3-none-any.whl
pds_concord-0.2.0.tar.gz
```

It validates:

- artifact names and versions;
- metadata;
- Python requirement;
- exact Core dependency;
- routing and publication entry points;
- required public Concord modules;
- sibling isolation;
- prohibited runtime/build residue;
- archive path safety;
- sdist package-source completeness;
- sdist `pyproject.toml` configuration;
- authoritative `_version.py` identity.

The sdist checks specifically reject an archive that contains metadata but omits the actual Concord public source package.

### Existing #33 acceptance remains authoritative

The complete installed producer lifecycle from #33 remains the primary end-to-end proof.

#34 does not duplicate it.

The release candidate continues to exercise:

```text
installed provenance
-> synthetic native workflow
-> academic-work registration
-> manifest revision 1
-> public reader revision 1
-> initial publication
-> publication replay
-> catalog revision 1
-> Core verification revision 1
-> authorized artifact revision 1
-> native correction
-> manifest revision 2
-> supersession
-> catalog revision 2
-> Core verification revision 2
-> historical artifact
-> withdrawal
-> final catalog
-> registry audit
-> immutability
```

## Documentation

Adds:

```text
docs/v0.2.0-release-audit.md
docs/v0.2.0-release-compatibility.md
docs/release_checklist.md
RELEASE_NOTES_v0.2.0.md
```

Updates README, docs index, and CHANGELOG for the v0.2.0 release boundary.

The release checklist explicitly separates:

```text
A. release-preparation PR
B. post-merge exact-main qualification
C. tag / GitHub Release publication
D. post-release fresh-download verification
```

The existing Group Planning / interoperability document remains explicitly future v0.3.0 scope.

## CLI release wording

The installed CLI description now reflects final v0.2.0 functionality:

```text
The complete Activity workflow is available through
a shared direct-command and teacher-menu surface.
```

rather than the prior development-era statement that it was still being built.

## Core qualification artifact

Owner-side qualification used the exact released Core artifact:

```text
pds_core-0.6.0-py3-none-any.whl

SHA-256:
be28c061b38463ef59ebc328ed1aa443767fe7f2c626babb769c2d8e5932f308
```

No editable Core checkout was used for authoritative qualification.

## Owner-side qualification

Final release-preparation qualification:

```text
focused CLI/read-only/version tests:
14 passed

Issue #34 focused release tests:
22 passed

full pytest:
567 collected
558 passed
9 skipped

Ruff:
passed

strict Mypy:
passed across 98 source files

documentation validation:
passed

release compatibility audit:
passed

wheel + sdist build:
passed

Twine:
passed

ordinary wheel package validation:
passed

release wheel + sdist validation:
passed

pip check:
passed

installed package:
pds-concord 0.2.0
pds-core 0.6.0

installed CLI version:
0.2.0

installed-wheel smoke:
passed

#33 installed producer acceptance:
all 20 stages passed

git diff --check:
passed
```

The nine Windows skips are the established privilege/POSIX-specific symlink and race tests covered by the cross-platform CI matrix.

## CI

The supported hosted matrix remains:

```text
ubuntu-latest
windows-latest

Python 3.11
Python 3.12
Python 3.13
Python 3.14
```

CI now includes the new release compatibility and artifact checks without reducing existing qualification.

## Release blockers

```text
None
```

The implementation audit found no v0.2.0 ADR, privacy, identity, publication, reader, Artifact-authorization, dependency-direction, or immutable-history release blocker.

## Explicitly deferred from v0.2.0

This PR does not implement:

```text
Group Planning
manual Group Plans
random grouping
similar-signal grouping
mixed-signal grouping
Core grouping_signal_set_v1
Meridian grouping-signal export
Template Definitions
Packet Definitions
Packet composition
starter collaborative handout library
broader packet-oriented teacher UI
Meridian's Concord adapter
Grade calculation
standards proficiency/mastery
consumer Score selection
portfolio policy
```

Those remain future work.

## Post-merge release actions

Merging this PR does **not** complete #34.

After squash merge:

1. reconcile local `main`;
2. require a clean working tree;
3. require local `main == origin/main`;
4. record the exact merged release commit;
5. rerun the complete authoritative validator **without `--allow-dirty`**;
6. build the final wheel and sdist from that exact commit;
7. record SHA-256 for both artifacts;
8. generate `SHA256SUMS.txt`;
9. create immutable tag `v0.2.0`;
10. create GitHub Release `pds-concord v0.2.0`;
11. attach the qualified wheel, sdist, and `SHA256SUMS.txt`;
12. download the published assets fresh;
13. authenticate the downloaded hashes;
14. perform fresh noneditable Core + Concord installation;
15. verify the released public reader/profile/Artifact boundary;
16. confirm the released artifact is ready for Meridian #23.

Only after those steps pass should #34 and umbrella #22 / the v0.2.0 milestone be closed.

## Scope note

No tag, GitHub Release, final release hash, package-index publication, issue closure, or milestone closure is performed by this PR.