### PR TITLE
Implement deterministic random GroupPlan planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Deterministic seeded random GroupPlan generation over the exact Core roster,
+  with the versioned `pds-concord:group-plan-random:v1` SHA-256 ranking contract,
+  exact size/count targets, balanced nonempty groups, and exact-roster race
+  protection.
+- Direct `concord group-plan create-random` and bounded teacher-menu random-plan
+  creation over the same typed workflow, preserving manual-edit/preview/approval
+  behavior while creating no canonical Group/Membership or signal dependency.
 - Native planning-only `GroupPlan` and `PlannedGroup` contracts registered in
   Concord's descriptor-driven record graph, with exact mapping conversion,
   Activity/class/context validation, existing immutable record-history

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ The package now includes the collaboration-context workflow required to create
 and manage Activities, Sessions, Groups, contextual Group Memberships, Roles,
 and Responsibilities. The v0.3 development line also includes teacher-restricted
 `GroupPlan` authoring with manual plan-local groups, exact Core-roster placement,
-explicit roster refresh, and strict `student_id,group` arrangement CSV import.
-Planning remains separate from canonical Group/Membership application, which is
+explicit roster refresh, strict `student_id,group` arrangement CSV import, and
+deterministic seeded random proposals using exact size/count targets. Planning
+remains separate from canonical Group/Membership application, which is
 reserved for issue #56. The same typed service layer supports a fully
 noninteractive direct CLI and a teacher-facing low-information-density menu.
 Canonical state remains protected by immutable history, exact expected-snapshot
@@ -106,7 +107,7 @@ concord activity create|list|show|update|set-status
 concord session add|list|show|update|set-status
 concord group create|list|show|update|set-status
 concord group member add|list|end|reassign
-concord group-plan list|show|create-manual|add-group|edit-group|remove-group
+concord group-plan list|show|create-manual|create-random|add-group|edit-group|remove-group
 concord group-plan place-student|unassign-student|refresh-roster
 concord group-plan import-arrangement|replace-arrangement|preview|approve|cancel
 concord role assign|list|end|reassign
@@ -190,6 +191,9 @@ The planning-only record/lifecycle foundation is documented in the
 authoring, arrangement CSV, direct CLI, menu, roster-refresh, and privacy
 boundaries are documented in the
 [manual Group planning guide](docs/v0.3.0-manual-group-planning.md).
+Issue #52's exact seeded SHA-256 ranking, balanced partitioning, direct CLI/menu
+creation, refresh behavior, and privacy boundaries are documented in the
+[deterministic random planning guide](docs/v0.3.0-random-group-planning.md).
 The clean installed-wheel producer lifecycle and its Core verification,
 authorization, audit, and immutability boundaries are documented in the
 [installed acceptance guide](docs/implementation/installed-end-to-end-acceptance.md).
@@ -202,7 +206,7 @@ Run focused checks with `python -m pytest`, `python -m ruff check .`, and
 `python -m mypy`. Run the complete repository validation on Windows with:
 
 ```powershell
-.\run_tests.ps1 -CoreWheel path\to\pds_core-0.6.0-py3-none-any.whl
+.\run_tests.ps1 -CoreWheel path\to\pds_core-0.6.1-py3-none-any.whl
 ```
 
 The cross-platform equivalent is:
