### PR TITLE
Audit reusable and instance-owned boundaries

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,9 +15,11 @@ Concord is the Paper Data Suite module responsible for paper-first evidence gene
 
 The architecture and conceptual-contract phase is complete. The skeptical
 foundation review concluded with the verdict `APPROVED WITH NONBLOCKING FOLLOW-UP`.
-The v0.2.0 vertical slice and issue #33 installed acceptance are complete.
-Issue #34 governs the release audit, compatibility freeze, qualification, and
-release closeout against the released `pds-core` v0.6.0 integration baseline.
+The v0.2.0 vertical slice, installed acceptance, release audit, compatibility
+freeze, and milestone closeout are complete against the released `pds-core`
+v0.6.0 integration baseline. Phase 1 v0.3.0 work is tracked by umbrella #47;
+issue #48 freezes reusable-versus-instance boundaries before the GroupPlan,
+Template, Packet, Activity-copy, preset, and guided-setup implementation work.
 
 The repository now contains:
 
@@ -65,8 +67,9 @@ teacher-local collaboration-context, PDS2 Artifact Page routing, returned Artifa
 assembly, Author/Subject, Review/Moderation, Criterion/Scale/Score, and academic
 publication workflows and the issue #32 consumer-neutral readers are complete.
 Concord declares separate routing and publication-producer entry points. The
-issue #33 full installed Activity-to-publication-to-consumer acceptance path is
-complete; issue #34 owns final release audit and closeout.
+issue #33 full installed Activity-to-publication-to-consumer acceptance path and
+issue #34 release closeout are complete. The current v0.3.0 work adds reusable
+planning/setup layers without rewriting the accepted v0.2.0 operational history.
 
 ### 21. v0.2.0 release audit
 
@@ -90,6 +93,14 @@ boundary expected by downstream consumers.
 
 Separates release-preparation PR work, exact post-merge qualification,
 tag/GitHub Release publication, and fresh-download verification.
+
+### 24. v0.3.0 reusable-versus-instance boundary audit
+
+[`v0.3.0-reusable-instance-boundary-audit.md`](v0.3.0-reusable-instance-boundary-audit.md)
+
+Freezes which current and planned fields are reusable definitions/defaults,
+Activity-specific configuration, planning-only state, shared references, or
+operational/history state. It is the normative #48 handoff for #50-#64.
 
 ### Future v0.3.0 Group Planning / Template / Packet plan
 
@@ -343,6 +354,7 @@ docs/
 ├── README.md
 ├── cli-contract.md
 ├── concord-conceptual-design-revised.md
+├── v0.3.0-reusable-instance-boundary-audit.md
 ├── decisions/
 │   ├── README.md
 │   └── 0001-... through 0015-...
@@ -466,11 +478,11 @@ Simple Activities remain simple. Milestones, Work Items, dependencies, Events, s
 
 ## v0.2.0 Release-Closeout Contract
 
-The complete v0.2.0 teacher-local vertical slice and installed producer
-acceptance are implemented. Issue #34 governs the release audit, compatibility
-freeze, packaging qualification, exact-main qualification, release publication,
-and post-release verification. Tagging and GitHub Release publication occur
-only after review, hosted CI, merge, and exact-main requalification.
+The complete v0.2.0 teacher-local vertical slice, installed producer
+acceptance, release audit, compatibility freeze, and milestone closeout are
+complete. The v0.3.0 work begins from that released boundary and must preserve
+its operational identities, immutable history, and downstream consumer contract
+while adding reusable planning/setup layers deliberately.
 
 Each implementation issue must preserve the accepted contract ownership,
 read-only import behavior, exact compatibility declarations, privacy-safe test