@@ -211,7 +215,7 @@ The cross-platform equivalent is:
 python scripts/validate_repository.py --core-wheel <wheel>
 ```
 
-The validator authenticates the exact Core v0.6.0 wheel, runs pytest, Ruff,
+The validator authenticates the exact Core v0.6.1 wheel, runs pytest, Ruff,
 strict Mypy, documentation checks, package builds, Twine validation, package
 inspection, isolated installed-wheel workflow/menu/public-reader smoke tests, and
 the full installed Activity-to-publication producer acceptance before

--- a/concord/cli_app/handlers/group_plan.py
+++ b/concord/cli_app/handlers/group_plan.py
@@ -17,6 +17,7 @@ from concord.workflows import (
     ArrangementImportResult,
     CancelGroupPlanRequest,
     CreateManualGroupPlanRequest,
+    CreateRandomGroupPlanRequest,
     EditPlannedGroupRequest,
     GroupPlanDetail,
     GroupPlanEditResult,
@@ -32,6 +33,7 @@ from concord.workflows import (
     approve_group_plan,
     cancel_group_plan,
     create_manual_group_plan,
+    create_random_group_plan,
     edit_planned_group,
     import_arrangement_group_plan,
     list_group_plans,
@@ -144,6 +146,39 @@ def handle_create_manual(args: argparse.Namespace) -> int:
     print_commit(result.commit)
     print(f"GroupPlan: {result.group_plan_id}")
     print(f"Status: {result.status}")
+    return 0
+
+
+def handle_create_random(args: argparse.Namespace) -> int:
+    result = create_random_group_plan(
+        CreateRandomGroupPlanRequest(
+            class_id=args.class_id,
+            activity_id=args.activity_id,
+            group_plan_id=args.group_plan_id,
+            expected_snapshot_revision=args.expected_snapshot,
+            actor=workflow_actor(args),
+            seed=args.seed,
+            target_group_size=args.target_group_size,
+            target_group_count=args.target_group_count,
+        ),
+        workspace_root=workspace_arg(args),
+        standards_library=load_command_standards_library(args),
+    )
+    mutation = result.mutation
+    print_commit(mutation.commit)
+    print(f"GroupPlan: {mutation.group_plan_id}")
+    print("Strategy: random")
+    print(f"Status: {mutation.status}")
+    if args.target_group_size is not None:
+        print(f"Target group size: {args.target_group_size}")
+    else:
+        print(f"Target group count: {args.target_group_count}")
+    print(f"Seed: {args.seed}")
+    print(f"Generated groups: {result.group_count}")
+    print(f"Assigned students: {result.assigned_student_count}")
+    print("Unresolved students: 0")
+    print(f"Group sizes: {','.join(str(size) for size in result.group_sizes)}")
+    print("Canonical Groups created: no")
     return 0
 
 

--- a/concord/cli_app/parser.py
+++ b/concord/cli_app/parser.py
@@ -359,6 +359,19 @@ def _group_plan_commands(
     target.add_argument("--target-group-count", type=int)
     create.set_defaults(handler=group_plan.handle_create_manual)
 
+    random_create = actions.add_parser(
+        "create-random",
+        help="Create a deterministic seeded random draft GroupPlan.",
+    )
+    _mutating_options(random_create)
+    _class_activity(random_create)
+    random_create.add_argument("--group-plan-id", required=True)
+    random_create.add_argument("--seed", required=True)
+    random_target = random_create.add_mutually_exclusive_group(required=True)
+    random_target.add_argument("--target-group-size", type=int)
+    random_target.add_argument("--target-group-count", type=int)
+    random_create.set_defaults(handler=group_plan.handle_create_random)
+
     add = actions.add_parser("add-group", help="Add an empty plan-local group.")
     _mutating_options(add)
     _class_activity(add)

--- a/concord/group_plan_random.py
+++ b/concord/group_plan_random.py
@@ -1,0 +1,168 @@
+"""Pure deterministic random GroupPlan proposal generation for Concord v0.3."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from hashlib import sha256
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from concord.models import PlannedGroup
+
+RANDOM_PLANNING_DOMAIN = "pds-concord:group-plan-random:v1"
+_DOMAIN_BYTES = RANDOM_PLANNING_DOMAIN.encode("utf-8") + b"\0"
+
+
+class RandomGroupPlanningError(ValueError):
+    """Raised when deterministic random-planning inputs are invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class RandomGroupPlanProposal:
+    """One complete deterministic planning proposal before persistence."""
+
+    roster_student_ids: tuple[str, ...]
+    proposed_groups: tuple[PlannedGroup, ...]
+    group_sizes: tuple[int, ...]
+    group_count: int
+
+    @property
+    def assigned_student_count(self) -> int:
+        return len(self.roster_student_ids)
+
+
+def _require_seed(seed: str) -> str:
+    if not isinstance(seed, str) or not seed.strip():
+        raise RandomGroupPlanningError("seed must be a nonempty string.")
+    if seed != seed.strip():
+        raise RandomGroupPlanningError(
+            "seed must not contain leading or trailing whitespace."
+        )
+    return seed
+
+
+def _canonical_roster(student_ids: tuple[str, ...]) -> tuple[str, ...]:
+    if not student_ids:
+        raise RandomGroupPlanningError("random planning requires a nonempty roster.")
+    validated: list[str] = []
+    for student_id in student_ids:
+        try:
+            validated.append(validate_identifier(student_id, "student_id"))
+        except (IdentifierValidationError, TypeError, ValueError) as error:
+            raise RandomGroupPlanningError(str(error)) from error
+    if len(set(validated)) != len(validated):
+        raise RandomGroupPlanningError(
+            "random planning roster must not contain duplicate student IDs."
+        )
+    return tuple(sorted(validated))
+
+
+def _positive_int(value: int | None, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise RandomGroupPlanningError(f"{field_name} must be a positive integer.")
+    return value
+
+
+def _resolve_group_count(
+    roster_size: int,
+    *,
+    target_group_size: int | None,
+    target_group_count: int | None,
+) -> int:
+    size = _positive_int(target_group_size, "target_group_size")
+    count = _positive_int(target_group_count, "target_group_count")
+    if (size is None) == (count is None):
+        raise RandomGroupPlanningError(
+            "exactly one of target_group_size or target_group_count is required."
+        )
+    if count is not None:
+        if count > roster_size:
+            raise RandomGroupPlanningError(
+                "target_group_count must not exceed the current roster size."
+            )
+        return count
+    assert size is not None
+    return (roster_size + size - 1) // size
+
+
+def _rank_digest(seed: str, student_id: str) -> bytes:
+    payload = (
+        _DOMAIN_BYTES
+        + seed.encode("utf-8")
+        + b"\0"
+        + student_id.encode("utf-8")
+    )
+    return sha256(payload).digest()
+
+
+def deterministic_random_student_order(
+    student_ids: tuple[str, ...],
+    seed: str,
+) -> tuple[str, ...]:
+    """Return the v1 deterministic seed-ranked exact student order."""
+
+    canonical = _canonical_roster(student_ids)
+    exact_seed = _require_seed(seed)
+    return tuple(
+        sorted(
+            canonical,
+            key=lambda student_id: (
+                _rank_digest(exact_seed, student_id),
+                student_id,
+            ),
+        )
+    )
+
+
+def generate_random_group_plan_proposal(
+    student_ids: tuple[str, ...],
+    *,
+    seed: str,
+    target_group_size: int | None = None,
+    target_group_count: int | None = None,
+) -> RandomGroupPlanProposal:
+    """Generate a complete balanced proposal with no persistence side effects."""
+
+    canonical = _canonical_roster(student_ids)
+    exact_seed = _require_seed(seed)
+    group_count = _resolve_group_count(
+        len(canonical),
+        target_group_size=target_group_size,
+        target_group_count=target_group_count,
+    )
+    ordered = tuple(
+        sorted(
+            canonical,
+            key=lambda student_id: (
+                _rank_digest(exact_seed, student_id),
+                student_id,
+            ),
+        )
+    )
+    base_size, extra = divmod(len(ordered), group_count)
+    group_sizes = tuple(
+        base_size + (1 if index < extra else 0)
+        for index in range(group_count)
+    )
+
+    offset = 0
+    groups: list[PlannedGroup] = []
+    for index, group_size in enumerate(group_sizes, start=1):
+        students = ordered[offset : offset + group_size]
+        offset += group_size
+        groups.append(
+            PlannedGroup(
+                planned_group_key=f"random-{index}",
+                label=f"Group {index}",
+                student_ids=students,
+            )
+        )
+
+    return RandomGroupPlanProposal(
+        roster_student_ids=canonical,
+        proposed_groups=tuple(groups),
+        group_sizes=group_sizes,
+        group_count=group_count,
+    )

--- a/concord/menu_group_plan.py
+++ b/concord/menu_group_plan.py
@@ -17,6 +17,8 @@ from concord.menu_prompts import (
     choose_student,
     confirm_write,
     handle_write_error,
+    prompt_exact_text,
+    prompt_positive_int,
     prompt_text,
     select_one,
     show_result,
@@ -36,6 +38,7 @@ from concord.workflows import (
     CancelGroupPlanRequest,
     ConcordWorkflowError,
     CreateManualGroupPlanRequest,
+    CreateRandomGroupPlanRequest,
     EditPlannedGroupRequest,
     GroupPlanDetail,
     GroupPlanSummary,
@@ -50,6 +53,7 @@ from concord.workflows import (
     approve_group_plan,
     cancel_group_plan,
     create_manual_group_plan,
+    create_random_group_plan,
     edit_planned_group,
     import_arrangement_group_plan,
     list_group_plans,
@@ -125,6 +129,12 @@ def _show_detail(detail: GroupPlanDetail) -> None:
     print(f"Record revision: {detail.record_revision}")
     print(f"Planned groups: {len(plan.proposed_groups)}")
     print(f"Unresolved students: {len(plan.unresolved_student_ids)}")
+    if plan.target_group_size is not None:
+        print(f"Target group size: {plan.target_group_size}")
+    if plan.target_group_count is not None:
+        print(f"Target group count: {plan.target_group_count}")
+    if plan.seed is not None:
+        print(f"Seed: {plan.seed}")
     print()
     for group in plan.proposed_groups:
         print(
@@ -198,6 +208,110 @@ def _create_manual(activity: ActivitySummary, state: MenuSessionContext) -> None
                 f"GroupPlan: {result.group_plan_id}",
                 f"Status: {result.status}",
                 f"Snapshot: {result.commit.snapshot_revision}",
+                "Canonical Groups created: no",
+            ),
+        )
+    except CancelMenuAction:
+        return
+    except Exception as error:
+        _handle_error(activity, "GroupPlan Error", error)
+
+
+def _create_random(activity: ActivitySummary, state: MenuSessionContext) -> None:
+    try:
+        current = _latest(activity)
+        plan_id = prompt_text(
+            "Create Random GroupPlan",
+            "GroupPlan ID",
+            help_text="Use a durable identifier for this planning proposal.",
+            default=slug_identifier(f"{current.activity_id}-random", "group-plan"),
+        )
+        assert plan_id is not None
+        target_kind = select_one(
+            "Random Group Target",
+            ("size", "count"),
+            ("Target group size", "Target group count"),
+            help_text=(
+                "Choose whether Concord should derive the group count from a maximum "
+                "target size or create an exact requested number of groups."
+            ),
+        )
+        if target_kind == "size":
+            target_group_size = prompt_positive_int(
+                "Create Random GroupPlan",
+                "Target group size",
+                help_text=(
+                    "Concord will use ceil(roster size / target size) groups and "
+                    "balance their sizes as evenly as possible."
+                ),
+                default=4,
+            )
+            target_group_count = None
+            target_line = f"Target group size: {target_group_size}"
+        else:
+            target_group_count = prompt_positive_int(
+                "Create Random GroupPlan",
+                "Target group count",
+                help_text=(
+                    "Concord will create exactly this many nonempty groups; the count "
+                    "cannot exceed the current roster size."
+                ),
+                default=4,
+            )
+            target_group_size = None
+            target_line = f"Target group count: {target_group_count}"
+        seed = prompt_exact_text(
+            "Create Random GroupPlan",
+            "Seed",
+            help_text=(
+                "Enter an explicit reproducibility seed. Leading or trailing "
+                "whitespace is invalid and will be rejected rather than trimmed. "
+                "The same exact roster, target, and seed reproduce the same v0.3 "
+                "arrangement."
+            ),
+        )
+        assert seed is not None
+        if not confirm_write(
+            "Create Random GroupPlan",
+            "CREATE",
+            (
+                f"Activity: {current.title}",
+                f"GroupPlan: {plan_id}",
+                target_line,
+                f"Seed: {seed}",
+                "The current Core roster will be assigned exactly once.",
+                "This is a deterministic random proposal, not an optimized grouping.",
+                "No canonical Groups or Memberships will be created.",
+            ),
+        ):
+            return
+        result = create_random_group_plan(
+            CreateRandomGroupPlanRequest(
+                class_id=current.class_id,
+                activity_id=current.activity_id,
+                group_plan_id=plan_id,
+                expected_snapshot_revision=current.snapshot_revision,
+                actor=state.require_actor(),
+                seed=seed,
+                target_group_size=target_group_size,
+                target_group_count=target_group_count,
+            )
+        )
+        mutation = result.mutation
+        show_result(
+            "GroupPlan Result",
+            (
+                "Random GroupPlan created.",
+                f"GroupPlan: {mutation.group_plan_id}",
+                "Strategy: random",
+                f"Status: {mutation.status}",
+                target_line,
+                f"Seed: {seed}",
+                f"Generated groups: {result.group_count}",
+                f"Assigned students: {result.assigned_student_count}",
+                "Unresolved students: 0",
+                f"Group sizes: {','.join(str(size) for size in result.group_sizes)}",
+                f"Snapshot: {mutation.commit.snapshot_revision}",
                 "Canonical Groups created: no",
             ),
         )
@@ -750,8 +864,9 @@ def launch_group_plan_menu(
         print()
         print("1. List GroupPlans")
         print("2. Create a manual GroupPlan")
-        print("3. Import an arrangement CSV")
-        print("4. Open a GroupPlan")
+        print("3. Create a random GroupPlan")
+        print("4. Import an arrangement CSV")
+        print("5. Open a GroupPlan")
         print_navigation()
         print()
         choice = input("Select an option: ").strip()
@@ -771,8 +886,10 @@ def launch_group_plan_menu(
         elif choice == "2":
             _create_manual(current, state)
         elif choice == "3":
-            _import_arrangement(current, state)
+            _create_random(current, state)
         elif choice == "4":
+            _import_arrangement(current, state)
+        elif choice == "5":
             try:
                 selected = _select_plan(current, title="Open a GroupPlan")
                 _open_plan(current, selected, state)

--- a/concord/menu_prompts.py
+++ b/concord/menu_prompts.py
@@ -86,6 +86,33 @@ def prompt_text(
             return None
 
 
+def prompt_exact_text(
+    title: str,
+    label: str,
+    *,
+    help_text: str,
+) -> str:
+    """Prompt for exact text while preserving whitespace for validation."""
+    while True:
+        clear_screen()
+        print_menu_header(title)
+        print_navigation()
+        print()
+        raw = input(f"{label}: ")
+        navigation = parse_menu_navigation(raw)
+        if navigation is ConcordMenuChoice.HELP:
+            clear_screen()
+            print_menu_header(f"{title} Help")
+            print(help_text)
+            print()
+            pause_for_user()
+            continue
+        if navigation is NavigationChoice.BACK:
+            raise CancelMenuAction
+        if raw != "":
+            return raw
+
+
 def prompt_positive_int(
     title: str,
     label: str,

--- a/concord/workflows/__init__.py
+++ b/concord/workflows/__init__.py
@@ -150,6 +150,11 @@ from concord.workflows.group_plan_manual import (
     replace_group_plan_from_arrangement,
     unassign_student_from_plan,
 )
+from concord.workflows.group_plan_random import (
+    CreateRandomGroupPlanRequest,
+    RandomGroupPlanCreationResult,
+    create_random_group_plan,
+)
 from concord.workflows.models import (
     ActivityContextResult,
     ActivityDetail,
@@ -476,4 +481,7 @@ __all__ = [
     "remove_planned_group",
     "replace_group_plan_from_arrangement",
     "unassign_student_from_plan",
+    "CreateRandomGroupPlanRequest",
+    "RandomGroupPlanCreationResult",
+    "create_random_group_plan",
 ]

--- a/concord/workflows/group_plan.py
+++ b/concord/workflows/group_plan.py
@@ -56,6 +56,7 @@ class CreateGroupPlanRequest:
     source_signal_set_id: str | None = None
     source_signal_set_digest: str | None = None
     source_signal_dimension_id: str | None = None
+    expected_roster_student_ids: tuple[str, ...] | None = None
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -342,6 +343,13 @@ def create_group_plan(
         "GroupPlan",
     )
     roster_student_ids = _roster_student_ids(root, request.class_id)
+    if (
+        request.expected_roster_student_ids is not None
+        and roster_student_ids != request.expected_roster_student_ids
+    ):
+        raise ConcordWorkflowConflictError(
+            "Core roster changed while preparing the GroupPlan; reload and retry."
+        )
     unresolved = _validate_proposed_students(
         request.proposed_groups,
         roster_student_ids,

--- a/concord/workflows/group_plan_random.py
+++ b/concord/workflows/group_plan_random.py
@@ -1,0 +1,104 @@
+"""Deterministic random GroupPlan creation over the native planning boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from pds_core.standards import StandardsLibrary
+
+from concord.group_plan_random import (
+    RandomGroupPlanningError,
+    generate_random_group_plan_proposal,
+)
+from concord.workflows.context import (
+    Clock,
+    require_core_class,
+    resolve_read_workspace_root,
+)
+from concord.workflows.errors import (
+    ConcordWorkflowNotFoundError,
+    ConcordWorkflowValidationError,
+)
+from concord.workflows.group_plan import (
+    CreateGroupPlanRequest,
+    GroupPlanMutationResult,
+    create_group_plan,
+)
+from concord.workflows.models import WorkflowActor
+from concord.workflows.participants import load_required_roster
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CreateRandomGroupPlanRequest:
+    class_id: str
+    activity_id: str
+    group_plan_id: str
+    expected_snapshot_revision: int
+    actor: WorkflowActor
+    seed: str
+    target_group_size: int | None = None
+    target_group_count: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RandomGroupPlanCreationResult:
+    mutation: GroupPlanMutationResult
+    group_count: int
+    assigned_student_count: int
+    group_sizes: tuple[int, ...]
+
+
+def create_random_group_plan(
+    request: CreateRandomGroupPlanRequest,
+    *,
+    workspace_root: str | Path | None = None,
+    standards_library: StandardsLibrary | None = None,
+    clock: Clock | None = None,
+) -> RandomGroupPlanCreationResult:
+    """Create one complete deterministic random draft through #50 services."""
+
+    root = resolve_read_workspace_root(workspace_root)
+    if root is None:
+        raise ConcordWorkflowNotFoundError(
+            "Paper Data Suite workspace does not exist."
+        )
+    require_core_class(root, request.class_id)
+    roster = load_required_roster(root, request.class_id)
+    roster_student_ids = tuple(
+        sorted(student.student_id for student in roster.students)
+    )
+    try:
+        proposal = generate_random_group_plan_proposal(
+            roster_student_ids,
+            seed=request.seed,
+            target_group_size=request.target_group_size,
+            target_group_count=request.target_group_count,
+        )
+    except RandomGroupPlanningError as error:
+        raise ConcordWorkflowValidationError(str(error)) from error
+
+    mutation = create_group_plan(
+        CreateGroupPlanRequest(
+            class_id=request.class_id,
+            activity_id=request.activity_id,
+            group_plan_id=request.group_plan_id,
+            strategy="random",
+            expected_snapshot_revision=request.expected_snapshot_revision,
+            actor=request.actor,
+            proposed_groups=proposal.proposed_groups,
+            target_group_size=request.target_group_size,
+            target_group_count=request.target_group_count,
+            seed=request.seed,
+            expected_roster_student_ids=proposal.roster_student_ids,
+        ),
+        workspace_root=root,
+        standards_library=standards_library,
+        clock=clock,
+    )
+    return RandomGroupPlanCreationResult(
+        mutation=mutation,
+        group_count=proposal.group_count,
+        assigned_student_count=proposal.assigned_student_count,
+        group_sizes=proposal.group_sizes,
+    )

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,9 @@ create/replace/read/preview/approve/cancel lifecycle services. Issue #51 now
 implements manual plan-local authoring, exact roster placement and refresh,
 strict `student_id,group` arrangement import/replacement, the direct
 `concord group-plan ...` family, and a bounded teacher-menu planning path.
-Canonical plan application remains reserved for #56.
+Issue #52 now adds exact seeded deterministic random proposals with explicit
+size/count targets and balanced partitioning. Canonical plan application remains
+reserved for #56.
 
 The repository now contains:
 
@@ -49,6 +51,8 @@ The repository now contains:
 * teacher-controlled manual GroupPlan editing, explicit Core-roster refresh,
   strict deterministic arrangement CSV import/replacement, and shared direct/menu
   planning surfaces with no canonical Group/Membership side effects;
+* deterministic seeded random GroupPlan generation with exact target semantics,
+  stable SHA-256 v1 ordering, balanced sizes, and no signal dependency;
 * contextual Membership, Role, and Responsibility workflow services;
 * a fully noninteractive direct CLI;
 * a teacher-facing H/B/M/Q menu with low-information-density screens;
@@ -145,12 +149,21 @@ refresh, strict deterministic `student_id,group` CSV import/replacement,
 direct CLI and bounded teacher-menu surfaces, lifecycle reuse, privacy
 constraints, and the hard separation from canonical Group/Membership creation.
 
+### 28. v0.3.0 deterministic random Group planning
+
+[`v0.3.0-random-group-planning.md`](v0.3.0-random-group-planning.md)
+
+Documents issue #52's exact seed contract, versioned SHA-256 ranking,
+target-size/count formulas, balanced partitioning, stable plan-local group
+identity, exact-roster race protection, manual-edit/refresh behavior, direct
+CLI/menu creation, privacy boundary, and #53-#56 handoffs.
+
 ### Future v0.3.0 Group Planning / Template / Packet plan
 
 [`pds-group-planning-interoperability-development-plan.md`](pds-group-planning-interoperability-development-plan.md)
 
 This remains the roadmap for future v0.3.0 issues beyond the implemented
-#48-#51 foundations. It does not make the #52-#56 random/signal planning,
+#48-#52 foundations. It does not make the #53-#56 signal planning,
 missing-signal policy, or canonical application implemented, nor does it make
 Template, Packet, guided Activity setup, or final integrated teacher UI behavior
 implemented merely because their contracts are documented.

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented through the v0.3.0 manual GroupPlan authoring workflow in issue #51.
+Implemented through the v0.3.0 deterministic random GroupPlan workflow in issue #52.
 
 ## Two interfaces, one service layer
 
@@ -60,6 +60,7 @@ concord group member reassign
 concord group-plan list
 concord group-plan show
 concord group-plan create-manual
+concord group-plan create-random
 concord group-plan add-group
 concord group-plan edit-group
 concord group-plan remove-group
@@ -247,8 +248,14 @@ operational `Group`/`GroupMembership` command family.
 
 The `group-plan` family supports manual draft creation, plan-local group metadata,
 exact roster-student placement/movement/unassignment, explicit roster refresh,
-strict arrangement CSV import/replacement, and the existing preview/approve/cancel
-lifecycle.
+strict arrangement CSV import/replacement, deterministic seeded random creation,
+and the existing preview/approve/cancel lifecycle.
+
+`group-plan create-random` requires an explicit seed and exactly one of
+`--target-group-size` or `--target-group-count`. The same exact roster, target,
+and seed use the documented `pds-concord:group-plan-random:v1` SHA-256 ranking
+and balanced partitioning contract. Random creation assigns the complete current
+roster, creates a `draft`, and creates no canonical Group or Membership.
 
 Targeted plan edits reject Core-roster drift instead of silently refreshing it.
 `refresh-roster` is the explicit operation that preserves remaining placements,

--- a/docs/v0.3.0-group-plan-contract.md
+++ b/docs/v0.3.0-group-plan-contract.md
@@ -142,7 +142,11 @@ but never both. Generated non-draft random/signal proposals require exactly one
 target. #50 records these inputs but does not implement a grouping algorithm.
 
 `seed` is reserved for deterministic random plans. A non-draft random proposal
-requires an explicit seed; #52 defines the algorithm and seed interpretation.
+requires an explicit seed. Issue #52 now implements the exact
+`pds-concord:group-plan-random:v1` SHA-256 ranking contract, exact size/count
+target semantics, balanced partitioning, deterministic `random-N` plan-local
+keys, and complete-roster draft generation. Random planning has no signal or
+Meridian dependency.
 
 ## Optional Core signal binding
 
@@ -320,7 +324,7 @@ Existing direct Group workflows remain unchanged.
 
 ```text
 #51 manual planning and student_id,group import — implemented
-#52 deterministic random planning
+#52 deterministic random planning — implemented
 #53 signal discovery/import/dimension diagnostics
 #54 similar-signal and mixed-signal algorithms
 #55 explicit missing-signal teacher decisions
@@ -357,6 +361,11 @@ fail-closed roster refresh, deterministic strict CSV normalization, direct
 `concord group-plan ...` commands, and a bounded teacher-menu planning path.
 Those operations reuse this lifecycle and preserve the no-canonical-side-effect
 boundary through approval.
+
+Issue #52 now layers deterministic seeded random generation on the same contract.
+It generates a complete draft from the exact Core roster, one explicit
+size/count target, and an explicit seed, then leaves all editing, preview, and
+approval behavior to the existing #50/#51 services.
 
 Canonical application remains reserved for #56; there is intentionally no
 generic `apply_group_plan`, `mark_group_plan_applied`, or status setter.

--- a/docs/v0.3.0-manual-group-planning.md
+++ b/docs/v0.3.0-manual-group-planning.md
@@ -90,6 +90,11 @@ no-op. Neither action creates native history or a new Activity-work snapshot.
 
 ## Editing generated or imported plans
 
+Issue #52 now implements the deterministic `random` origin described by this
+editing contract. Random plans use these same draft/previewed edit operations,
+and ordinary teacher edits preserve their original seed and size/count target
+rather than converting the plan to `manual`.
+
 The manual editor is not restricted to plans whose strategy is `manual`.
 
 A draft or previewed plan created by a later random or signal-backed planner may