--- a/docs/v0.3.0-reusable-instance-boundary-audit.md
+++ b/docs/v0.3.0-reusable-instance-boundary-audit.md
@@ -1,0 +1,721 @@
+# Concord v0.3.0 reusable-versus-instance boundary audit
+
+**Issue:** #48 — Audit current Activity, Group, and packet setup and identify reusable versus instance-owned fields
+**Umbrella:** #47 — v0.3.0 Group Planning, Templates, Packets, and Guided Setup
+**Audit date:** 2026-08-19
+**Audited branch baseline:** `48-audit-reusable-instance-boundaries`
+**Audited commit:** `a742d7bb5e46f44d1fb0af3ff1bc77799427559e`
+**Audited package:** `pds-concord 0.2.0`
+**Audited Core dependency:** `pds-core>=0.6,<0.7`
+
+## 1. Purpose and decision
+
+This document freezes the boundary between reusable definitions, reusable defaults,
+Activity-specific configuration, planning-only state, shared/external references,
+and operational/history state before the v0.3.0 implementation issues add GroupPlan,
+Template/Packet management, Activity copying, reusable presets, and guided setup.
+
+The audit conclusion is:
+
+> Reuse in Concord must mean reuse of definitions, references, or starting values.
+> It must never mean reuse of an earlier Activity's canonical identities, assignment
+> state, evidence, judgments, routes, publications, or history.
+
+The durable instantiation direction is:
+
+```text
+reusable definition / preset / selected shared reference
+    -> fresh Activity-specific configuration or planning state
+    -> explicit teacher approval where required
+    -> fresh canonical operational records
+    -> fresh evidence / routing / judgment history
+```
+
+The inverse direction is prohibited:
+
+```text
+old Activity operational record
+    -X-> copied into a new Activity as if it were reusable configuration
+```
+
+This audit is normative input for #50-#64. It does not implement those issues.
+
+## 2. Sources and authority
+
+The audit used the exact repository state at the commit above, including:
+
+- `pyproject.toml` and `concord/_version.py`;
+- `README.md`, `docs/README.md`, and `docs/cli-contract.md`;
+- `docs/v0.2.0-release-audit.md`;
+- `docs/concord-conceptual-design-revised.md`;
+- `docs/design/conceptual-data-contracts.md`;
+- `docs/design/initial-concord-domain-model.md`;
+- `docs/design/cross-case-requirements.md`;
+- accepted ADRs under `docs/decisions/`;
+- `docs/pds-group-planning-interoperability-development-plan.md`;
+- representative packet-model research under `docs/packet_models/`;
+- native collaboration, Artifact, common-reference, and scoring models;
+- the native record registry and Activity-scoped storage-path implementation;
+- Activity, Session, Group, Membership, Role, Responsibility, Criterion Set,
+  Scoring Scale, Score, and Artifact Page services;
+- teacher-menu implementations for Activity, Group, Role, Responsibility,
+  Artifact/Page, and scoring workflows;
+- the direct CLI parser/handlers; and
+- focused workflow, graph, storage, CLI, menu, PDS2, scoring, publication, and
+  installed-acceptance tests.
+
+Authority order for this audit is:
+
+1. accepted ADRs;
+2. later accepted conceptual contracts where they do not conflict with ADRs;
+3. implemented v0.2.0 native/service/storage behavior for statements about what
+   currently exists;
+4. implementation documentation and tests as evidence of the accepted behavior;
+5. v0.3.0 planning documents for future intent; and
+6. packet models/research as representative or provisional guidance only.
+
+A future-facing field in a v0.2 model is not evidence that the corresponding
+future subsystem is already implemented.
+
+## 3. Source-status reconciliation
+
+| Source/concept | Status at audited commit | Consequence for v0.3 |
+| --- | --- | --- |
+| Activity, Session, Group, GroupMembership | **Implemented canonical v0.2 behavior** | Preserve identity, lifecycle, exact-snapshot concurrency, and Activity ownership. |
+| RoleAssignment, ResponsibilityAssignment | **Implemented canonical v0.2 behavior** | Presets may describe functions/obligations; existing assignments remain history. |
+| ArtifactInstance, ArtifactPage, ScanReference | **Implemented canonical v0.2 behavior** | Generated identities/routes/scan lineage are instance state and never reusable definitions. |
+| ArtifactAuthor, ArtifactSubject | **Implemented canonical v0.2 behavior** | Reusable templates may carry expectations, never prior Author/Subject associations. |
+| Artifact Review, Moderation, correction history | **Implemented canonical v0.2 behavior** | Never copy into a new Activity/template/packet. |
+| CriterionSet/Criterion | **Implemented canonical v0.2 behavior** | `scope=reusable` is semantic metadata only in v0.2; there is no cross-Activity library. |
+| ScoringScale | **Implemented canonical v0.2 behavior** | Exact immutable revisions are Activity-work records today; v0.3 preset/library work must evolve storage/selection deliberately. |
+| ScoreRecord/ScoreEvidenceLink | **Implemented canonical v0.2 behavior** | Teacher judgment/history; never reusable configuration. |
+| Academic Work Registration / Publication Records | **Implemented Core integration** | Select/create anew for new Activity; never copied as producer history. |
+| Concord manifest revisions/publication series | **Implemented v0.2 behavior** | Immutable historical projection; never copied into a new Activity. |
+| Template Definition / Template Version | **Accepted conceptual contract, not a v0.2 native subsystem** | #57/#58 must implement canonical definition/version management rather than assuming current string references are sufficient. |
+| Packet Definition / Packet Version / Packet Component / Packet Instance | **Accepted conceptual contract, not a v0.2 native subsystem** | #59/#60/#62 own native contracts/storage/instantiation. |
+| `ArtifactInstance.template_version_id` | **Implemented opaque identifier field** | Does not currently resolve through a Template registry or prove Template Version existence. |
+| `ArtifactInstance.packet_instance_id` | **Implemented optional opaque reference field** | Current page-preparation workflow does not instantiate or resolve Packet records. |
+| Minimal PDS2 Artifact renderer | **Implemented v0.2 behavior** | Produces generic Concord pages from canonical Artifact Pages; it does not render from a Template Version definition. |
+| GroupPlan | **Planned v0.3 concept** | Must remain a proposal/lifecycle distinct from Group and Membership. |
+| `grouping_signal_set_v1` | **External Phase-1/Core contract work** | #48 only freezes consumption boundaries; no signal implementation or dependency change occurs here. |
+| Packet models and `provisional_findings.md` | **Provisional/research guidance** | Useful for capability pressure-testing; not runtime contracts by themselves. |
+
+### 3.1 Important v0.2 Template/Packet clarification
+
+The accepted conceptual architecture already defines Template Definition/Version
+and Packet Definition/Version/Component/Instance, but the v0.2 native registry
+contains no Template or Packet record kinds. Canonical native storage is scoped
+beneath one Concord `ModuleWorkRef`, where `work_id = activity_id`.
+
+The current Artifact Page preparation service accepts a caller-supplied
+`template_version_id`, but it does not load or validate a Template Version record.
+The current minimal renderer renders canonical Artifact Pages and PDS2 routes; it
+does not consult `template_version_id` for printable content/layout.
+
+Therefore:
+
+```text
+template_version_id present on ArtifactInstance
+!=
+implemented reusable Template Version subsystem
+```
+
+Likewise:
+
+```text
+packet_instance_id field present on ArtifactInstance
+!=
+implemented Packet Definition/Version/Instance subsystem
+```
+
+This distinction is a required premise for #57-#62.
+
+### 3.2 Criterion/Scale clarification
+
+`CriterionSet.scope` supports `reusable`, but the v0.2 implementation explicitly
+treats that value as semantic metadata only. Criterion Sets, Criteria, and
+Scoring Scales are currently persisted inside an Activity work graph. There is
+no cross-Activity Criterion/Scale library or storage root.
+
+Consequently, #64 must not implement reuse by pointing a second Activity at an
+arbitrary first Activity's work-scoped native record. It should define an
+explicit reusable-definition/preset authority and an intentional instantiation
+or selection rule while preserving exact historical revisions used by Scores.
+
+## 4. Reuse classification vocabulary
+
+Every later v0.3 field should use one of these classes.
+
+### R1 — Reusable definition
+
+A durable definition intentionally usable by more than one Activity. It has its
+own lineage/version semantics and must not acquire Activity-instance history merely
+because an Activity selects it.
+
+### R2 — Reusable default or preset
+
+A reusable starting value or bundle. Applying it creates or configures fresh
+Activity-owned state and fresh provenance where applicable. A preset is not the
+operational record created from it.
+
+### I — Instance-owned configuration
+
+Configuration belonging to one specific Activity, Session, Group, generated
+Packet/Artifact, or other concrete classroom context. It may be initialized from
+R1/R2 but the resulting state belongs to the new instance.
+
+### H — Operational or historical state
+
+State that records what actually happened, what was generated, who was assigned,
+what evidence returned, or what judgment was made. This state is never copied as
+reusable configuration.
+
+### X — External/shared reference
+
+A durable reference to Core or another owning system. Reuse means select/resolve
+the authoritative reference, not copy the referenced record into Concord.
+
+### P — Planning-only state
+
+A proposal or input that exists before canonical operational records. Planning
+state may retain reproducibility metadata but is not canonical Group/Membership,
+evidence, or Score state.
+
+## 5. Field-level reuse/copy matrix
+
+The matrix intentionally groups fields only where ownership/lifecycle semantics
+are the same.
+
+| Area / field | Current owner/source | Class | Permitted reuse/copy behavior | Fresh state required | Explicitly forbidden | Handoff |
+| --- | --- | --- | --- | --- | --- | --- |
+| Activity `activity_id` | Concord | I/H identity | Never copy; generate/select a new durable Activity ID | **Yes** | Reusing predecessor Activity identity | #63 |
+| Activity Core `class_reference` | Core reference | X | Select target class afresh; may default to current teacher context | Reference resolution | Copying Core class record into Concord | #63, guided setup |
+| Activity `title`, `description` | Concord | R2 -> I | May copy as editable starting text | New Activity record/provenance | Treating copied text as historical linkage | #63 |
+| Activity `activity_type` | Concord controlled key | R2 -> I | May preset/copy | New Activity record | Copying old lifecycle/history | #63, guided setup |
+| Activity `scoring_orientation` | Concord | R2 -> I | May preset/copy only with compatible standards/criteria configuration | New Activity validation | Inferring Scores/Grades | #63, #64 |
+| `standards_profile_id` | Core reference | X -> I selection | May preselect only if valid for target class/context; must resolve through Core | Revalidation | Copying a Core standards object | #63 |
+| ordered `focus_standard_ids` | Core references selected by Activity | R2/X -> I | May copy as proposed selection only; target Activity must revalidate profile membership | Revalidation | Treating prior selection as evidence/mastery | #63 |
+| `criterion_set_ids` on Activity | Concord exact revision refs | I selection | Future copy may map through explicit reusable preset logic; do not blindly retain source Activity work-scoped IDs | Target-specific selection/instantiation | Cross-Activity pointer into another work root; removal of historically used Sets | #63, #64 |
+| Activity `privacy_policy` | Concord | R2 -> I | May default from preset/template when authorized; effective target policy must be resolved explicitly | New Activity policy/provenance | Broadening prior restrictions automatically | #63, #57 |
+| Activity `status` | Concord | H | New Activity starts from creation policy (`draft` unless later contract changes) | **Yes** | Copying `active`, `completed`, `cancelled`, `archived` | #63 |
+| Activity provenance / update history | Concord | H | Never copy | **Yes** | Actor/timestamp/source history reuse | #63 |
+| Activity `external_reference_ids` | Concord links to external records | X/I | Select deliberately for new Activity; no automatic carry-forward | Revalidation | Assuming old external relation still applies | #63 |
+| Session `session_id` | Concord | I/H identity | Never copy identity | **Yes** | Old Session identity | #63 |
+| Session sequence/label/scheduled pattern | Concord | R2 -> I | May be copied as a scheduling/session-layout default where appropriate | New Session records | Actual timestamps/status/history | #63, guided setup |
+| Session actual start/end, status reason, historical notes | Concord | H | Never copy as template state | **Yes** | Operational chronology | #63 |
+| Group `group_id` | Concord | I/H identity | Never copy from another Activity | **Yes** | Old Group identity | #50-#56, #63 |
+| Group label/description | Concord | R2 -> I | May be proposed/defaulted by a plan/preset | New Group record | Treating label as identity | #50-#56 |
+| Group parent/effective context | Concord | I | May be proposed for the target Activity only, referencing target Activity Groups/Sessions | **Yes** | Source Activity Group/Session IDs | #50-#56 |
+| Group status/provenance/supersession | Concord | H | Never reusable configuration | **Yes** | Copying lifecycle/history | #50-#56, #63 |
+| Membership `membership_id` | Concord | H identity | Never copy | **Yes** | Reusing source Membership | #51, #56 |
+| Membership participant | Core roster reference | X -> H assignment | May appear as a *proposal* only after resolving exact target-class roster; application creates fresh Membership | Fresh Membership | Persisting prior membership as reusable grouping state | #51, #56 |
+| Membership Group/effective context/status | Concord | H | Plan may propose placement/context; canonical values are created at apply time | **Yes** | Copying source Membership history | #51, #56 |
+| Membership provenance/supersession | Concord | H | Never copy | **Yes** | Prior assignment/change history | #56 |
+| Role vocabulary `role_key` / display label concept | Concord controlled key | R1/R2 | Suitable for named reusable presets | Fresh RoleAssignment on application | Student/Group/effective assignment history | #64 |
+| RoleAssignment ID/participant/membership/group/context/status/provenance/supersession | Concord | H | Never reuse assignment; preset may propose role only | **Yes** | Prior student assignment or fulfillment inference | #64 |
+| Responsibility description / expected-output pattern | Concord | R2 candidate | Suitable for reusable responsibility preset text | Fresh ResponsibilityAssignment | Prior assignee/context/status/provenance | #64 |
+| Responsibility assignee/group/work-item/context/status/provenance/supersession | Concord | H | Never reuse assignment state | **Yes** | Prior assignment, completion, contribution inference | #64 |
+| Criterion Set lineage/name/purpose/kind/criterion definitions | Concord | R1 candidate | Semantically reusable; #64 must create an explicit cross-Activity preset/library model rather than cross-work pointers | Depends on #64 design | Treating v0.2 `scope=reusable` as an existing global registry | #64 |
+| Criterion Set exact work-scoped IDs/revisions | Concord Activity graph | I/H definition history | Preserve for source historical Scores; target Activity should explicitly instantiate/select compatible reusable definitions | Usually **yes** for target-native revision unless #64 defines a separate global identity | Blind cross-Activity ID copying | #63, #64 |
+| Criterion `standard_id` / alignments | Core refs within Concord definition | X/R1 | May be part of reusable definition; must revalidate against target Activity profile/Focus Standards | Revalidation | Turning alignment into Score/mastery | #64 |
+| Criterion supported target kinds/default Scale hint | Concord | R1/R2 | Reusable definition/default | Target validation | Automatic Score creation | #64 |
+| Scoring Scale lineage/name/type/levels/intended use | Concord | R1 candidate | Suitable for reusable preset/library; preserve type-sensitive exact values | #64-defined target selection/instantiation | Cross-work pointer without authority; automatic normalization | #64 |
+| Scoring Scale exact work-scoped revision used by Score | Concord Activity graph | H supporting judgment | Historical only for existing Scores | No copying | Replacing historical Scale under a prior Score | #64 |
+| ScoreRecord all fields | Concord | H | Never reusable/copyable | **Yes for any future Score** | Values, dispositions, targets, rationale, scorer, timestamps, moderation state, successor history | #63/#64 exclusion |
+| ScoreEvidenceLink all fields | Concord | H | Never copy | **Yes** | Evidence lineage/moderation selection reuse | #63/#64 exclusion |
+| Template Definition lineage/name/purpose/category/owner/status | Accepted Concord concept | R1 | Reusable definition | Native identity/version workflow in #57/#58 | Activity/Group/student binding | #57/#58 |
+| Template Version printable content/layout/page manifest/return rules/default privacy/authorship/subject expectations/supported Criteria/QR requirements | Accepted Concord concept | R1 immutable version | Reuse exact immutable version by reference when compatible | New Artifact instances | Generated instance IDs, prior routes, prior Authors/Subjects | #57/#58 |
+| Template Version status/provenance/supersession | Accepted Concord concept | H of definition lifecycle | Preserve as definition history; do not transplant into another lineage | New lineage only when explicitly copied-as-new-definition | Pretending old provenance is new definition provenance | #57/#58 |
+| Packet Definition lineage/name/purpose | Accepted Concord concept | R1 | Reusable definition | Native identity/version workflow | Activity/student/generated-state embedding | #59/#60 |
+| Packet Version component order, exact Template Version refs, quantity/audience/requirement/generation rules | Accepted Concord concept | R1 immutable version | Reuse exact compatible version | New Packet Instance | Prior instance bindings/history | #59/#60 |
+| Packet Component external reference | Source-owned system reference | X/R1 | Reuse reference only if still compatible/authorized | Revalidation | Copying external owned record | #59/#60 |
+| Packet Instance ID/activity/session/group/participant/series/previous instance/generation state/generated artifacts/provenance | Accepted Concord concept | I/H | Create fresh for target Activity context | **Yes** | Reusing prior Packet Instance or generated artifacts | #62 |
+| Artifact `artifact_instance_id` | Concord | H identity | Never copy | **Yes** | Source Artifact identity | #62/#63 |
+| Artifact `template_version_id` | Concord field; future Template authority | X to R1 definition | Future workflow should resolve an exact compatible Template Version; current v0.2 value is opaque | New Artifact | Treating arbitrary source string as validated reusable Template | #57/#62 |
+| Artifact `packet_instance_id` | Concord optional field | I reference | Set only from fresh target Packet Instance when #62 implements it | Target-specific | Prior Packet Instance ID | #62 |
+| Artifact activity/session/group bindings | Concord | I/H | Derive from current Activity context only | **Yes** | Source Activity/Session/Group IDs | #62 |
+| Artifact category/return expectation/privacy | Concord | R2 -> I | May be defaults from Template Version but become effective instance state | Revalidation | Automatic privacy broadening | #57/#62 |
+| Artifact generation/status/page IDs/provenance/supersession | Concord | H | Never copy | **Yes** | Generated/history state | #62/#63 |
+| Artifact Page ID/route ID/human fallback | Concord + Core route registration | H identity/routing | Always fresh for newly generated returnable pages | **Yes** | Route reuse | #62 |
+| Artifact Page number/kind/return-required/route-required structure | Concord; future Template page manifest | R1/R2 -> I | May derive from exact Template Version page manifest | Fresh page records | Old Page identities/status | #57/#62 |
+| Page lifecycle/continuation/history | Concord | H | Never copy except structural *rule* represented separately in Template | **Yes** | Old return/missing/duplicate state | #62 |
+| ScanReference / retained-source path/digest | Core source + Concord link | H | Never reusable | **Yes when new scan returns** | Retained source lineage in definitions/copies | exclusions |
+| ArtifactAuthor / ArtifactSubject association records | Concord | H | Never reuse association | **Yes** | Prior persons/groups/confirmation/provenance | #62/#63 exclusion |
+| Template authorship/subject *expectation* | Accepted Template concept | R1/R2 | May describe how target instance should later be attributed/subjected | Fresh associations still required | Treating expectation as confirmed attribution | #57/#62 |
+| Artifact Review / Moderation / Correction | Concord | H | Never copy | **Yes** | Prior evidence decisions/history | exclusions |
+| PDS2 RouteRegistration / route target | Core | H/X | Create through Core for fresh Artifact Page | **Yes** | Old route ID or semantic graph embedded in route | #62 |
+| Academic Work Registration | Core | H/X | New Activity registration is an explicit new decision | **Yes** | Copying source registration | #63 exclusion |
+| Concord manifest revisions / Publication Records | Concord + Core | H | Never copy | **Yes if new Activity later publishes** | Prior manifest bytes/digests/publication IDs | #63 exclusion |
+| GroupPlan identity/status/proposed groups/strategy/seed/missing-signal decisions/provenance | Future Concord | P | Reusable strategy defaults may seed a new plan; plan state itself remains plan-local | **Yes** | Treating plan as Group/Membership | #50-#56 |
+| GroupPlan selected signal-set ID/digest | Core immutable signal reference | P/X | Record exact identity/digest for reproducibility | New plan reference | Copying band values into Membership/Artifact/Score | #53-#56 |
+| grouping-signal bands | Core neutral planning input | P/X sensitive input | Consume only within authorized planning; do not template/copy into operational records | N/A | Packets, routes, memberships, scores, manifests | #53-#56 |
+
+## 6. Activity copying boundary (#63)
+
+A copied Activity is a **new Activity**, not an Activity revision and not a clone
+of the source record graph.
+
+### 6.1 Values that may be offered as copied defaults
+
+Subject to target-class validation and teacher preview, #63 may offer:
+
+- title and description;
+- Activity type;
+- scoring orientation;
+- Core standards profile and ordered Focus Standards as proposed selections;
+- selected reusable Criterion/Scale preset choices after #64 defines the
+  cross-Activity authority;
+- privacy defaults;
+- selected reusable Template/Packet definition/version choices after #57-#60;
+- Session *shape* such as count, sequence pattern, labels, and planned schedule
+  fields when the teacher chooses to copy them;
+- Role/Responsibility preset definitions, not assignments.
+
+### 6.2 Values that must be new or selected afresh
+
+- `activity_id` and Activity provenance;
+- target Core class resolution;
+- Session identities and operational state;
+- any target Activity-scoped Criterion/Scale instances required by #64's design;
+- every Group, Membership, RoleAssignment, ResponsibilityAssignment;
+- every GroupPlan;
+- every generated Packet/Artifact/Page;
+- every route;
+- all returned evidence and all judgment/publication state.
+
+### 6.3 Absolute exclusions
+
+#63 must not copy:
+
+```text
+Sessions as historical records
+Groups
+GroupMemberships
+GroupPlans or plan lifecycle
+GroupingSignal values/bands
+RoleAssignments
+ResponsibilityAssignments
+ArtifactInstances
+ArtifactPages
+RouteRegistrations / route IDs
+ScanReferences / retained source
+ArtifactAuthors
+ArtifactSubjects
+Reviews
+ModerationRecords
+Corrections
+ScoreRecords
+ScoreEvidenceLinks
+Academic Result manifests
+Academic Work Registrations
+Publication Records
+publication/catalog state
+storage revision history
+snapshot history
+created/updated/scored/generated provenance from the source Activity
+```
+
+## 7. Direct Group workflow and GroupPlan boundary (#50-#56)
+
+The current direct Group workflow is authoritative and remains first-class.
+Implemented service operations include:
+
+```text
+create_group
+create_group_with_members
+add_membership / add_memberships
+end_membership
+reassign_membership
+update_group
+assign/end/reassign Role
+assign/end/reassign Responsibility
+```
+
+The composite `create_group_with_members` service validates the candidate Group,
+Memberships, Roles, and Responsibilities and publishes them atomically. Batch
+Membership adds are also atomic. Membership creation resolves students against
+the Core-owned class roster. Reassignment preserves the predecessor and creates
+a new durable successor identity.
+
+Direct CLI commands expose Group creation/update and Membership add/list/end/
+reassign. The teacher menu provides direct Group creation/editing and student
+Membership management. These surfaces must remain available after GroupPlan is
+introduced.
+
+The v0.3 relationship is:
+
+```text
+manual/random/signal planning inputs
+    -> GroupPlan (draft/preview/approval lifecycle)
+    -> explicit teacher approval
+    -> preview exact native write set
+    -> existing/new Concord Group and GroupMembership application services
+```
+
+Not:
+
+```text
+GroupPlan == Group
+GroupPlan == GroupMembership
+signal band == membership attribute
+```
+
+A plan may retain the exact input identity/digest and planning choices for
+reproducibility. Application must not copy signal bands into Memberships and must
+not infer a Score.
+
+## 8. Role and Responsibility preset boundary (#64)
+
+The current menu repeatedly asks the teacher to select a student/Group, choose a
+Role key or enter Responsibility text, choose optional Group context, and choose
+Effective Context. This makes Role/Responsibility **definitions** good preset
+candidates, but the assignment records themselves are not reusable.
+
+### Reusable Role preset may contain
+
+- stable preset name;
+- `role_key` or approved namespaced key;
+- optional teacher-facing description/label;
+- applicability hints.
+
+### Reusable Role preset must not contain
+
+- `role_assignment_id`;
+- student/participant identity;
+- `membership_id`;
+- Activity-specific `group_id`;
+- Effective Context Session IDs;
+- assignment status;
+- assigning actor/provenance;
+- supersession history;
+- any claim of fulfillment/performance/authorship.
+
+### Reusable Responsibility preset may contain
+
+- preset name;
+- reusable obligation text;
+- optional expected-output text;
+- applicability hints.
+
+It must not contain a prior assignee, Group, Session context, status, status
+reason, provenance, supersession, contribution claim, or performance judgment.
+
+## 9. Criterion and Scoring Scale preset boundary (#64)
+
+The current scoring model already has immutable definition lineages, which is a
+strong basis for presets, but it is Activity-work scoped.
+
+#64 must therefore make an explicit architectural choice for cross-Activity
+reuse. Whichever representation it adopts must satisfy all of these invariants:
+
+1. a reusable definition has a canonical authority distinct from an arbitrary
+   source Activity work root;
+2. selecting/applying a preset cannot rewrite an existing exact revision used by
+   historical Scores;
+3. standard-backed Criteria must be revalidated against the target Activity's
+   Core standards profile and Focus Standards;
+4. `Criterion.default_scoring_scale_id` remains a convenience hint, not automatic
+   scoring;
+5. Scale values remain exact and type-sensitive;
+6. no reusable definition contains Score values, dispositions, targets,
+   evidence links, scorer/provenance, or correction history.
+
+This is a **downstream design requirement**, not a blocker for #48.
+
+## 10. Template boundary (#57-#58)
+
+The accepted reusable relationship is:
+
+```text
+Template Definition
+    -> immutable Template Version
+        -> generated Artifact Instance
+            -> fresh Artifact Page(s)
+                -> fresh Core PDS2 route(s)
+```
+
+Template reusable state may include:
+
+- lineage/name/purpose/category;
+- exact printable content/layout/rendering specification;
+- page manifest;
+- expected-return behavior;
+- default privacy;
+- default authorship and subject expectations;
+- supported Criterion compatibility;
+- QR/route requirements;
+- rendering input definitions and compatibility metadata.
+
+It must not include:
+
+- class, Activity, Session, Group, GroupPlan, Membership, student identity;
+- grouping-signal set/value/band;
+- generated Artifact/Page/route identity;
+- prior Author/Subject associations;
+- returned scans;
+- Review, Moderation, Score, publication, or operational history.
+
+Defaults become effective instance state only after target-context resolution.
+An authorship/subject expectation never becomes a confirmed association without
+the appropriate instance workflow.
+
+## 11. Packet boundary (#59-#62)
+
+The accepted reusable relationship is:
+
+```text
+Packet Definition
+    -> immutable Packet Version
+        -> ordered Packet Components
+            -> fresh Activity-specific Packet Instance
+                -> fresh Artifact Instances
+                    -> fresh Artifact Pages/routes
+```
+
+Reusable Packet state may include exact Template Version references, copy/
+quantity rules, audience/role **intent**, requirement levels, conditions,
+external-component references, and packet-level generation rules.
+
+A Packet Instance is operational state. It binds the reusable definition to one
+Activity context and records what was actually generated. It must receive fresh
+identity/provenance and must not be confused with the reusable Packet Version.
+
+Physical assembly does not transfer ownership of external components into
+Concord.
+
+## 12. Artifact, PDS2, Author, Subject, and target separation
+
+The following distinctions remain frozen:
+
+```text
+GroupMembership != ArtifactAuthor
+RoleAssignment != ArtifactAuthor
+ArtifactAuthor != ArtifactSubject
+ArtifactSubject != route target
+ArtifactSubject != Score target
+route target != Score target
+Group Score != individual student Score
+Template/Packet audience intent != historical Author/Subject association
+```
+
+A normal Concord PDS2 route targets an already-created `ArtifactPage`. The route
+must not carry the complete semantic graph. Fresh generated pages require fresh
+route IDs; route reuse across Activities is prohibited.
+
+## 13. Group-planning signal boundary
+
+#48 introduces no signal model, storage, dependency, or algorithm.
+
+The v0.3 contract must preserve:
+
+- Core owns the neutral `grouping_signal_set_v1` interchange, validation,
+  immutable exchange storage, and class/student identity diagnostics;
+- Concord owns GroupPlan strategy, preview/edit, approval, and application;
+- Meridian is an optional producer and must not become a Concord runtime
+  dependency;
+- direct/manual Group workflows work with no signal installed;
+- signal bands are contextual planning values, not permanent learner attributes;
+- signals do not become Scores, Group scores, Membership fields, packet metadata,
+  routes, Artifacts, manifests, or publications;
+- a GroupPlan may preserve the selected signal-set identity/digest for
+  reproducibility without copying bands into canonical Memberships.
+
+## 14. Repeated teacher-input inventory
+
+| Current surface | Repeated semantic input | Current underlying field/service | Reuse interpretation | Owning follow-up |
+| --- | --- | --- | --- | --- |
+| Activity create/menu | Activity type | `Activity.activity_type` | Preset/default -> new Activity field | #63 / guided setup |
+| Activity create/menu | Scoring orientation | `Activity.scoring_orientation` | Preset/default with target validation | #63 / guided setup |
+| Activity create/menu | Standards profile + Focus Standards | Core refs stored on Activity | Proposed shared-reference selection; revalidate | #63 / guided setup |
+| Activity create/session menu | First/later Session ID, label, sequence, schedule | `Session` | Session *shape* may be preset; identity/history must be fresh | #63 / guided setup |
+| Group menu/direct CLI | Group label/description/context | `Group` | Plan/preset may propose; Group identity/context is target-instance state | #50-#56 |
+| Group Membership menu/CLI | Student selection + Effective Context | Membership services | Planning may stage placement; application creates fresh Membership | #51/#56 |
+| Role menu | Role key | `RoleAssignment.role_key` | Strong R1/R2 preset candidate | #64 |
+| Role menu | Student/Group/context | Role assignment | Always fresh assignment state | #64 |
+| Responsibility menu | Description/expected output | Responsibility assignment | Text/pattern is preset candidate | #64 |
+| Responsibility menu | Assignee/Group/context | Responsibility assignment | Always fresh assignment state | #64 |
+| Scoring menu/CLI | Criterion Set definition | `CriterionSet` + `Criterion` | Reusable semantic definition; requires explicit cross-Activity authority | #64 |
+| Scoring menu/CLI | Scoring Scale definition | `ScoringScale` | Reusable semantic definition; requires explicit cross-Activity authority | #64 |
+| Score entry | target/Criterion/Scale/disposition/value/evidence | `ScoreRecord` / links | Judgment, never preset/copy | exclusion |
+| Artifact Page menu | caller-provided Template Version ID | `ArtifactInstance.template_version_id` | Future exact Template Version selection; current value is opaque | #57/#62 |
+| Artifact Page menu | physical page count/structure | `ArtifactPagePlan` | Move structural rules into exact Template Version where applicable | #57/#62 |
+| Artifact Page menu | privacy/category/return behavior | Artifact/Page instance fields | Template defaults -> resolved target instance | #57/#62 |
+| Packet research/conceptual design | component order/quantity/audience rules | future Packet Version | R1 definition | #59/#60 |
+| Group planning | strategy/target size/count | future GroupPlan | R2 strategy default -> fresh plan | #50-#55 |
+
+Repeated input is evidence of teacher friction, not proof that the corresponding
+canonical record should be shared.
+
+## 15. Advanced/direct interface preservation
+
+The v0.2 direct CLI is deterministic and noninteractive. It exposes exact
+Activity, Session, Group, Membership, Role, Responsibility, Criterion Set,
+Scoring Scale, Score, Artifact, Review, Moderation, and publication operations.
+Mutations use explicit actor provenance and exact expected-snapshot concurrency.
+
+v0.3 guided setup and menu simplification should route to typed application
+services rather than eliminate exact operations. In particular:
+
+- direct Group creation must remain available;
+- direct Membership lifecycle operations must remain available;
+- GroupPlan must be additive rather than mandatory;
+- reusable definitions/presets may simplify input but must not hide identity or
+  history boundaries;
+- advanced interfaces remain necessary for diagnostics, scripting, recovery,
+  testing, and exact-state management.
+
+## 16. Future-record separation matrix
+
+| Future concept | May derive/select from | Must remain separate from | Owner |
+| --- | --- | --- | --- |
+| GroupPlan | target Core roster, teacher choices, optional immutable signal set, strategy preset | Group, GroupMembership, Score, signal source record | #50-#56 |
+| Manual GroupPlan | teacher placements and target Activity Sessions | direct canonical Membership state until approval/application | #51 |
+| Random plan | exact target roster, size/count, deterministic seed | automatic canonical writes | #52 |
+| Signal-based plan | exact Core signal snapshot + target roster | proficiency/ability interpretation, Scores, Membership band storage | #53-#55 |
+| Template Definition | reusable printable-design lineage | Activity/Group/student/generated Artifact history | #57 |
+| Template Version | exact immutable content/layout/page/return/privacy expectations | Artifact/Page/route instance identities | #57/#58 |
+| Packet Definition | reusable packet lineage | Activity-specific Packet Instance | #59 |
+| Packet Version | exact ordered component rules | generated Artifacts/pages/routes | #59/#60 |
+| Packet Instance | approved Packet Version + current Activity/Session/Group/participant context | reusable Packet Version identity/history | #62 |
+| Activity copy | explicitly approved reusable defaults/references | Sessions/Groups/Memberships/plans/signals/evidence/judgments/publications/history | #63 |
+| Role preset | reusable role key/description | RoleAssignment | #64 |
+| Responsibility preset | reusable obligation/output text | ResponsibilityAssignment | #64 |
+| Criterion preset/library | reusable Criterion Set semantics | arbitrary source Activity work graph and prior Scores | #64 |
+| Scale preset/library | reusable exact Scale definition | source Activity Score history | #64 |
+
+## 17. Privacy and safety boundary
+
+Reusable definitions, presets, starter libraries, and examples must be synthetic
+and privacy-minimized. They must not contain real student data.
+
+By default they exclude:
+
+- student names/IDs and roster snapshots;
+- prior Group/Membership/Role/Responsibility assignments;
+- grouping-signal values/bands;
+- raw grades/percentages;
+- Artifact Author/Subject associations from prior work;
+- Scan References and retained-source paths/digests;
+- Review/Moderation contents;
+- Score values/dispositions/rationale/evidence links;
+- route IDs/human fallbacks;
+- registration/publication IDs;
+- operational timestamps or copied provenance.
+
+A reusable privacy default must not silently broaden a target instance's effective
+audience. Target-context privacy resolution remains explicit and record-specific.
+
+## 18. Ownership freeze
+
+### Core remains authoritative for
+
+- workspace and safe path construction;
+- class/roster/student identity;
+- standards libraries/profiles and durable standard IDs;
+- PDS2 locator grammar and Route Registrations;
+- retained source scans and generic dispatch;
+- Academic Work Registration;
+- Publication Records and shared registries/catalogs;
+- neutral grouping-signal interchange after the relevant Core release.
+
+### Concord remains authoritative for
+
+- Activity and Session;
+- Group and GroupMembership;
+- Role and Responsibility assignments;
+- future GroupPlan;
+- future reusable Concord Template/Packet definitions;
+- generated Packet/Artifact/Page instances;
+- Artifact Authors and Subjects;
+- Review, Moderation, Criteria, Scoring Scales, Scores, and native history;
+- Concord Academic Result Manifest projection.
+
+Meridian remains optional and must not become a Concord runtime dependency.
+
+## 19. Documentation reconciliation findings
+
+### 19.1 Fixed by #48
+
+`docs/README.md` still described the v0.2.0 release audit/closeout as pending even
+though issue #34 and the v0.2.0 milestone are closed and this branch starts from
+the completed v0.2.0 release-audit commit. #48 updates that status language and
+adds this audit to the documentation index.
+
+### 19.2 Classified, not rewritten
+
+The conceptual design/contracts describe Template/Packet records that are not
+v0.2 runtime records. Those documents remain valid future architecture and are
+not stale merely because the native registry does not implement them yet. This
+audit supplies the missing status bridge rather than deleting the accepted
+conceptual material.
+
+The packet models remain representative cases, not mandatory production packet
+specifications.
+
+The group-planning interoperability plan remains future v0.3/Core work; no
+Meridian dependency or signal implementation is implied by this audit.
+
+## 20. Downstream decisions and blockers
+
+No blocker prevents #48 from closing.
+
+The following decisions are intentionally delegated but constrained:
+
+1. **#57/#58 Template authority/storage:** must establish a native reusable
+   definition/version authority; current `template_version_id` strings are not
+   sufficient.
+2. **#59/#60 Packet authority/storage:** must implement actual Packet
+   Definition/Version/Component management rather than treating physical or
+   conceptual packet descriptions as canonical instances.
+3. **#64 cross-Activity Criterion/Scale reuse:** must define explicit reusable
+   preset/library authority because v0.2 native definitions are Activity-work
+   scoped even when semantically reusable.
+4. **#63 Activity copy mapping:** must map selected reusable definitions/defaults
+   into fresh target state; it may not clone the source work graph.
+
+These are downstream design requirements, not unresolved questions requiring a
+new #48 decision.
+
+## 21. Validation expectations for this docs-only change
+
+#48 intentionally changes documentation only. It introduces no runtime model,
+storage, CLI, menu, dependency, or schema behavior.
+
+Repository qualification remains:
+
+```text
+python -m pytest
+python -m ruff check .
+python -m mypy
+git diff --check
+```
+
+The complete release validator may also be used when the authenticated Core
+wheel is available. No existing test should be weakened for this audit.
+
+## 22. Handoff checklist
+
+After #48 merges, later agents may rely on the following frozen answers:
+
+- reusable definition != prior Activity operational record;
+- copied Activity != cloned work graph;
+- GroupPlan != Group != GroupMembership;
+- direct manual Group creation remains supported;
+- signal band != ability/proficiency label != Score;
+- Role/Responsibility preset != assignment;
+- `CriterionSet.scope=reusable` does not imply an existing global library;
+- Template/Packet conceptual contracts are accepted, but native management is
+  still #57-#62 work;
+- `ArtifactInstance.template_version_id` is not proof of Template Version
+  resolution in v0.2;
+- Packet Version != Packet Instance;
+- new Packet/Artifact/Page instances require fresh identities;
+- new returnable pages require fresh PDS2 routes;
+- Authors, Subjects, Memberships, route targets, and Score targets remain
+  independent;
+- Scores/evidence/review/moderation/publication/history are never reusable
+  configuration;
+- Core shared records are referenced, not copied;
+- Meridian remains optional.
+
+That boundary is the completed deliverable of #48.