@@ -474,7 +479,7 @@ git status --short
 Issue #51 leaves these concerns deliberately deferred:
 
 ```text
-#52 deterministic random planner
+#52 deterministic random planner — implemented
 #53 grouping-signal discovery/import/dimension diagnostics
 #54 similar-signal and mixed-signal planners
 #55 explicit missing-signal teacher disposition

--- a/docs/v0.3.0-random-group-planning.md
+++ b/docs/v0.3.0-random-group-planning.md
@@ -1,0 +1,224 @@
+# Concord v0.3.0 Deterministic Random Group Planning
+
+**Issue:** #52 — Implement deterministic random planning
+**Status:** Implemented on the v0.3.0 development line
+**Development version:** `pds-concord 0.3.0.dev0`
+**Core requirement:** `pds-core>=0.6.1,<0.7`
+
+## Purpose
+
+Issue #52 adds Concord's first generated `GroupPlan` strategy without adding a
+second proposal model or changing the teacher-approval boundary.
+
+```text
+exact Core roster
++ exactly one size/count target
++ explicit seed
+        |
+        v
+deterministic random proposal
+        |
+        v
+GroupPlan(strategy=random, status=draft)
+        |
+        +--> optional #51 manual edits
+        |
+        v
+preview -> approve
+        |
+        | #56 only
+        v
+Group + GroupMembership
+```
+
+A generated plan remains teacher-restricted planning state. Generation,
+editing, preview, and approval create no canonical Group or GroupMembership.
+
+## Exact inputs
+
+The public workflow is `create_random_group_plan` with
+`CreateRandomGroupPlanRequest`.
+
+A request contains class, Activity, stable `group_plan_id`, exact expected
+Activity snapshot revision, actor provenance, explicit seed, and exactly one of
+`target_group_size` or `target_group_count`.
+
+The seed is an exact nonempty string. Leading or trailing whitespace is invalid
+and is rejected rather than trimmed. Case and interior characters are preserved.
+Concord does not generate an implicit seed from time, UUIDs, process state, or
+OS entropy.
+
+Random planning requires a nonempty exact Core roster. Student identity is only
+the exact Core `student_id`. Names, email, roster positions, grades, signals,
+demographics, behavior, attendance, roles, and prior collaboration are not
+algorithm inputs.
+
+## Target semantics
+
+Let `N` be the roster size.
+
+For target group count `K`, require `1 <= K <= N` and generate exactly `K`
+nonempty groups.
+
+For target group size `S`, require `S >= 1` and compute:
+
+```text
+K = ceil(N / S)
+K = (N + S - 1) // S
+```
+
+The original size target remains persisted as `target_group_size`; Concord does
+not replace it with the derived count.
+
+Examples:
+
+```text
+N=10, K=3 -> sizes 4,3,3
+N=10, K=4 -> sizes 3,3,2,2
+N=10, S=4 -> K=3 -> sizes 4,3,3
+N=8,  S=3 -> K=3 -> sizes 3,3,2
+```
+
+## Deterministic random v1 contract
+
+The algorithm contract is versioned by this exact domain separator:
+
+```text
+pds-concord:group-plan-random:v1
+```
+
+Canonicalize the roster with `sorted(exact_student_ids)`. For each exact
+`student_id`, construct:
+
+```text
+b"pds-concord:group-plan-random:v1\0"
++ seed.encode("utf-8")
++ b"\0"
++ student_id.encode("utf-8")
+```
+
+Then compute `rank = sha256(payload).digest()` and order students by
+`(rank, student_id)`. The exact student ID is the deterministic collision
+tie-breaker.
+
+The authoritative v1 algorithm does not use Python `hash()`, `random.shuffle`,
+`random.sample`, set iteration, dictionary iteration derived from noncanonical
+input, wall-clock time, or OS randomness. SHA-256 is used as a stable
+cross-platform ranking function, not as a security claim.
+
+For the same exact roster, target, and seed, the resulting planned membership is
+identical regardless of source roster order, process, supported Python version,
+Windows versus Linux, actor, timestamp, or `group_plan_id`.
+
+## Balanced partitioning
+
+After deriving ordered students and `K`, Concord computes
+`base_size, extra = divmod(N, K)`. The first `extra` groups contain
+`base_size + 1` students and the rest contain `base_size`. Therefore
+`max(group_size) - min(group_size) <= 1` for every valid #52 proposal. For a
+size target, no generated group exceeds the requested target.
+
+## Plan-local identity and persistence
+
+Generated groups use deterministic plan-local identities:
+
+```text
+random-1 -> Group 1
+random-2 -> Group 2
+...
+random-K -> Group K
+```
+
+They are not canonical `group_id` values. New generated groups have no
+description or Effective Context.
+
+The pure planner has no workspace/storage side effects. The workflow creates a
+complete proposal first and then calls the existing #50 `create_group_plan`
+boundary with an exact expected-roster precondition. If Core roster identity
+changes between generation and persistence, creation fails closed.
+
+A successful plan persists `strategy=random`, `status=draft`, the exact seed,
+only the selected target field, no signal binding, and
+`unresolved_student_ids=()`.
+
+## Manual editing and explicit roster refresh
+
+Random plans use the #51 editor unchanged. Teachers may rename/add/remove
+plan-local groups and place/move/unassign/re-place students. Material edits
+preserve `strategy=random`, the original seed, and the original target.
+
+Explicit roster refresh preserves placements for still-rostered students,
+removes departed students, adds newcomers unresolved, preserves empty groups and
+random-origin metadata, and returns a previewed plan to draft. Refresh never
+silently reruns the random algorithm. A teacher who wants a fresh arrangement
+creates a new random GroupPlan.
+
+## Lifecycle and interfaces
+
+Random generation creates only a draft. Preview and approval remain separate
+explicit #50 writes. Approval creates no canonical Group or GroupMembership.
+Only Issue #56 may apply an approved plan.
+
+The noninteractive command is:
+
+```text
+concord group-plan create-random
+```
+
+It requires an explicit seed and exactly one of `--target-group-size` or
+`--target-group-count`, plus the normal class/Activity/plan/actor/snapshot
+arguments. Success reports compact counts and explicitly states:
+
+```text
+Canonical Groups created: no
+```
+
+The bounded `Plan groups` menu now exposes manual, random, and arrangement-import
+creation. The random path asks for target type/value and exact seed, reviews the
+inputs, and requires `CREATE`. The exact seed prompt preserves whitespace so
+invalid leading/trailing whitespace is rejected rather than silently normalized.
+
+## Privacy and dependency boundary
+
+Random planning consumes only Core class/roster identity, Activity identity,
+teacher target, and teacher seed. It does not consume or emit
+`grouping_signal_set_v1` and does not import Meridian.
+
+Generation/edit/preview/approval create no Group, GroupMembership,
+RoleAssignment, ResponsibilityAssignment, ArtifactInstance, ArtifactPage,
+ArtifactReview, ModerationRecord, ScoreRecord, Academic Result Manifest, Core
+Publication Record, or PDS2 route. Plan assignments remain teacher-restricted
+and are not projected into packet metadata, routing payloads, academic results,
+publication records, or default support output.
+
+## Qualification and handoffs
+
+Focused qualification covers the exact SHA-256 fixture, roster-order
+independence, collision tie-breaking, size/count formulas, edge cases, invalid
+inputs, complete coverage, roster-race protection, persistence, manual editing,
+refresh without rerandomization, direct CLI, teacher menu, lifecycle, and
+absence of unrelated state.
+
+Repository qualification remains:
+
+```text
+python -m pytest
+python -m ruff check .
+python -m mypy
+python scripts/check_documentation.py
+python scripts/verify_release_compatibility.py
+python scripts/validate_repository.py --core-wheel <authenticated-Core-0.6.1-wheel> --allow-dirty
+git diff --check
+git status --short
+```
+
+Deferred work remains:
+
+```text
+Issue #53 grouping-signal discovery/import/dimension diagnostics
+Issue #54 similar-signal and mixed-signal planners
+Issue #55 explicit missing-signal teacher disposition
+Issue #56 approved-plan application to Group/GroupMembership
+#65 guided Activity setup
+#66 final integrated menu design
+```

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -40,6 +40,7 @@ GROUPING_SIGNAL_DOC = (
 )
 GROUP_PLAN_DOC = ROOT / "docs" / "v0.3.0-group-plan-contract.md"
 MANUAL_GROUP_PLAN_DOC = ROOT / "docs" / "v0.3.0-manual-group-planning.md"
+RANDOM_GROUP_PLAN_DOC = ROOT / "docs" / "v0.3.0-random-group-planning.md"
 REQUIRED_GROUP_PLAN_DOC_PHRASES = (
     "GroupPlan != Group",
     "record kind: group_plan",
@@ -57,6 +58,17 @@ REQUIRED_MANUAL_GROUP_PLAN_DOC_PHRASES = (
     "Plan groups",
     "GroupPlan approval != Group creation",
     "#56",
+)
+REQUIRED_RANDOM_GROUP_PLAN_DOC_PHRASES = (
+    "create_random_group_plan",
+    "pds-concord:group-plan-random:v1",
+    "sha256",
+    "ceil(N / S)",
+    "random-1",
+    "concord group-plan create-random",
+    "Canonical Groups created: no",
+    "Issue #53",
+    "Issue #56",
 )
 REQUIRED_GROUPING_SIGNAL_DOC_PHRASES = (
     "pds-core>=0.6.1,<0.7",
@@ -247,6 +259,22 @@ def check_documentation() -> None:
         if MANUAL_GROUP_PLAN_DOC.name not in docs_index:
             failures.append(
                 "Documentation index does not link the manual Group planning document."
+            )
+    if not RANDOM_GROUP_PLAN_DOC.is_file():
+        failures.append(
+            "Current v0.3.0 deterministic random Group planning document is missing."
+        )
+    else:
+        random_group_plan_doc = RANDOM_GROUP_PLAN_DOC.read_text(encoding="utf-8")
+        for phrase in REQUIRED_RANDOM_GROUP_PLAN_DOC_PHRASES:
+            if phrase not in random_group_plan_doc:
+                failures.append(
+                    "Random Group planning document is missing required "
+                    f"boundary wording {phrase!r}."
+                )
+        if RANDOM_GROUP_PLAN_DOC.name not in docs_index:
+            failures.append(
+                "Documentation index does not link the random Group planning document."
             )
     for active_path in (
         ROOT / "README.md",

--- a/tests/test_group_plan_random_boundaries_issue52.py
+++ b/tests/test_group_plan_random_boundaries_issue52.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.rosters import create_roster
+from pds_core.workspace import ensure_workspace_root
+
+from concord.storage import load_current_record_graph
+from concord.workflows import (
+    ApproveGroupPlanRequest,
+    CreateActivityContextRequest,
+    CreateRandomGroupPlanRequest,
+    EditPlannedGroupRequest,
+    PlaceStudentInPlanRequest,
+    PreviewGroupPlanRequest,
+    RefreshGroupPlanRosterRequest,
+    UnassignStudentFromPlanRequest,
+    WorkflowActor,
+    approve_group_plan,
+    create_activity_context,
+    create_random_group_plan,
+    edit_planned_group,
+    place_student_in_plan,
+    preview_group_plan,
+    refresh_group_plan_roster,
+    show_group_plan,
+    unassign_student_from_plan,
+)
+from concord.workflows.errors import ConcordWorkflowConflictError
+
+
+def _clock(day: int) -> datetime:
+    return datetime(2026, 8, day, 17, 0, tzinfo=timezone.utc)
+
+
+def _actor(actor_id: str = "teacher-1") -> WorkflowActor:
+    return WorkflowActor(actor_id=actor_id, role_label="teacher")
+
+
+def _roster(*student_ids: str):
+    return create_roster(
+        "class-1",
+        tuple(
+            {
+                "student_id": student_id,
+                "last_name": f"Last-{index}",
+                "first_name": f"First-{index}",
+                "period": "1",
+            }
+            for index, student_id in enumerate(student_ids, start=1)
+        ),
+    )
+
+
+def _workspace(
+    tmp_path: Path,
+    *,
+    name: str = "workspace",
+    student_ids: tuple[str, ...] = (
+        "student-1",
+        "student-2",
+        "student-3",
+        "student-4",
+        "student-5",
+        "student-6",
+    ),
+) -> tuple[Path, int]:
+    root = ensure_workspace_root(tmp_path / name)
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata("class-1", "2026-2027", created_at=_clock(1)),
+    )
+    write_class_roster(root, _roster(*student_ids))
+    created = create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            title="Random Planning Boundary",
+            activity_type="project",
+            scoring_orientation="evidence_only",
+            session_id="session-1",
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(2),
+    )
+    return root, created.commit.snapshot_revision
+
+
+def _membership(detail) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    return tuple(
+        (group.planned_group_key, group.student_ids)
+        for group in detail.plan.proposed_groups
+    )
+
+
+def test_random_arrangement_does_not_depend_on_plan_actor_or_clock(
+    tmp_path: Path,
+) -> None:
+    root_a, revision_a = _workspace(tmp_path, name="a")
+    root_b, revision_b = _workspace(tmp_path, name="b")
+
+    create_random_group_plan(
+        CreateRandomGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="plan-a",
+            expected_snapshot_revision=revision_a,
+            actor=_actor("teacher-a"),
+            seed="same-seed",
+            target_group_count=3,
+        ),
+        workspace_root=root_a,
+        clock=lambda: _clock(3),
+    )
+    create_random_group_plan(
+        CreateRandomGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="different-plan-id",
+            expected_snapshot_revision=revision_b,
+            actor=_actor("teacher-b"),
+            seed="same-seed",
+            target_group_count=3,
+        ),
+        workspace_root=root_b,
+        clock=lambda: _clock(9),
+    )
+
+    a = show_group_plan(
+        "class-1",
+        "activity-1",
+        "plan-a",
+        workspace_root=root_a,
+    )
+    b = show_group_plan(
+        "class-1",
+        "activity-1",
+        "different-plan-id",
+        workspace_root=root_b,
+    )
+    assert _membership(a) == _membership(b)
+
+
+def test_random_plan_manual_edits_preserve_origin_metadata(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    created = create_random_group_plan(
+        CreateRandomGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="random-plan",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            seed="seed-52",
+            target_group_count=2,
+        ),
+        workspace_root=root,
+    )
+    detail = show_group_plan(
+        "class-1",
+        "activity-1",
+        "random-plan",
+        workspace_root=root,
+    )
+    first, second = detail.plan.proposed_groups
+
+    renamed = edit_planned_group(
+        EditPlannedGroupRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="random-plan",
+            planned_group_key=first.planned_group_key,
+            label="Teacher Table",
+            expected_snapshot_revision=(
+                created.mutation.commit.snapshot_revision
+            ),
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+    student_id = renamed.detail.plan.proposed_groups[0].student_ids[0]
+
+    unassigned = unassign_student_from_plan(
+        UnassignStudentFromPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="random-plan",
+            student_id=student_id,
+            expected_snapshot_revision=(
+                renamed.detail.summary.snapshot_revision
+            ),
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+    replaced = place_student_in_plan(
+        PlaceStudentInPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="random-plan",
+            student_id=student_id,
+            planned_group_key=second.planned_group_key,
+            expected_snapshot_revision=(
+                unassigned.detail.summary.snapshot_revision
+            ),
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+
+    assert replaced.detail.plan.strategy == "random"
+    assert replaced.detail.plan.seed == "seed-52"
+    assert replaced.detail.plan.target_group_count == 2
+    assert replaced.detail.plan.proposed_groups[0].label == "Teacher Table"
+    assert replaced.detail.plan.unresolved_student_ids == ()
+
+
+def test_explicit_refresh_preserves_random_origin_and_does_not_rerandomize(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(
+        tmp_path,
+        student_ids=(
+            "student-1",
+            "student-2",
+            "student-3",
+            "student-4",
+        ),
+    )
+    created = create_random_group_plan(
+        CreateRandomGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="random-plan",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            seed="seed-52",
+            target_group_count=2,
+        ),
+        workspace_root=root,
+    )
+    before = show_group_plan(
+        "class-1",
+        "activity-1",
+        "random-plan",
+        workspace_root=root,
+    )
+    departed = before.plan.proposed_groups[0].student_ids[0]
+    survivors = {
+        student_id: group.planned_group_key
+        for group in before.plan.proposed_groups
+        for student_id in group.student_ids
+        if student_id != departed
+    }
+    current_students = tuple(
+        student_id
+        for student_id in before.plan.roster_student_ids
+        if student_id != departed
+    ) + ("student-9",)
+    write_class_roster(root, _roster(*current_students), overwrite=True)
+
+    refreshed = refresh_group_plan_roster(
+        RefreshGroupPlanRosterRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="random-plan",
+            expected_snapshot_revision=(
+                created.mutation.commit.snapshot_revision
+            ),
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+
+    assert refreshed.detail.plan.strategy == "random"
+    assert refreshed.detail.plan.seed == "seed-52"
+    assert refreshed.detail.plan.target_group_count == 2
+    assert refreshed.detail.plan.unresolved_student_ids == ("student-9",)
+
+    after_locations = {
+        student_id: group.planned_group_key
+        for group in refreshed.detail.plan.proposed_groups
+        for student_id in group.student_ids
+    }
+    assert after_locations == survivors
+
+
+def test_random_preview_and_approval_create_only_group_plan_state(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    created = create_random_group_plan(
+        CreateRandomGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="random-plan",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            seed="seed-52",
+            target_group_count=2,
+        ),
+        workspace_root=root,
+    )
+    previewed = preview_group_plan(
+        PreviewGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="random-plan",
+            expected_snapshot_revision=(
+                created.mutation.commit.snapshot_revision
+            ),
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+    approved = approve_group_plan(
+        ApproveGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="random-plan",
+            expected_snapshot_revision=(
+                previewed.summary.snapshot_revision
+            ),
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+
+    graph = load_current_record_graph(root, approved.commit.work).graph
+    assert len(graph.group_plans) == 1
+    assert graph.group_plans[0].status == "approved"
+    assert graph.group_plans[0].strategy == "random"
+    assert graph.groups == ()
+    assert graph.memberships == ()
+    assert graph.role_assignments == ()
+    assert graph.responsibility_assignments == ()
+    assert graph.artifact_instances == ()
+    assert graph.artifact_pages == ()
+    assert graph.scan_references == ()
+    assert graph.artifact_authors == ()
+    assert graph.artifact_subjects == ()
+    assert graph.artifact_reviews == ()
+    assert graph.moderation_records == ()
+    assert graph.criterion_sets == ()
+    assert graph.criteria == ()
+    assert graph.scoring_scales == ()
+    assert graph.score_records == ()
+    assert graph.score_evidence_links == ()
+    assert graph.correction_records == ()
+
+
+def test_random_workflow_respects_snapshot_and_plan_identity_conflicts(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    created = create_random_group_plan(
+        CreateRandomGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="random-plan",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            seed="seed-52",
+            target_group_count=2,
+        ),
+        workspace_root=root,
+    )
+
+    with pytest.raises(ConcordWorkflowConflictError):
+        create_random_group_plan(
+            CreateRandomGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="second-plan",
+                expected_snapshot_revision=revision,
+                actor=_actor(),
+                seed="seed-52",
+                target_group_count=2,
+            ),
+            workspace_root=root,
+        )
+
+    with pytest.raises(ConcordWorkflowConflictError):
+        create_random_group_plan(
+            CreateRandomGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="random-plan",
+                expected_snapshot_revision=(
+                    created.mutation.commit.snapshot_revision
+                ),
+                actor=_actor(),
+                seed="seed-52",
+                target_group_count=2,
+            ),
+            workspace_root=root,
+        )

--- a/tests/test_group_plan_random_cli_issue52.py
+++ b/tests/test_group_plan_random_cli_issue52.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.rosters import create_roster
+from pds_core.workspace import ensure_workspace_root
+
+from concord.cli import main
+from concord.cli_app.parser import build_parser
+
+
+def _workspace(tmp_path: Path, count: int = 6) -> Path:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata(
+            "class-1",
+            "2026-2027",
+            created_at=datetime(2026, 8, 20, tzinfo=timezone.utc),
+        ),
+    )
+    write_class_roster(
+        root,
+        create_roster(
+            "class-1",
+            tuple(
+                {
+                    "student_id": f"student-{index}",
+                    "last_name": f"Last-{index}",
+                    "first_name": f"First-{index}",
+                    "period": "1",
+                }
+                for index in range(1, count + 1)
+            ),
+        ),
+    )
+    assert main([
+        "activity", "create", "--workspace-root", str(root),
+        "--class-id", "class-1", "--activity-id", "activity-1",
+        "--title", "Random Planning CLI", "--activity-type", "project",
+        "--scoring-orientation", "evidence_only", "--session-id", "session-1",
+        "--actor-id", "teacher-1",
+    ]) == 0
+    return root
+
+
+def _random_base(root: Path, plan_id: str = "random-plan") -> list[str]:
+    return [
+        "group-plan", "create-random", "--workspace-root", str(root),
+        "--class-id", "class-1", "--activity-id", "activity-1",
+        "--group-plan-id", plan_id, "--expected-snapshot", "1",
+        "--actor-id", "teacher-1", "--seed", "seed-52",
+    ]
+
+
+def test_create_random_count_cli_and_lifecycle_remain_planning_only(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = _workspace(tmp_path)
+    capsys.readouterr()
+    assert main(_random_base(root) + ["--target-group-count", "2"]) == 0
+    created = capsys.readouterr().out
+    assert "Committed snapshot 2." in created
+    assert "GroupPlan: random-plan" in created
+    assert "Strategy: random" in created
+    assert "Status: draft" in created
+    assert "Target group count: 2" in created
+    assert "Seed: seed-52" in created
+    assert "Generated groups: 2" in created
+    assert "Assigned students: 6" in created
+    assert "Unresolved students: 0" in created
+    assert "Group sizes: 3,3" in created
+    assert "Canonical Groups created: no" in created
+    assert "student-1" not in created
+
+    common = [
+        "--workspace-root", str(root), "--class-id", "class-1",
+        "--activity-id", "activity-1", "--group-plan-id", "random-plan",
+        "--actor-id", "teacher-1",
+    ]
+    assert main(["group-plan", "preview", *common, "--expected-snapshot", "2"]) == 0
+    assert "Status: previewed" in capsys.readouterr().out
+    assert main(["group-plan", "approve", *common, "--expected-snapshot", "3"]) == 0
+    approved = capsys.readouterr().out
+    assert "Status: approved" in approved
+    assert "Canonical Groups created: no" in approved
+    assert main([
+        "group", "list", "--workspace-root", str(root), "--class-id", "class-1",
+        "--activity-id", "activity-1",
+    ]) == 0
+    assert "No Groups found." in capsys.readouterr().out
+
+
+def test_create_random_size_cli_preserves_size_target(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = _workspace(tmp_path, count=10)
+    capsys.readouterr()
+    assert main(_random_base(root) + ["--target-group-size", "4"]) == 0
+    output = capsys.readouterr().out
+    assert "Target group size: 4" in output
+    assert "Generated groups: 3" in output
+    assert "Group sizes: 4,3,3" in output
+
+
+def test_create_random_parser_requires_exactly_one_target(tmp_path: Path) -> None:
+    root = _workspace(tmp_path)
+    parser = build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(_random_base(root))
+    with pytest.raises(SystemExit):
+        parser.parse_args(_random_base(root) + [
+            "--target-group-size", "3", "--target-group-count", "2",
+        ])
+
+
+def test_create_random_invalid_count_is_nonmutating(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = _workspace(tmp_path, count=3)
+    capsys.readouterr()
+    assert main(_random_base(root) + ["--target-group-count", "4"]) == 1
+    captured = capsys.readouterr()
+    assert "must not exceed the current roster size" in captured.err
+    assert main([
+        "group-plan", "list", "--workspace-root", str(root),
+        "--class-id", "class-1", "--activity-id", "activity-1",
+    ]) == 0
+    assert "No GroupPlans found." in capsys.readouterr().out

--- a/tests/test_group_plan_random_issue52.py
+++ b/tests/test_group_plan_random_issue52.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.rosters import create_roster
+from pds_core.workspace import ensure_workspace_root
+
+import concord.group_plan_random as random_planning
+from concord.group_plan_random import (
+    RandomGroupPlanningError,
+    deterministic_random_student_order,
+    generate_random_group_plan_proposal,
+)
+from concord.workflows import (
+    CreateActivityContextRequest,
+    CreateRandomGroupPlanRequest,
+    WorkflowActor,
+    create_activity_context,
+    create_random_group_plan,
+    list_group_plans,
+    show_group_plan,
+)
+from concord.workflows.errors import (
+    ConcordWorkflowConflictError,
+    ConcordWorkflowValidationError,
+)
+from concord.workflows.group_plan_manual import (
+    PlaceStudentInPlanRequest,
+    place_student_in_plan,
+)
+
+
+def _clock(day: int) -> datetime:
+    return datetime(2026, 8, day, 15, 0, tzinfo=timezone.utc)
+
+
+def _actor(actor_id: str = "teacher-1") -> WorkflowActor:
+    return WorkflowActor(
+        actor_id=actor_id,
+        display_label="Synthetic Teacher",
+        role_label="teacher",
+    )
+
+
+def _roster(*student_ids: str):
+    return create_roster(
+        "class-1",
+        tuple(
+            {
+                "student_id": student_id,
+                "last_name": f"Last-{index}",
+                "first_name": f"First-{index}",
+                "period": "1",
+            }
+            for index, student_id in enumerate(student_ids, start=1)
+        ),
+    )
+
+
+def _workspace(tmp_path: Path, *student_ids: str) -> tuple[Path, int]:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata("class-1", "2026-2027", created_at=_clock(1)),
+    )
+    write_class_roster(root, _roster(*student_ids))
+    created = create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            title="Synthetic Planning Activity",
+            activity_type="project",
+            scoring_orientation="evidence_only",
+            session_id="session-1",
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(2),
+    )
+    return root, created.commit.snapshot_revision
+
+
+def _students(count: int) -> tuple[str, ...]:
+    return tuple(f"student-{index}" for index in range(1, count + 1))
+
+
+def _memberships(proposal) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    return tuple(
+        (group.planned_group_key, group.student_ids)
+        for group in proposal.proposed_groups
+    )
+
+
+def test_fixed_seed_fixture_has_exact_v1_membership() -> None:
+    proposal = generate_random_group_plan_proposal(
+        _students(10),
+        seed="seed-7",
+        target_group_count=3,
+    )
+    assert proposal.group_sizes == (4, 3, 3)
+    assert _memberships(proposal) == (
+        ("random-1", ("student-1", "student-2", "student-3", "student-6")),
+        ("random-2", ("student-10", "student-4", "student-9")),
+        ("random-3", ("student-5", "student-7", "student-8")),
+    )
+    assert tuple(group.label for group in proposal.proposed_groups) == (
+        "Group 1",
+        "Group 2",
+        "Group 3",
+    )
+
+
+def test_roster_input_order_does_not_change_proposal() -> None:
+    forward = generate_random_group_plan_proposal(
+        _students(10),
+        seed="same-seed",
+        target_group_count=4,
+    )
+    reversed_roster = generate_random_group_plan_proposal(
+        tuple(reversed(_students(10))),
+        seed="same-seed",
+        target_group_count=4,
+    )
+    assert forward == reversed_roster
+
+
+def test_rank_collision_uses_exact_student_id_as_tie_breaker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(random_planning, "_rank_digest", lambda seed, student: b"x")
+    assert deterministic_random_student_order(
+        ("student-3", "student-1", "student-2"),
+        "seed",
+    ) == ("student-1", "student-2", "student-3")
+
+
+@pytest.mark.parametrize(
+    ("count", "target", "expected_sizes"),
+    (
+        (10, 3, (4, 3, 3)),
+        (10, 4, (3, 3, 2, 2)),
+        (7, 7, (1, 1, 1, 1, 1, 1, 1)),
+        (7, 1, (7,)),
+    ),
+)
+def test_target_count_balances_exactly(
+    count: int,
+    target: int,
+    expected_sizes: tuple[int, ...],
+) -> None:
+    proposal = generate_random_group_plan_proposal(
+        _students(count),
+        seed="balance",
+        target_group_count=target,
+    )
+    assert proposal.group_count == target
+    assert proposal.group_sizes == expected_sizes
+    assert max(proposal.group_sizes) - min(proposal.group_sizes) <= 1
+
+
+@pytest.mark.parametrize(
+    ("count", "target", "expected_sizes"),
+    (
+        (10, 4, (4, 3, 3)),
+        (8, 3, (3, 3, 2)),
+        (7, 1, (1, 1, 1, 1, 1, 1, 1)),
+        (7, 7, (7,)),
+        (7, 20, (7,)),
+    ),
+)
+def test_target_size_uses_ceiling_count_and_balances(
+    count: int,
+    target: int,
+    expected_sizes: tuple[int, ...],
+) -> None:
+    proposal = generate_random_group_plan_proposal(
+        _students(count),
+        seed="balance",
+        target_group_size=target,
+    )
+    assert proposal.group_sizes == expected_sizes
+    assert max(proposal.group_sizes) <= target
+    assert max(proposal.group_sizes) - min(proposal.group_sizes) <= 1
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        {},
+        {"target_group_size": 2, "target_group_count": 2},
+        {"target_group_size": 0},
+        {"target_group_size": -1},
+        {"target_group_count": 0},
+        {"target_group_count": 4},
+    ),
+)
+def test_invalid_target_requests_fail(kwargs: dict[str, int]) -> None:
+    with pytest.raises(RandomGroupPlanningError):
+        generate_random_group_plan_proposal(
+            _students(3),
+            seed="seed",
+            **kwargs,
+        )
+
+
+@pytest.mark.parametrize("seed", ("", " ", " seed", "seed "))
+def test_invalid_seed_fails(seed: str) -> None:
+    with pytest.raises(RandomGroupPlanningError):
+        generate_random_group_plan_proposal(
+            _students(3),
+            seed=seed,
+            target_group_count=2,
+        )
+
+
+def test_empty_and_duplicate_rosters_fail() -> None:
+    with pytest.raises(RandomGroupPlanningError, match="nonempty roster"):
+        generate_random_group_plan_proposal(
+            (),
+            seed="seed",
+            target_group_count=1,
+        )
+    with pytest.raises(RandomGroupPlanningError, match="duplicate student IDs"):
+        generate_random_group_plan_proposal(
+            ("student-1", "student-1"),
+            seed="seed",
+            target_group_count=1,
+        )
+
+
+def test_workflow_creates_complete_random_draft(tmp_path: Path) -> None:
+    root, revision = _workspace(tmp_path, *_students(10))
+    result = create_random_group_plan(
+        CreateRandomGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="plan-random",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            seed="seed-7",
+            target_group_count=3,
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(3),
+    )
+    detail = show_group_plan(
+        "class-1",
+        "activity-1",
+        "plan-random",
+        workspace_root=root,
+    )
+    assert result.group_count == 3
+    assert result.assigned_student_count == 10
+    assert result.group_sizes == (4, 3, 3)
+    assert detail.plan.strategy == "random"
+    assert detail.plan.status == "draft"
+    assert detail.plan.seed == "seed-7"
+    assert detail.plan.target_group_count == 3
+    assert detail.plan.target_group_size is None
+    assert detail.plan.unresolved_student_ids == ()
+    assert detail.plan.source_signal_set_id is None
+    assert detail.plan.source_signal_set_digest is None
+    assert detail.plan.source_signal_dimension_id is None
+
+
+def test_size_target_is_preserved_instead_of_derived_count(tmp_path: Path) -> None:
+    root, revision = _workspace(tmp_path, *_students(10))
+    create_random_group_plan(
+        CreateRandomGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="plan-random",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            seed="seed",
+            target_group_size=4,
+        ),
+        workspace_root=root,
+    )
+    detail = show_group_plan(
+        "class-1",
+        "activity-1",
+        "plan-random",
+        workspace_root=root,
+    )
+    assert detail.plan.target_group_size == 4
+    assert detail.plan.target_group_count is None
+    assert tuple(len(group.student_ids) for group in detail.plan.proposed_groups) == (
+        4,
+        3,
+        3,
+    )
+
+
+def test_generated_random_plan_remains_manually_editable(tmp_path: Path) -> None:
+    root, revision = _workspace(tmp_path, *_students(6))
+    created = create_random_group_plan(
+        CreateRandomGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="plan-random",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            seed="seed",
+            target_group_count=2,
+        ),
+        workspace_root=root,
+    )
+    detail = show_group_plan(
+        "class-1",
+        "activity-1",
+        "plan-random",
+        workspace_root=root,
+    )
+    source = detail.plan.proposed_groups[0]
+    destination = detail.plan.proposed_groups[1]
+    student_id = source.student_ids[0]
+    edited = place_student_in_plan(
+        PlaceStudentInPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="plan-random",
+            student_id=student_id,
+            planned_group_key=destination.planned_group_key,
+            expected_snapshot_revision=created.mutation.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+    assert edited.detail.plan.strategy == "random"
+    assert edited.detail.plan.seed == "seed"
+    assert edited.detail.plan.target_group_count == 2
+
+
+def test_workflow_validation_failure_creates_no_plan(tmp_path: Path) -> None:
+    root, revision = _workspace(tmp_path, *_students(3))
+    with pytest.raises(ConcordWorkflowValidationError, match="exactly one"):
+        create_random_group_plan(
+            CreateRandomGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="plan-random",
+                expected_snapshot_revision=revision,
+                actor=_actor(),
+                seed="seed",
+            ),
+            workspace_root=root,
+        )
+    assert list_group_plans("class-1", "activity-1", workspace_root=root) == ()
+
+
+def test_roster_change_between_generation_and_commit_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, revision = _workspace(tmp_path, *_students(3))
+    import concord.workflows.group_plan_random as workflow_module
+
+    original_create = workflow_module.create_group_plan
+
+    def mutate_roster_then_create(request, **kwargs):
+        write_class_roster(
+            root,
+            _roster("student-1", "student-2", "student-3", "student-4"),
+            overwrite=True,
+        )
+        return original_create(request, **kwargs)
+
+    monkeypatch.setattr(
+        workflow_module,
+        "create_group_plan",
+        mutate_roster_then_create,
+    )
+    with pytest.raises(ConcordWorkflowConflictError, match="roster changed"):
+        create_random_group_plan(
+            CreateRandomGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="plan-random",
+                expected_snapshot_revision=revision,
+                actor=_actor(),
+                seed="seed",
+                target_group_count=2,
+            ),
+            workspace_root=root,
+        )
+    assert list_group_plans("class-1", "activity-1", workspace_root=root) == ()

--- a/tests/test_group_plan_random_menu_issue52.py
+++ b/tests/test_group_plan_random_menu_issue52.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from pds_core.routing_models import ModuleWorkRef
+
+import concord.menu_group_plan as plan_menu
+import concord.menu_prompts as prompts
+from concord.menu_context import MenuSessionContext
+from concord.workflows import ActivitySummary, WorkflowActor, WorkflowCommitResult
+
+
+def _activity(snapshot: int = 7) -> ActivitySummary:
+    return ActivitySummary(
+        class_id="class-1",
+        activity_id="activity-1",
+        title="Planning Activity",
+        status="draft",
+        scoring_orientation="evidence_only",
+        session_count=1,
+        group_count=0,
+        snapshot_revision=snapshot,
+    )
+
+
+def _state() -> MenuSessionContext:
+    return MenuSessionContext(actor=WorkflowActor(actor_id="teacher-1"))
+
+
+def _commit(snapshot: int = 8) -> WorkflowCommitResult:
+    return WorkflowCommitResult(
+        work=ModuleWorkRef(
+            module_id="concord",
+            class_id="class-1",
+            work_id="activity-1",
+        ),
+        snapshot_revision=snapshot,
+        snapshot_sha256="a" * 64,
+        changed_records=(),
+        no_op=False,
+    )
+
+
+def test_random_menu_creation_uses_latest_snapshot_and_exact_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current = _activity(11)
+    captured_requests: list[object] = []
+    shown: list[tuple[str, tuple[str, ...]]] = []
+
+    monkeypatch.setattr(plan_menu, "_latest", lambda _activity: current)
+    monkeypatch.setattr(
+        plan_menu,
+        "prompt_text",
+        lambda *a, **k: "activity-1-random",
+    )
+    monkeypatch.setattr(
+        plan_menu,
+        "prompt_exact_text",
+        lambda *a, **k: "seed-52",
+    )
+    monkeypatch.setattr(plan_menu, "select_one", lambda *a, **k: "size")
+    monkeypatch.setattr(
+        plan_menu,
+        "prompt_positive_int",
+        lambda *a, **k: 4,
+    )
+    monkeypatch.setattr(
+        plan_menu,
+        "confirm_write",
+        lambda *a, **k: True,
+    )
+    monkeypatch.setattr(
+        plan_menu,
+        "show_result",
+        lambda title, lines: shown.append((title, tuple(lines))),
+    )
+
+    def fake_create(request: object) -> object:
+        captured_requests.append(request)
+        return SimpleNamespace(
+            mutation=SimpleNamespace(
+                commit=_commit(12),
+                group_plan_id="activity-1-random",
+                status="draft",
+            ),
+            group_count=3,
+            assigned_student_count=10,
+            group_sizes=(4, 3, 3),
+        )
+
+    monkeypatch.setattr(
+        plan_menu,
+        "create_random_group_plan",
+        fake_create,
+    )
+    plan_menu._create_random(current, _state())
+
+    request = captured_requests[0]
+    assert getattr(request, "expected_snapshot_revision") == 11
+    assert getattr(request, "seed") == "seed-52"
+    assert getattr(request, "target_group_size") == 4
+    assert getattr(request, "target_group_count") is None
+
+    lines = shown[0][1]
+    assert "Random GroupPlan created." in lines
+    assert "Generated groups: 3" in lines
+    assert "Assigned students: 10" in lines
+    assert "Unresolved students: 0" in lines
+    assert "Group sizes: 4,3,3" in lines
+    assert "Canonical Groups created: no" in lines
+
+
+def test_plan_groups_menu_exposes_random_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    values = iter(["3", "b"])
+
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt="": next(values),
+    )
+    monkeypatch.setattr(plan_menu, "clear_screen", lambda: None)
+    monkeypatch.setattr(
+        plan_menu,
+        "print_menu_header",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        plan_menu,
+        "print_navigation",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        plan_menu,
+        "_latest",
+        lambda activity: activity,
+    )
+    monkeypatch.setattr(
+        plan_menu,
+        "_create_random",
+        lambda _activity, _state: calls.append("random"),
+    )
+
+    plan_menu.launch_group_plan_menu(_activity(), _state())
+    assert calls == ["random"]
+
+
+def test_exact_text_prompt_preserves_whitespace_for_validation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda _prompt="": " seed-52 ",
+    )
+    monkeypatch.setattr(prompts, "clear_screen", lambda: None)
+    monkeypatch.setattr(
+        prompts,
+        "print_menu_header",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        prompts,
+        "print_navigation",
+        lambda *_a, **_k: None,
+    )
+
+    result = prompts.prompt_exact_text(
+        "Random Seed",
+        "Seed",
+        help_text="Exact seed.",
+    )
+    assert result == " seed-52 "


### PR DESCRIPTION
## Summary

Implements deterministic seeded random `GroupPlan` creation for issue #52.

This adds Concord's first generated planning strategy while preserving the existing #50/#51 planning lifecycle:

```text
exact Core roster
+ exactly one size/count target
+ explicit seed
        |
        v
deterministic random proposal
        |
        v
GroupPlan(strategy=random, status=draft)
        |
        +--> optional manual editing
        |
        v
preview -> approve
```

Random planning remains planning-only. Generation, editing, preview, and approval create no canonical `Group` or `GroupMembership`; application remains reserved for #56.

Closes #52.
Part of #47.

## What changed

### Deterministic random planner

Adds a small pure planning layer in `concord/group_plan_random.py` that:

- canonicalizes the exact Core roster independently of source enumeration order;
- requires an explicit, exact seed;
- requires exactly one of target group size or target group count;
- derives a deterministic student ranking using SHA-256;
- partitions the ranked roster into balanced nonempty groups;
- generates stable plan-local `random-N` keys and `Group N` labels; and
- returns ordinary `PlannedGroup` values for the existing GroupPlan workflow.

The v0.3 deterministic ranking contract is:

```text
domain = pds-concord:group-plan-random:v1

payload =
    b"pds-concord:group-plan-random:v1\0"
    + seed.encode("utf-8")
    + b"\0"
    + student_id.encode("utf-8")

rank = sha256(payload).digest()
```

Students are ordered by:

```text
(rank, student_id)
```

The exact `student_id` is the deterministic collision tie-breaker.

The authoritative algorithm does not depend on:

- Python `hash(...)`;
- `random.shuffle(...)` or `random.sample(...)`;
- set/dict iteration order;
- wall-clock time;
- process state;
- OS entropy;
- UUID generation; or
- actor / `group_plan_id` / provenance values.

### Balanced target semantics

For target group count `K`:

```text
1 <= K <= N
```

and exactly `K` nonempty groups are generated.

For target group size `S`:

```text
K = ceil(N / S)
  = (N + S - 1) // S