### PR DESCRIPTION
## Summary

Completes #48 by auditing Concord's current Activity, Group, scoring, Artifact/Page, and packet-related setup and freezing the boundary between reusable definitions/defaults and Activity-owned operational state before the rest of the v0.3.0 work proceeds.

This is intentionally documentation-only. It does not introduce GroupPlan, Template, Packet, preset, guided-setup, Core dependency, or runtime behavior changes.

Closes #48.

## What changed

- Added docs/v0.3.0-reusable-instance-boundary-audit.md as the normative #48 handoff for later v0.3.0 issues.
- Classified current and planned fields as reusable definitions, reusable defaults/presets, Activity-instance configuration, operational/history state, external/shared references, or planning-only state.
- Froze Activity-copy exclusions so later copying cannot duplicate Sessions, Groups, Memberships, GroupPlans, grouping signals, Artifacts, routes, Authors/Subjects, Reviews, Moderation, Scores, manifests, publications, or provenance/history.
- Preserved direct manual Group creation as a first-class workflow distinct from future GroupPlan proposal/approval/application.
- Clarified that Role/Responsibility presets describe reusable functions or obligations, not prior assignments.
- Clarified that CriterionSet.scope=reusable is semantic metadata in v0.2.0; there is currently no cross-Activity Criterion/Scale library.
- Clarified that ArtifactInstance.template_version_id and packet_instance_id do not mean a native Template/Packet subsystem is already implemented.
- Froze the fresh-identity chain for new Activity-specific Packet/Artifact/Page instances and PDS2 routes.
- Recorded grouping-signal privacy/ownership boundaries without adding a Meridian dependency or implementing the Core signal contract.
- Updated docs/README.md to index the audit and correct stale v0.2.0 release-closeout wording.

## Architectural outcome

The audit establishes this rule for later v0.3.0 work:

    reusable definition / preset / selected shared reference
        -> fresh Activity-specific configuration or planning state
        -> explicit teacher approval where required
        -> fresh canonical operational records
        -> fresh evidence / routing / judgment history

An earlier Activity's operational records must never be copied into a new Activity as if they were reusable configuration.

## Validation

Local validation on Windows / Python 3.11.9:

    python -m pytest
    557 passed, 10 skipped

    python -m ruff check .
    All checks passed!

    python -m mypy
    Success: no issues found in 98 source files

    git diff --check
    clean

The 10 pytest skips are the existing environment-specific symlink/POSIX-only cases plus the release-validator PDS_CORE_WHEEL qualification test.

## Scope

Changed files only:

    docs/README.md
    docs/v0.3.0-reusable-instance-boundary-audit.md

No runtime code, schemas, dependencies, package metadata, or migrations are changed.