```

Group sizes use:

```text
base_size, extra = divmod(N, K)
```

so generated sizes differ by at most one.

Examples:

```text
N=10, K=3 -> 4,3,3
N=10, K=4 -> 3,3,2,2
N=10, S=4 -> 4,3,3
N=7,  S=1 -> seven groups of one
N=7,  S>=7 -> one group of seven
```

A size request remains persisted as `target_group_size`; it is not replaced with the derived group count.

### Typed workflow

Adds:

```text
CreateRandomGroupPlanRequest
RandomGroupPlanCreationResult
create_random_group_plan
```

The workflow:

1. resolves the existing Concord/Core workspace;
2. requires the exact Core class;
3. loads the exact current Core roster;
4. validates the random-planning inputs;
5. derives the complete proposal in the pure planner;
6. delegates persistence to the existing `create_group_plan` boundary; and
7. creates one ordinary draft `GroupPlan`.

The resulting plan preserves:

```text
strategy = random
status = draft
seed = <exact supplied seed>
target_group_size / target_group_count = <selected target only>
signal binding = None
unresolved_student_ids = ()
```

### Exact-roster race protection

Extends `CreateGroupPlanRequest` with an optional exact-roster creation precondition.

Random planning necessarily reads the roster before deriving the proposal. The existing creation service then reads Core again while committing. Without an explicit precondition, a roster change between those steps could turn a supposedly complete generated proposal into a plan with a newly added student unresolved.

Random creation therefore supplies the exact roster used by the planner to `create_group_plan`.

If the roster changes between generation and persistence:

```text
Core roster changed
-> conflict
-> no GroupPlan write
```

Existing GroupPlan callers remain unchanged because the precondition is optional.

### #51 editing interoperability

Random plans continue to use the existing manual editing services.

Teachers may:

- rename plan-local groups;
- add/edit/remove planned groups;
- move students;
- unassign/re-place students; and
- explicitly refresh against the Core roster.

These operations preserve the random plan's origin metadata:

```text
strategy = random
seed = original seed
target = original size/count target
```

Manual editing does not relabel a random plan as `manual`.

Explicit roster refresh:

- preserves placements for still-rostered students;
- removes departed students;
- adds newcomers unresolved;
- preserves strategy/seed/target; and
- does **not** silently rerun the random algorithm.

A fresh randomized arrangement after roster change is represented by a new GroupPlan.

### Direct CLI

Adds:

```text
concord group-plan create-random
```

Required inputs include:

```text
--class-id
--activity-id
--group-plan-id
--expected-snapshot
--actor-id
--seed
```

plus exactly one mutually exclusive target:

```text
--target-group-size
--target-group-count
```

Successful output reports compact planning information including:

- GroupPlan ID;
- `random` strategy;
- `draft` status;
- selected target;
- exact seed;
- generated group count;
- assigned count;
- unresolved count;
- group-size distribution; and
- explicit confirmation that canonical Groups were not created.

Creation output does not dump the complete roster.

### Teacher menu

Extends the bounded `Plan groups` workflow with:

```text
Create a manual GroupPlan
Create a random GroupPlan
Import an arrangement CSV
```

Random creation:

- uses the latest Activity snapshot;
- prompts for stable GroupPlan ID;
- asks for size vs. count target;
- requires a positive target;
- requires an explicit seed;
- presents a focused pre-write confirmation;
- calls the same typed workflow as the CLI; and
- reports concise generated-plan diagnostics.

The seed prompt intentionally preserves exact user input so leading/trailing whitespace is rejected by validation rather than silently normalized.

### Documentation

Adds:

- `docs/v0.3.0-random-group-planning.md`

and updates:

- `README.md`;
- `docs/README.md`;
- `docs/cli-contract.md`;
- `docs/v0.3.0-group-plan-contract.md`;
- `docs/v0.3.0-manual-group-planning.md`;
- `CHANGELOG.md`; and
- `scripts/check_documentation.py`.

The random-planning document freezes the exact v0.3 algorithm sufficiently for an independent implementation to reproduce the result without inspecting source code.

## Boundaries preserved

This PR deliberately does **not**:

- read or import `grouping_signal_set_v1`;
- inspect grades, percentages, proficiency, scores, demographics, attendance, behavior, or support data;
- import or call Meridian;
- depend on any sibling PDS module;
- claim fairness, optimality, academic balance, or ability balance;
- automatically preview or approve a generated plan;
- create canonical `Group` or `GroupMembership` records;
- provide `GroupPlan` application;
- create Roles or Responsibilities;
- create Artifacts, Artifact Pages, Reviews, or Moderation state;
- create Scores, Academic Result Manifests, Publication Records, or PDS2 routes; or
- alter direct canonical Group creation.

Signal discovery/import remains #53, signal-backed planning remains #54, missing-signal disposition remains #55, and approved-plan application remains #56.

## Tests

Adds focused coverage for:

- exact SHA-256 v1 deterministic fixture;
- reordered-roster invariance;
- deterministic collision tie-breaking;
- independence from actor, clock, and `group_plan_id`;
- exact target-count behavior;
- exact target-size behavior;
- balanced size distributions;
- one-group and one-student-per-group boundaries;
- oversized target-size handling;
- invalid target combinations and values;
- empty and duplicate roster rejection;
- blank/whitespace seed rejection;
- exact complete roster coverage;
- plan-local key/label generation;
- random draft persistence;
- selected-target persistence;
- exact-roster race rejection;
- atomic failure behavior;
- #51 rename/move/unassign/re-place interoperability;
- random-origin metadata preservation;
- explicit roster refresh without rerandomization;
- `draft -> previewed -> approved`;
- absence of canonical and unrelated state;
- CLI size/count creation;
- CLI mutual exclusion and validation;
- bounded CLI output;
- teacher-menu discovery and typed-service routing; and
- exact menu seed handling.

## Qualification

Full local repository qualification was run against the authenticated released Core v0.6.1 wheel:

```text
672 passed
9 skipped
```

The nine skips are expected Windows/POSIX symlink/race tests unavailable under the local Windows privilege/filesystem environment.

Also passed:

```text
python -m ruff check .
python -m mypy
python scripts/check_documentation.py
python scripts/verify_release_compatibility.py
python -m build
python -m twine check ...
scripts/check_package.py
scripts/verify_release_artifacts.py
scripts/smoke_test_wheel.py
installed producer acceptance
git diff --check
```

The built `pds-concord 0.3.0.dev0` wheel installed successfully with `pds-core 0.6.1`, and the complete installed producer acceptance suite passed.