### PR TITLE
Implement bounded signal group planners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Deterministic `similar_signal` and `mixed_signal` GroupPlan generation from one
+  explicitly selected Core signal/dimension, with shared full-roster size/count
+  targets, exact canonical-digest binding, balanced represented-student placement,
+  visible unresolved missing coverage, and fail-closed roster races.
+- Direct `concord group-plan create-similar-signal|create-mixed-signal` commands and
+  bounded teacher-menu signal-plan creation with explicit signal/dimension selection,
+  neutral band-distribution diagnostics, in-memory membership preview, reviewed
+  roster/digest preconditions, and `CREATE` confirmation without canonical
+  Group/Membership creation or Meridian runtime dependency.
 - Core-backed grouping-signal discovery, exact immutable signal inspection,
   explicit dimension diagnostics/selection, and teacher-controlled
   `grouping_signal_csv_v1` import with complete/projection identity semantics,
@@ -43,6 +52,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Random and signal-backed generated planning now share one pure full-roster target
+  resolution/balanced-size implementation while preserving the frozen #52 random
+  ranking and seed behavior.
 - The teacher-facing `Groups and Participants` screen now distinguishes planning
   (`GroupPlan`/`PlannedGroup`) from operational Group/Membership management;
   GroupPlan approval still creates no canonical Groups and issue #56 remains the

--- a/README.md
+++ b/README.md
@@ -15,9 +15,11 @@ and Responsibilities. The v0.3 development line also includes teacher-restricted
 explicit roster refresh, strict `student_id,group` arrangement CSV import, and
 deterministic seeded random proposals using exact size/count targets. The v0.3
 line now also provides Core grouping-signal discovery, exact signal/dimension
-diagnostics, and teacher-controlled `grouping_signal_csv_v1` import without a
-Meridian runtime dependency. Planning remains separate from canonical
-Group/Membership application, which is reserved for issue #56. The same typed
+diagnostics, teacher-controlled `grouping_signal_csv_v1` import, and deterministic
+`similar_signal` / `mixed_signal` GroupPlan drafts with exact signal provenance,
+full-roster target semantics, explicit unresolved missing coverage, and no Meridian
+runtime dependency. Signal-plan generation remains separate from missing-signal
+disposition (#55) and canonical Group/Membership application (#56). The same typed
 service layer supports a fully
 noninteractive direct CLI and a teacher-facing low-information-density menu.
 Canonical state remains protected by immutable history, exact expected-snapshot
@@ -111,6 +113,7 @@ concord session add|list|show|update|set-status
 concord group create|list|show|update|set-status
 concord group member add|list|end|reassign
 concord group-plan list|show|create-manual|create-random|add-group|edit-group|remove-group
+concord group-plan create-similar-signal|create-mixed-signal
 concord group-plan place-student|unassign-student|refresh-roster
 concord group-plan import-arrangement|replace-arrangement|preview|approve|cancel
 concord grouping-signal list|show|diagnose|import-csv
@@ -199,8 +202,12 @@ Issue #52's exact seeded SHA-256 ranking, balanced partitioning, direct CLI/menu
 creation, refresh behavior, and privacy boundaries are documented in the
 [deterministic random planning guide](docs/v0.3.0-random-group-planning.md).
 Issue #53's exact discovery, diagnostics, dimension selection, Core CSV import,
-privacy, producer-neutrality, and #54 handoff are documented in the
+privacy, producer-neutrality, and signal-selection boundary are documented in the
 [grouping-signal workflow guide](docs/v0.3.0-grouping-signal-workflows.md).
+Issue #54's deterministic similar/mixed algorithms, full-roster targets, exact Core
+signal binding, partial-coverage behavior, direct CLI/menu creation, lifecycle reuse,
+and privacy/dependency boundaries are documented in the
+[signal-backed Group planning guide](docs/v0.3.0-signal-group-planning.md).
 The clean installed-wheel producer lifecycle and its Core verification,
 authorization, audit, and immutability boundaries are documented in the
 [installed acceptance guide](docs/implementation/installed-end-to-end-acceptance.md).

--- a/concord/cli_app/handlers/group_plan.py
+++ b/concord/cli_app/handlers/group_plan.py
@@ -18,6 +18,7 @@ from concord.workflows import (
     CancelGroupPlanRequest,
     CreateManualGroupPlanRequest,
     CreateRandomGroupPlanRequest,
+    CreateSignalGroupPlanRequest,
     EditPlannedGroupRequest,
     GroupPlanDetail,
     GroupPlanEditResult,
@@ -28,12 +29,14 @@ from concord.workflows import (
     RefreshGroupPlanRosterRequest,
     RemovePlannedGroupRequest,
     ReplaceArrangementGroupPlanRequest,
+    SignalGroupPlanCreationResult,
     UnassignStudentFromPlanRequest,
     add_planned_group,
     approve_group_plan,
     cancel_group_plan,
     create_manual_group_plan,
     create_random_group_plan,
+    create_signal_group_plan,
     edit_planned_group,
     import_arrangement_group_plan,
     list_group_plans,
@@ -180,6 +183,58 @@ def handle_create_random(args: argparse.Namespace) -> int:
     print(f"Group sizes: {','.join(str(size) for size in result.group_sizes)}")
     print("Canonical Groups created: no")
     return 0
+
+
+def _handle_create_signal(args: argparse.Namespace, strategy: str) -> int:
+    result = create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id=args.class_id,
+            activity_id=args.activity_id,
+            group_plan_id=args.group_plan_id,
+            strategy=strategy,
+            signal_set_id=args.signal_set_id,
+            dimension_id=args.dimension_id,
+            expected_snapshot_revision=args.expected_snapshot,
+            actor=workflow_actor(args),
+            target_group_size=args.target_group_size,
+            target_group_count=args.target_group_count,
+        ),
+        workspace_root=workspace_arg(args),
+        standards_library=load_command_standards_library(args),
+    )
+    _print_signal_create_result(result, args)
+    return 0
+
+
+def _print_signal_create_result(
+    result: SignalGroupPlanCreationResult,
+    args: argparse.Namespace,
+) -> None:
+    mutation = result.mutation
+    print_commit(mutation.commit)
+    print(f"GroupPlan: {mutation.group_plan_id}")
+    print(f"Strategy: {result.strategy}")
+    print(f"Status: {mutation.status}")
+    if args.target_group_size is not None:
+        print(f"Target group size: {args.target_group_size}")
+    else:
+        print(f"Target group count: {args.target_group_count}")
+    print(f"Signal set: {result.signal_set_id}")
+    print(f"Signal digest: {result.signal_set_digest}")
+    print(f"Signal dimension: {result.dimension_id}")
+    print(f"Generated groups: {result.group_count}")
+    print(f"Assigned students: {result.assigned_student_count}")
+    print(f"Unresolved students: {result.unresolved_student_count}")
+    print(f"Group sizes: {','.join(str(size) for size in result.group_sizes)}")
+    print("Canonical Groups created: no")
+
+
+def handle_create_similar_signal(args: argparse.Namespace) -> int:
+    return _handle_create_signal(args, "similar_signal")
+
+
+def handle_create_mixed_signal(args: argparse.Namespace) -> int:
+    return _handle_create_signal(args, "mixed_signal")
 
 
 def handle_add_group(args: argparse.Namespace) -> int:

--- a/concord/cli_app/parser.py
+++ b/concord/cli_app/parser.py
@@ -425,6 +425,34 @@ def _group_plan_commands(
     random_target.add_argument("--target-group-count", type=int)
     random_create.set_defaults(handler=group_plan.handle_create_random)
 
+    similar_create = actions.add_parser(
+        "create-similar-signal",
+        help="Create a deterministic similar-signal draft GroupPlan.",
+    )
+    _mutating_options(similar_create)
+    _class_activity(similar_create)
+    similar_create.add_argument("--group-plan-id", required=True)
+    similar_create.add_argument("--signal-set-id", required=True)
+    similar_create.add_argument("--dimension-id", required=True)
+    similar_target = similar_create.add_mutually_exclusive_group(required=True)
+    similar_target.add_argument("--target-group-size", type=int)
+    similar_target.add_argument("--target-group-count", type=int)
+    similar_create.set_defaults(handler=group_plan.handle_create_similar_signal)
+
+    mixed_create = actions.add_parser(
+        "create-mixed-signal",
+        help="Create a deterministic mixed-signal draft GroupPlan.",
+    )
+    _mutating_options(mixed_create)
+    _class_activity(mixed_create)
+    mixed_create.add_argument("--group-plan-id", required=True)
+    mixed_create.add_argument("--signal-set-id", required=True)
+    mixed_create.add_argument("--dimension-id", required=True)
+    mixed_target = mixed_create.add_mutually_exclusive_group(required=True)
+    mixed_target.add_argument("--target-group-size", type=int)
+    mixed_target.add_argument("--target-group-count", type=int)
+    mixed_create.set_defaults(handler=group_plan.handle_create_mixed_signal)
+
     add = actions.add_parser("add-group", help="Add an empty plan-local group.")
     _mutating_options(add)
     _class_activity(add)

--- a/concord/group_plan_random.py
+++ b/concord/group_plan_random.py
@@ -7,6 +7,11 @@ from hashlib import sha256
 
 from pds_core.identifiers import IdentifierValidationError, validate_identifier
 
+from concord.group_plan_targets import (
+    GroupPlanTargetError,
+    balanced_group_sizes,
+    resolve_group_count,
+)
 from concord.models import PlannedGroup
 
 RANDOM_PLANNING_DOMAIN = "pds-concord:group-plan-random:v1"
@@ -57,36 +62,6 @@ def _canonical_roster(student_ids: tuple[str, ...]) -> tuple[str, ...]:
     return tuple(sorted(validated))
 
 
-def _positive_int(value: int | None, field_name: str) -> int | None:
-    if value is None:
-        return None
-    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
-        raise RandomGroupPlanningError(f"{field_name} must be a positive integer.")
-    return value
-
-
-def _resolve_group_count(
-    roster_size: int,
-    *,
-    target_group_size: int | None,
-    target_group_count: int | None,
-) -> int:
-    size = _positive_int(target_group_size, "target_group_size")
-    count = _positive_int(target_group_count, "target_group_count")
-    if (size is None) == (count is None):
-        raise RandomGroupPlanningError(
-            "exactly one of target_group_size or target_group_count is required."
-        )
-    if count is not None:
-        if count > roster_size:
-            raise RandomGroupPlanningError(
-                "target_group_count must not exceed the current roster size."
-            )
-        return count
-    assert size is not None
-    return (roster_size + size - 1) // size
-
-
 def _rank_digest(seed: str, student_id: str) -> bytes:
     payload = (
         _DOMAIN_BYTES
@@ -127,11 +102,15 @@ def generate_random_group_plan_proposal(
 
     canonical = _canonical_roster(student_ids)
     exact_seed = _require_seed(seed)
-    group_count = _resolve_group_count(
-        len(canonical),
-        target_group_size=target_group_size,
-        target_group_count=target_group_count,
-    )
+    try:
+        group_count = resolve_group_count(
+            len(canonical),
+            target_group_size=target_group_size,
+            target_group_count=target_group_count,
+        )
+    except GroupPlanTargetError as error:
+        raise RandomGroupPlanningError(str(error)) from error
+
     ordered = tuple(
         sorted(
             canonical,
@@ -141,11 +120,7 @@ def generate_random_group_plan_proposal(
             ),
         )
     )
-    base_size, extra = divmod(len(ordered), group_count)
-    group_sizes = tuple(
-        base_size + (1 if index < extra else 0)
-        for index in range(group_count)
-    )
+    group_sizes = balanced_group_sizes(len(ordered), group_count)
 
     offset = 0
     groups: list[PlannedGroup] = []

--- a/concord/group_plan_signal.py
+++ b/concord/group_plan_signal.py
@@ -1,0 +1,210 @@
+"""Pure deterministic signal-backed GroupPlan proposal generation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from concord.group_plan_targets import (
+    GroupPlanTargetError,
+    balanced_group_sizes,
+    resolve_group_count,
+)
+from concord.models import PlannedGroup
+
+
+class SignalGroupPlanningError(ValueError):
+    """Raised when deterministic signal-planning inputs are invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class SignalGroupPlanProposal:
+    """One deterministic signal-backed proposal before persistence."""
+
+    roster_student_ids: tuple[str, ...]
+    proposed_groups: tuple[PlannedGroup, ...]
+    unresolved_student_ids: tuple[str, ...]
+    group_sizes: tuple[int, ...]
+    group_count: int
+
+    @property
+    def assigned_student_count(self) -> int:
+        return sum(self.group_sizes)
+
+    @property
+    def unresolved_student_count(self) -> int:
+        return len(self.unresolved_student_ids)
+
+
+def _canonical_roster(student_ids: tuple[str, ...]) -> tuple[str, ...]:
+    if not student_ids:
+        raise SignalGroupPlanningError(
+            "signal planning requires a nonempty current roster."
+        )
+    validated: list[str] = []
+    for student_id in student_ids:
+        try:
+            validated.append(validate_identifier(student_id, "student_id"))
+        except (IdentifierValidationError, TypeError, ValueError) as error:
+            raise SignalGroupPlanningError(str(error)) from error
+    if len(set(validated)) != len(validated):
+        raise SignalGroupPlanningError(
+            "signal planning roster must not contain duplicate student IDs."
+        )
+    return tuple(sorted(validated))
+
+
+def _validated_signal_bands(
+    roster_student_ids: tuple[str, ...],
+    signal_bands: Mapping[str, int],
+) -> dict[str, int]:
+    if not isinstance(signal_bands, Mapping):
+        raise SignalGroupPlanningError(
+            "signal_bands must be a student-to-band mapping."
+        )
+
+    roster_set = set(roster_student_ids)
+    validated: dict[str, int] = {}
+    for raw_student_id, band in signal_bands.items():
+        try:
+            student_id = validate_identifier(raw_student_id, "student_id")
+        except (IdentifierValidationError, TypeError, ValueError) as error:
+            raise SignalGroupPlanningError(str(error)) from error
+        if student_id not in roster_set:
+            raise SignalGroupPlanningError(
+                "signal_bands must contain only exact current-roster student IDs."
+            )
+        if isinstance(band, bool) or not isinstance(band, int) or band <= 0:
+            raise SignalGroupPlanningError(
+                f"signal band for {student_id!r} must be a positive integer."
+            )
+        validated[student_id] = band
+    return validated
+
+
+def _group_count(
+    roster_size: int,
+    *,
+    target_group_size: int | None,
+    target_group_count: int | None,
+) -> int:
+    try:
+        return resolve_group_count(
+            roster_size,
+            target_group_size=target_group_size,
+            target_group_count=target_group_count,
+        )
+    except GroupPlanTargetError as error:
+        raise SignalGroupPlanningError(str(error)) from error
+
+
+def _proposal(
+    roster_student_ids: tuple[str, ...],
+    signal_bands: Mapping[str, int],
+    *,
+    strategy: str,
+    target_group_size: int | None,
+    target_group_count: int | None,
+) -> SignalGroupPlanProposal:
+    roster = _canonical_roster(roster_student_ids)
+    bands = _validated_signal_bands(roster, signal_bands)
+    group_count = _group_count(
+        len(roster),
+        target_group_size=target_group_size,
+        target_group_count=target_group_count,
+    )
+    unresolved = tuple(
+        student_id for student_id in roster if student_id not in bands
+    )
+
+    if strategy == "similar_signal":
+        ordered = tuple(
+            student_id
+            for student_id, _band in sorted(
+                bands.items(),
+                key=lambda item: (item[1], item[0]),
+            )
+        )
+        group_sizes = balanced_group_sizes(len(ordered), group_count)
+        groups: list[PlannedGroup] = []
+        offset = 0
+        for index, group_size in enumerate(group_sizes, start=1):
+            students = ordered[offset : offset + group_size]
+            offset += group_size
+            groups.append(
+                PlannedGroup(
+                    planned_group_key=f"similar-{index}",
+                    label=f"Group {index}",
+                    student_ids=students,
+                )
+            )
+    elif strategy == "mixed_signal":
+        ordered = tuple(
+            student_id
+            for student_id, _band in sorted(
+                bands.items(),
+                key=lambda item: (-item[1], item[0]),
+            )
+        )
+        buckets: list[list[str]] = [[] for _index in range(group_count)]
+        for position, student_id in enumerate(ordered):
+            buckets[position % group_count].append(student_id)
+        group_sizes = tuple(len(bucket) for bucket in buckets)
+        groups = [
+            PlannedGroup(
+                planned_group_key=f"mixed-{index}",
+                label=f"Group {index}",
+                student_ids=tuple(bucket),
+            )
+            for index, bucket in enumerate(buckets, start=1)
+        ]
+    else:
+        raise SignalGroupPlanningError(
+            "strategy must be 'similar_signal' or 'mixed_signal'."
+        )
+
+    return SignalGroupPlanProposal(
+        roster_student_ids=roster,
+        proposed_groups=tuple(groups),
+        unresolved_student_ids=unresolved,
+        group_sizes=group_sizes,
+        group_count=group_count,
+    )
+
+
+def generate_similar_signal_group_plan_proposal(
+    roster_student_ids: tuple[str, ...],
+    signal_bands: Mapping[str, int],
+    *,
+    target_group_size: int | None = None,
+    target_group_count: int | None = None,
+) -> SignalGroupPlanProposal:
+    """Cluster equal/nearby ordinal bands by deterministic contiguous partition."""
+
+    return _proposal(
+        roster_student_ids,
+        signal_bands,
+        strategy="similar_signal",
+        target_group_size=target_group_size,
+        target_group_count=target_group_count,
+    )
+
+
+def generate_mixed_signal_group_plan_proposal(
+    roster_student_ids: tuple[str, ...],
+    signal_bands: Mapping[str, int],
+    *,
+    target_group_size: int | None = None,
+    target_group_count: int | None = None,
+) -> SignalGroupPlanProposal:
+    """Distribute ordinal bands by deterministic descending-band round robin."""
+
+    return _proposal(
+        roster_student_ids,
+        signal_bands,
+        strategy="mixed_signal",
+        target_group_size=target_group_size,
+        target_group_count=target_group_count,
+    )

--- a/concord/group_plan_targets.py
+++ b/concord/group_plan_targets.py
@@ -1,0 +1,70 @@
+"""Shared pure target arithmetic for generated Concord GroupPlans."""
+
+from __future__ import annotations
+
+
+class GroupPlanTargetError(ValueError):
+    """Raised when a generated GroupPlan target is invalid."""
+
+
+def _positive_int(value: int | None, field_name: str) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise GroupPlanTargetError(f"{field_name} must be a positive integer.")
+    return value
+
+
+def resolve_group_count(
+    roster_size: int,
+    *,
+    target_group_size: int | None,
+    target_group_count: int | None,
+) -> int:
+    """Resolve an exact generated-plan group count against the full roster."""
+
+    if (
+        isinstance(roster_size, bool)
+        or not isinstance(roster_size, int)
+        or roster_size <= 0
+    ):
+        raise GroupPlanTargetError("roster_size must be a positive integer.")
+
+    size = _positive_int(target_group_size, "target_group_size")
+    count = _positive_int(target_group_count, "target_group_count")
+    if (size is None) == (count is None):
+        raise GroupPlanTargetError(
+            "exactly one of target_group_size or target_group_count is required."
+        )
+    if count is not None:
+        if count > roster_size:
+            raise GroupPlanTargetError(
+                "target_group_count must not exceed the current roster size."
+            )
+        return count
+
+    assert size is not None
+    return (roster_size + size - 1) // size
+
+
+def balanced_group_sizes(item_count: int, group_count: int) -> tuple[int, ...]:
+    """Return deterministic left-heavy balanced sizes, permitting empty groups."""
+
+    if (
+        isinstance(item_count, bool)
+        or not isinstance(item_count, int)
+        or item_count < 0
+    ):
+        raise GroupPlanTargetError("item_count must be a nonnegative integer.")
+    if (
+        isinstance(group_count, bool)
+        or not isinstance(group_count, int)
+        or group_count <= 0
+    ):
+        raise GroupPlanTargetError("group_count must be a positive integer.")
+
+    base_size, extra = divmod(item_count, group_count)
+    return tuple(
+        base_size + (1 if index < extra else 0)
+        for index in range(group_count)
+    )

--- a/concord/menu_group_plan.py
+++ b/concord/menu_group_plan.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from pds_core.workspace import resolve_workspace_root
 
 from concord.menu_context import CancelMenuAction, MenuSessionContext
+from concord.menu_group_plan_signal import create_signal_group_plan_from_menu
 from concord.menu_grouping_signal import launch_grouping_signal_menu
 from concord.menu_navigation import (
     ConcordMenuChoice,
@@ -136,6 +137,10 @@ def _show_detail(detail: GroupPlanDetail) -> None:
         print(f"Target group count: {plan.target_group_count}")
     if plan.seed is not None:
         print(f"Seed: {plan.seed}")
+    if plan.source_signal_set_id is not None:
+        print(f"Signal set: {plan.source_signal_set_id}")
+        print(f"Core signal digest: {plan.source_signal_set_digest}")
+        print(f"Signal dimension: {plan.source_signal_dimension_id}")
     print()
     for group in plan.proposed_groups:
         print(
@@ -869,6 +874,8 @@ def launch_group_plan_menu(
         print("4. Import an arrangement CSV")
         print("5. Grouping signals")
         print("6. Open a GroupPlan")
+        print("7. Create similar-signal plan")
+        print("8. Create mixed-signal plan")
         print_navigation()
         print()
         choice = input("Select an option: ").strip()
@@ -879,6 +886,10 @@ def launch_group_plan_menu(
             print("GroupPlans are editable proposals for later teacher approval.")
             print("They remain separate from canonical Groups and Memberships.")
             print("Direct Group management remains available from the previous menu.")
+            print(
+                "Signal-backed plans require explicit signal and dimension "
+                "selection and never assign academic meaning to ordinal bands."
+            )
             print()
             pause_for_user()
         elif navigation is NavigationChoice.BACK:
@@ -901,6 +912,10 @@ def launch_group_plan_menu(
                 continue
             except Exception as error:
                 show_result("GroupPlan Error", (str(error),))
+        elif choice == "7":
+            create_signal_group_plan_from_menu(current, state, "similar_signal")
+        elif choice == "8":
+            create_signal_group_plan_from_menu(current, state, "mixed_signal")
         else:
             print(navigation_hint_with_help())
             pause_for_user()

--- a/concord/menu_group_plan_signal.py
+++ b/concord/menu_group_plan_signal.py
@@ -1,0 +1,344 @@
+"""Teacher-facing creation of deterministic signal-backed GroupPlans."""
+
+from __future__ import annotations
+
+from pds_core.workspace import resolve_workspace_root
+
+from concord.group_plan_signal import (
+    SignalGroupPlanProposal,
+    generate_mixed_signal_group_plan_proposal,
+    generate_similar_signal_group_plan_proposal,
+)
+from concord.menu_context import CancelMenuAction, MenuSessionContext
+from concord.menu_prompts import (
+    confirm_write,
+    handle_write_error,
+    prompt_positive_int,
+    prompt_text,
+    select_one,
+    show_result,
+    slug_identifier,
+)
+from concord.menu_ui import (
+    clear_screen,
+    pause_for_user,
+    print_menu_header,
+)
+from concord.workflows import (
+    ActivitySummary,
+    ConcordWorkflowConflictError,
+    CreateSignalGroupPlanRequest,
+    GroupingSignalDimensionSelection,
+    SignalGroupPlanCreationResult,
+    create_signal_group_plan,
+    list_grouping_signals,
+    load_required_roster,
+    select_grouping_signal_dimension,
+    show_activity,
+)
+
+_SIGNAL_LABELS = {
+    "similar_signal": "Similar-signal",
+    "mixed_signal": "Mixed-signal",
+}
+
+
+def _latest(activity: ActivitySummary) -> ActivitySummary:
+    return show_activity(activity.class_id, activity.activity_id).summary
+
+
+def _handle_error(activity: ActivitySummary, error: Exception) -> None:
+    handle_write_error(
+        error,
+        reload=lambda: _latest(activity),
+        error_title="GroupPlan Error",
+    )
+
+
+def _roster_student_ids(class_id: str) -> tuple[str, ...]:
+    root = resolve_workspace_root()
+    roster = load_required_roster(root, class_id)
+    return tuple(sorted(student.student_id for student in roster.students))
+
+
+def _select_signal_dimension(
+    activity: ActivitySummary,
+) -> tuple[GroupingSignalDimensionSelection, tuple[str, ...]]:
+    summaries = list_grouping_signals(activity.class_id)
+    if not summaries:
+        raise ValueError(
+            "No grouping signals are available for this class. Import or create "
+            "a Core grouping signal before creating a signal-backed GroupPlan."
+        )
+    signal = select_one(
+        "Choose a Grouping Signal",
+        summaries,
+        tuple(
+            (
+                f"{item.signal_set_id} - {item.source_kind}; "
+                f"dimensions: {len(item.dimension_ids)}"
+            )
+            for item in summaries
+        ),
+        help_text=(
+            "Choose one exact immutable Core signal snapshot. Concord never "
+            "chooses a latest or current signal automatically."
+        ),
+    )
+    dimension_id = select_one(
+        "Choose a Signal Dimension",
+        signal.dimension_ids,
+        tuple(f"{item}" for item in signal.dimension_ids),
+        help_text=(
+            "Choose the exact ordinal-band dimension for this plan. Concord never "
+            "combines dimensions or selects the first dimension automatically."
+        ),
+    )
+
+    before = _roster_student_ids(activity.class_id)
+    selection = select_grouping_signal_dimension(
+        activity.class_id,
+        signal.signal_set_id,
+        dimension_id,
+    )
+    after = _roster_student_ids(activity.class_id)
+    if before != after:
+        raise ConcordWorkflowConflictError(
+            "Core roster changed while preparing the signal GroupPlan preview; "
+            "reload and retry."
+        )
+    return selection, after
+
+
+def _show_signal_diagnostics(
+    selection: GroupingSignalDimensionSelection,
+) -> None:
+    diagnostics = selection.dimension_diagnostics
+    clear_screen()
+    print_menu_header("Signal Planning Diagnostics")
+    print(f"Signal set: {selection.signal_set_id}")
+    print(f"Core signal digest: {selection.digest}")
+    print(f"Dimension: {selection.dimension_id}")
+    print(f"Roster students: {diagnostics.roster_student_count}")
+    print(f"Matched students: {diagnostics.matched_student_count}")
+    print(f"Missing students: {diagnostics.missing_student_count}")
+    print()
+    print("Band distribution:")
+    for band, count in diagnostics.band_counts:
+        print(f"Band {band}: {count}")
+    print()
+    print("Missing signal coverage remains unresolved; it is never treated as a band.")
+    print("Ordinal bands are contextual planning inputs, not learner labels.")
+    print()
+    pause_for_user()
+
+
+def _choose_target(
+    strategy: str,
+    roster_count: int,
+) -> tuple[int | None, int | None, str]:
+    label = _SIGNAL_LABELS[strategy]
+    target_kind = select_one(
+        f"{label} Group Target",
+        ("size", "count"),
+        ("Target group size", "Target group count"),
+        help_text=(
+            "The target is resolved against the full current Core roster. "
+            "Students missing the selected signal dimension remain unresolved."
+        ),
+    )
+    if target_kind == "size":
+        size = prompt_positive_int(
+            f"Create {label} GroupPlan",
+            "Target group size",
+            help_text=(
+                "Concord will create ceil(full roster size / target size) planned "
+                "groups. Missing signal coverage does not reduce that group count."
+            ),
+            default=4,
+        )
+        return size, None, f"Target group size: {size}"
+
+    default_count = min(4, roster_count)
+    count = prompt_positive_int(
+        f"Create {label} GroupPlan",
+        "Target group count",
+        help_text=(
+            "Concord will create exactly this many planned groups. The count cannot "
+            "exceed the full current Core roster size; empty planned groups may "
+            "remain when signal coverage is partial."
+        ),
+        default=default_count,
+    )
+    return None, count, f"Target group count: {count}"
+
+
+def _signal_bands(
+    selection: GroupingSignalDimensionSelection,
+) -> dict[str, int]:
+    return {
+        entry.student_id: entry.band
+        for entry in selection.inspection.stored.signal.student_bands
+        if entry.dimension_id == selection.dimension_id
+    }
+
+
+def _proposal(
+    strategy: str,
+    roster_student_ids: tuple[str, ...],
+    selection: GroupingSignalDimensionSelection,
+    *,
+    target_group_size: int | None,
+    target_group_count: int | None,
+) -> SignalGroupPlanProposal:
+    bands = _signal_bands(selection)
+    if strategy == "similar_signal":
+        return generate_similar_signal_group_plan_proposal(
+            roster_student_ids,
+            bands,
+            target_group_size=target_group_size,
+            target_group_count=target_group_count,
+        )
+    return generate_mixed_signal_group_plan_proposal(
+        roster_student_ids,
+        bands,
+        target_group_size=target_group_size,
+        target_group_count=target_group_count,
+    )
+
+
+def _show_preview(
+    strategy: str,
+    selection: GroupingSignalDimensionSelection,
+    proposal: SignalGroupPlanProposal,
+    target_line: str,
+) -> None:
+    label = _SIGNAL_LABELS[strategy]
+    clear_screen()
+    print_menu_header(f"{label} GroupPlan Preview")
+    print(f"Signal set: {selection.signal_set_id}")
+    print(f"Core signal digest: {selection.digest}")
+    print(f"Dimension: {selection.dimension_id}")
+    print(target_line)
+    print(f"Planned groups: {proposal.group_count}")
+    print(f"Assigned students: {proposal.assigned_student_count}")
+    print(f"Unresolved students: {proposal.unresolved_student_count}")
+    print(f"Group sizes: {','.join(str(size) for size in proposal.group_sizes)}")
+    print()
+    print("Planned memberships:")
+    for group in proposal.proposed_groups:
+        students = ", ".join(group.student_ids) or "-"
+        print(f"{group.label} ({group.planned_group_key}): {students}")
+    if proposal.unresolved_student_ids:
+        print()
+        print(f"Unresolved IDs: {', '.join(proposal.unresolved_student_ids)}")
+    print()
+    print("Group numbers do not represent academic rank or a permanent learner label.")
+    print("No canonical Groups or Memberships have been created.")
+    print()
+    pause_for_user()
+
+
+def _result_lines(
+    result: SignalGroupPlanCreationResult,
+    target_line: str,
+) -> tuple[str, ...]:
+    label = _SIGNAL_LABELS[result.strategy]
+    mutation = result.mutation
+    return (
+        f"{label} GroupPlan created.",
+        f"GroupPlan: {mutation.group_plan_id}",
+        f"Strategy: {result.strategy}",
+        f"Status: {mutation.status}",
+        f"Signal set: {result.signal_set_id}",
+        f"Core signal digest: {result.signal_set_digest}",
+        f"Dimension: {result.dimension_id}",
+        target_line,
+        f"Planned groups: {result.group_count}",
+        f"Assigned students: {result.assigned_student_count}",
+        f"Unresolved students: {result.unresolved_student_count}",
+        f"Group sizes: {','.join(str(size) for size in result.group_sizes)}",
+        f"Snapshot: {mutation.commit.snapshot_revision}",
+        "Canonical Groups created: no",
+    )
+
+
+def create_signal_group_plan_from_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+    strategy: str,
+) -> None:
+    """Preview and persist one exact signal-backed planning proposal."""
+
+    if strategy not in _SIGNAL_LABELS:
+        raise ValueError(f"Unsupported signal GroupPlan strategy: {strategy}")
+    try:
+        current = _latest(activity)
+        label = _SIGNAL_LABELS[strategy]
+        plan_id = prompt_text(
+            f"Create {label} GroupPlan",
+            "GroupPlan ID",
+            help_text="Use a durable identifier for this planning proposal.",
+            default=slug_identifier(
+                f"{current.activity_id}-{strategy.replace('_signal', '')}",
+                "group-plan",
+            ),
+        )
+        assert plan_id is not None
+        selection, roster_student_ids = _select_signal_dimension(current)
+        _show_signal_diagnostics(selection)
+
+        target_size, target_count, target_line = _choose_target(
+            strategy,
+            len(roster_student_ids),
+        )
+        proposal = _proposal(
+            strategy,
+            roster_student_ids,
+            selection,
+            target_group_size=target_size,
+            target_group_count=target_count,
+        )
+        _show_preview(strategy, selection, proposal, target_line)
+
+        if not confirm_write(
+            f"Create {label} GroupPlan",
+            "CREATE",
+            (
+                f"Activity: {current.title}",
+                f"GroupPlan: {plan_id}",
+                f"Strategy: {strategy}",
+                f"Signal set: {selection.signal_set_id}",
+                f"Core signal digest: {selection.digest}",
+                f"Dimension: {selection.dimension_id}",
+                target_line,
+                f"Planned groups: {proposal.group_count}",
+                f"Assigned students: {proposal.assigned_student_count}",
+                f"Unresolved students: {proposal.unresolved_student_count}",
+                "The displayed preview must still match the current Core roster.",
+                "No canonical Groups or Memberships will be created.",
+            ),
+        ):
+            return
+
+        result = create_signal_group_plan(
+            CreateSignalGroupPlanRequest(
+                class_id=current.class_id,
+                activity_id=current.activity_id,
+                group_plan_id=plan_id,
+                strategy=strategy,
+                signal_set_id=selection.signal_set_id,
+                dimension_id=selection.dimension_id,
+                expected_snapshot_revision=current.snapshot_revision,
+                actor=state.require_actor(),
+                target_group_size=target_size,
+                target_group_count=target_count,
+                expected_roster_student_ids=proposal.roster_student_ids,
+                expected_signal_set_digest=selection.digest,
+            )
+        )
+        show_result("GroupPlan Result", _result_lines(result, target_line))
+    except CancelMenuAction:
+        return
+    except Exception as error:
+        _handle_error(activity, error)

--- a/concord/menu_grouping_signal.py
+++ b/concord/menu_grouping_signal.py
@@ -389,7 +389,7 @@ def launch_grouping_signal_menu(activity: ActivitySummary) -> None:
             )
             print(
                 "This menu does not create GroupPlans or canonical Groups. "
-                "Signal-backed planning begins in issue #54."
+                "Signal-backed planning is available from Plan groups."
             )
             print()
             pause_for_user()

--- a/concord/workflows/__init__.py
+++ b/concord/workflows/__init__.py
@@ -155,6 +155,11 @@ from concord.workflows.group_plan_random import (
     RandomGroupPlanCreationResult,
     create_random_group_plan,
 )
+from concord.workflows.group_plan_signal import (
+    CreateSignalGroupPlanRequest,
+    SignalGroupPlanCreationResult,
+    create_signal_group_plan,
+)
 from concord.workflows.grouping_signal import (
     GroupingSignalCsvSourceInspection,
     GroupingSignalDimensionSelection,
@@ -499,6 +504,9 @@ __all__ = [
     "CreateRandomGroupPlanRequest",
     "RandomGroupPlanCreationResult",
     "create_random_group_plan",
+    "CreateSignalGroupPlanRequest",
+    "SignalGroupPlanCreationResult",
+    "create_signal_group_plan",
     "GroupingSignalCsvSourceInspection",
     "GroupingSignalDimensionSelection",
     "GroupingSignalImportPreview",

--- a/concord/workflows/group_plan_signal.py
+++ b/concord/workflows/group_plan_signal.py
@@ -1,0 +1,191 @@
+"""Signal-backed deterministic GroupPlan creation over the native planning boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from pds_core.standards import StandardsLibrary
+
+from concord.group_plan_signal import (
+    SignalGroupPlanningError,
+    generate_mixed_signal_group_plan_proposal,
+    generate_similar_signal_group_plan_proposal,
+)
+from concord.workflows.context import (
+    Clock,
+    require_core_class,
+    resolve_read_workspace_root,
+)
+from concord.workflows.errors import (
+    ConcordWorkflowConflictError,
+    ConcordWorkflowNotFoundError,
+    ConcordWorkflowValidationError,
+)
+from concord.workflows.group_plan import (
+    CreateGroupPlanRequest,
+    GroupPlanMutationResult,
+    create_group_plan,
+)
+from concord.workflows.grouping_signal import (
+    GroupingSignalDimensionSelection,
+    select_grouping_signal_dimension,
+)
+from concord.workflows.models import WorkflowActor
+from concord.workflows.participants import load_required_roster
+
+_SIGNAL_STRATEGIES = frozenset({"similar_signal", "mixed_signal"})
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CreateSignalGroupPlanRequest:
+    """Create one deterministic signal-backed draft from an exact Core dimension."""
+
+    class_id: str
+    activity_id: str
+    group_plan_id: str
+    strategy: str
+    signal_set_id: str
+    dimension_id: str
+    expected_snapshot_revision: int
+    actor: WorkflowActor
+    target_group_size: int | None = None
+    target_group_count: int | None = None
+    expected_roster_student_ids: tuple[str, ...] | None = None
+    expected_signal_set_digest: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SignalGroupPlanCreationResult:
+    """Privacy-bounded result for one persisted signal-backed draft."""
+
+    mutation: GroupPlanMutationResult
+    strategy: str
+    group_count: int
+    assigned_student_count: int
+    unresolved_student_count: int
+    group_sizes: tuple[int, ...]
+    signal_set_id: str
+    signal_set_digest: str
+    dimension_id: str
+
+
+def _roster_student_ids(root: Path, class_id: str) -> tuple[str, ...]:
+    roster = load_required_roster(root, class_id)
+    return tuple(sorted(student.student_id for student in roster.students))
+
+
+def _selected_signal_bands(
+    selection: GroupingSignalDimensionSelection,
+) -> dict[str, int]:
+    return {
+        entry.student_id: entry.band
+        for entry in selection.inspection.stored.signal.student_bands
+        if entry.dimension_id == selection.dimension_id
+    }
+
+
+def create_signal_group_plan(
+    request: CreateSignalGroupPlanRequest,
+    *,
+    workspace_root: str | Path | None = None,
+    standards_library: StandardsLibrary | None = None,
+    clock: Clock | None = None,
+) -> SignalGroupPlanCreationResult:
+    """Create one signal-backed draft without creating canonical Groups."""
+
+    if request.strategy not in _SIGNAL_STRATEGIES:
+        raise ConcordWorkflowValidationError(
+            "strategy must be 'similar_signal' or 'mixed_signal'."
+        )
+
+    root = resolve_read_workspace_root(workspace_root)
+    if root is None:
+        raise ConcordWorkflowNotFoundError(
+            "Paper Data Suite workspace does not exist."
+        )
+    require_core_class(root, request.class_id)
+
+    roster_student_ids = _roster_student_ids(root, request.class_id)
+    if (
+        request.expected_roster_student_ids is not None
+        and roster_student_ids != request.expected_roster_student_ids
+    ):
+        raise ConcordWorkflowConflictError(
+            "Core roster changed since the signal GroupPlan preview; "
+            "reload and retry."
+        )
+
+    selection = select_grouping_signal_dimension(
+        request.class_id,
+        request.signal_set_id,
+        request.dimension_id,
+        workspace_root=root,
+    )
+    if (
+        request.expected_signal_set_digest is not None
+        and selection.digest != request.expected_signal_set_digest
+    ):
+        raise ConcordWorkflowConflictError(
+            "Grouping signal changed since the GroupPlan preview; reload and retry."
+        )
+
+    # The #53 diagnostics above were calculated against a concrete Core roster.
+    # Do not combine them with a different roster if the shared class changed
+    # while the exact signal/dimension was being selected.
+    if _roster_student_ids(root, request.class_id) != roster_student_ids:
+        raise ConcordWorkflowConflictError(
+            "Core roster changed while selecting the grouping signal; "
+            "reload and retry."
+        )
+
+    signal_bands = _selected_signal_bands(selection)
+    try:
+        if request.strategy == "similar_signal":
+            proposal = generate_similar_signal_group_plan_proposal(
+                roster_student_ids,
+                signal_bands,
+                target_group_size=request.target_group_size,
+                target_group_count=request.target_group_count,
+            )
+        else:
+            proposal = generate_mixed_signal_group_plan_proposal(
+                roster_student_ids,
+                signal_bands,
+                target_group_size=request.target_group_size,
+                target_group_count=request.target_group_count,
+            )
+    except SignalGroupPlanningError as error:
+        raise ConcordWorkflowValidationError(str(error)) from error
+
+    mutation = create_group_plan(
+        CreateGroupPlanRequest(
+            class_id=request.class_id,
+            activity_id=request.activity_id,
+            group_plan_id=request.group_plan_id,
+            strategy=request.strategy,
+            expected_snapshot_revision=request.expected_snapshot_revision,
+            actor=request.actor,
+            proposed_groups=proposal.proposed_groups,
+            target_group_size=request.target_group_size,
+            target_group_count=request.target_group_count,
+            source_signal_set_id=selection.signal_set_id,
+            source_signal_set_digest=selection.digest,
+            source_signal_dimension_id=selection.dimension_id,
+            expected_roster_student_ids=proposal.roster_student_ids,
+        ),
+        workspace_root=root,
+        standards_library=standards_library,
+        clock=clock,
+    )
+    return SignalGroupPlanCreationResult(
+        mutation=mutation,
+        strategy=request.strategy,
+        group_count=proposal.group_count,
+        assigned_student_count=proposal.assigned_student_count,
+        unresolved_student_count=proposal.unresolved_student_count,
+        group_sizes=proposal.group_sizes,
+        signal_set_id=selection.signal_set_id,
+        signal_set_digest=selection.digest,
+        dimension_id=selection.dimension_id,
+    )

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,8 +30,11 @@ Issue #52 now adds exact seeded deterministic random proposals with explicit
 size/count targets and balanced partitioning. Issue #53 now implements exact
 Core grouping-signal discovery, bounded inspection/diagnostics, explicit
 dimension selection, and teacher-controlled `grouping_signal_csv_v1` import.
-Signal-backed planning remains reserved for #54, missing-signal disposition for
-#55, and canonical plan application for #56.
+Issue #54 now implements deterministic `similar_signal` and `mixed_signal` drafts
+with full-roster targets, exact Core signal/dimension binding, explicit unresolved
+missing coverage, bounded direct/menu UX, and no Meridian runtime dependency.
+Missing-signal disposition remains reserved for #55 and canonical plan application
+for #56.
 
 The repository now contains:
 
@@ -59,6 +62,9 @@ The repository now contains:
 * exact Core grouping-signal discovery, canonical-digest inspection, explicit
   dimension diagnostics/selection, and immutable teacher-controlled Core CSV
   import with no Activity/GroupPlan or sibling-module side effects;
+* deterministic similar-signal and mixed-signal GroupPlan generation with shared
+  full-roster target semantics, exact signal provenance, visible unresolved missing
+  coverage, explicit teacher review, and no canonical Group/Membership side effects;
 * contextual Membership, Role, and Responsibility workflow services;
 * a fully noninteractive direct CLI;
 * a teacher-facing H/B/M/Q menu with low-information-density screens;
@@ -174,15 +180,25 @@ complete/projection CSV import, immutable replay/conflict semantics,
 review-to-write digest binding, direct CLI/menu surfaces, privacy boundary, and
 #54-#56 handoffs without a Meridian runtime dependency.
 
+### 30. v0.3.0 signal-backed Group planning
+
+[`v0.3.0-signal-group-planning.md`](v0.3.0-signal-group-planning.md)
+
+Documents issue #54's deterministic `similar_signal` and `mixed_signal` algorithms,
+shared full-roster size/count targets, exact Core signal/dimension/digest binding,
+partial-coverage and unresolved semantics, roster/preview race protection, direct
+CLI and explicit teacher-menu review, lifecycle reuse, privacy constraints, sibling
+isolation, and the #55/#56 handoffs.
+
 ### Future v0.3.0 Group Planning / Template / Packet plan
 
 [`pds-group-planning-interoperability-development-plan.md`](pds-group-planning-interoperability-development-plan.md)
 
 This remains the roadmap for future v0.3.0 issues beyond the implemented
-#48-#53 foundations. It does not make the #54-#56 signal-backed planning,
-missing-signal policy, or canonical application implemented, nor does it make
-Template, Packet, guided Activity setup, or final integrated teacher UI behavior
-implemented merely because their contracts are documented.
+#48-#54 foundations. It does not make #55 missing-signal policy or #56 canonical
+application implemented, nor does it make Template, Packet, guided Activity setup,
+or final integrated teacher UI behavior implemented merely because their contracts
+are documented.
 
 ### 14. PDS2 Artifact Page integration
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented through the v0.3.0 grouping-signal workflow in issue #53.
+Implemented through the v0.3.0 signal-backed GroupPlan workflow in issue #54.
 
 ## Two interfaces, one service layer
 
@@ -61,6 +61,8 @@ concord group-plan list
 concord group-plan show
 concord group-plan create-manual
 concord group-plan create-random
+concord group-plan create-similar-signal
+concord group-plan create-mixed-signal
 concord group-plan add-group
 concord group-plan edit-group
 concord group-plan remove-group
@@ -263,13 +265,22 @@ operational `Group`/`GroupMembership` command family.
 The `group-plan` family supports manual draft creation, plan-local group metadata,
 exact roster-student placement/movement/unassignment, explicit roster refresh,
 strict arrangement CSV import/replacement, deterministic seeded random creation,
-and the existing preview/approve/cancel lifecycle.
+deterministic similar-signal/mixed-signal creation, and the existing
+preview/approve/cancel lifecycle.
 
 `group-plan create-random` requires an explicit seed and exactly one of
 `--target-group-size` or `--target-group-count`. The same exact roster, target,
 and seed use the documented `pds-concord:group-plan-random:v1` SHA-256 ranking
 and balanced partitioning contract. Random creation assigns the complete current
 roster, creates a `draft`, and creates no canonical Group or Membership.
+
+`group-plan create-similar-signal` and `group-plan create-mixed-signal` require an
+explicit Core signal set, explicit dimension, and exactly one size/count target.
+They accept no seed. The target is resolved against the full exact Core roster;
+selected-dimension missing students remain unresolved. Success reports the exact
+Core canonical signal digest and aggregate group/coverage counts without emitting
+student-band rows. Both commands create only a `draft` GroupPlan and explicitly
+report `Canonical Groups created: no`.
 
 Targeted plan edits reject Core-roster drift instead of silently refreshing it.
 `refresh-roster` is the explicit operation that preserves remaining placements,

--- a/docs/v0.3.0-core-grouping-signal-integration.md
+++ b/docs/v0.3.0-core-grouping-signal-integration.md
@@ -137,8 +137,8 @@ Core grouping-signal digest
     -> digest of the canonical grouping_signal_set_v1 bytes
 ```
 
-A future signal-backed GroupPlan may preserve the exact Core signal identity
-and canonical digest for reproducibility. It must not substitute the producer's
+Issue #54 signal-backed GroupPlans preserve the exact Core signal identity and
+canonical digest for reproducibility. They do not substitute the producer's
 `source.snapshot_digest` for the Core signal digest.
 
 ## Contextual ordinal bands
@@ -186,8 +186,8 @@ One signal set may contain several independent dimensions. Concord does not:
 - compare the same band number across separate dimensions; or
 - infer that one dimension is academically stronger or more important.
 
-Issue #53 now provides explicit teacher selection and diagnostic presentation.
-Issue #54 will consume one explicitly selected dimension through the #53 typed
+Issue #53 provides explicit teacher selection and diagnostic presentation.
+Issue #54 now consumes one explicitly selected dimension through that typed
 selection boundary for the bounded signal-dependent planning strategies.
 
 ## Exact student identity and partial coverage

--- a/docs/v0.3.0-group-plan-contract.md
+++ b/docs/v0.3.0-group-plan-contract.md
@@ -326,7 +326,7 @@ Existing direct Group workflows remain unchanged.
 #51 manual planning and student_id,group import — implemented
 #52 deterministic random planning — implemented
 #53 signal discovery/import/dimension diagnostics — implemented
-#54 similar-signal and mixed-signal algorithms
+#54 similar-signal and mixed-signal algorithms — implemented
 #55 explicit missing-signal teacher decisions
 #56 approved-plan application to Group/GroupMembership
 ```
@@ -366,6 +366,14 @@ Issue #52 now layers deterministic seeded random generation on the same contract
 It generates a complete draft from the exact Core roster, one explicit
 size/count target, and an explicit seed, then leaves all editing, preview, and
 approval behavior to the existing #50/#51 services.
+
+Issue #54 now layers deterministic `similar_signal` and `mixed_signal` generation
+on the same contract. Both consume one exact #53 signal/dimension selection, share
+#52's full-roster size/count target semantics, preserve only exact signal
+ID/Core-digest/dimension provenance, leave missing selected-dimension roster
+students unresolved, and reuse #51 editing/refresh without rerunning the planner.
+Direct CLI and teacher-menu creation remain draft-only and create no canonical
+Group or GroupMembership.
 
 Canonical application remains reserved for #56; there is intentionally no
 generic `apply_group_plan`, `mark_group_plan_applied`, or status setter.

--- a/docs/v0.3.0-grouping-signal-workflows.md
+++ b/docs/v0.3.0-grouping-signal-workflows.md
@@ -14,7 +14,7 @@ Issue #53 is Concord's explicit teacher-facing bridge from Core's neutral:
 grouping_signal_set_v1
 ```
 
-exchange to the later signal-dependent GroupPlan strategies.
+exchange to the signal-dependent GroupPlan strategies implemented by issue #54.
 
 The implemented boundary is:
 
@@ -41,8 +41,9 @@ preview -> approve
 Group + GroupMembership
 ```
 
-Issue #53 does not implement a grouping algorithm and does not create a
-GroupPlan.
+Issue #53 itself does not implement a grouping algorithm and does not create a
+GroupPlan. Issue #54 now consumes this exact selection boundary to create
+deterministic signal-backed drafts.
 
 ## Core remains authoritative
 
@@ -136,7 +137,7 @@ The Core signal digest binds the canonical `grouping_signal_set_v1` bytes.
 `source.snapshot_digest`, when present, binds whatever upstream snapshot the
 producer identified.
 
-Concord displays these separately and future GroupPlan provenance must use the
+Concord displays these separately and signal-backed GroupPlan provenance uses the
 Core signal digest for:
 
 ```text
@@ -168,7 +169,7 @@ dimension_id
 and returns the exact Core signal, canonical digest, selected dimension, and
 Core diagnostic report.
 
-This is the intended signal-resolution handoff for issue #54.
+This is the signal-resolution handoff consumed by issue #54.
 
 Selection is transient and read-only. Concord does not persist:
 
@@ -533,7 +534,9 @@ create a RoleAssignment
 create a ResponsibilityAssignment
 ```
 
-The first signal-backed GroupPlan belongs to issue #54.
+Issue #54 now creates signal-backed GroupPlan drafts through a separate planning
+workflow. The #53 discovery/inspection/diagnostic/import operations documented in
+this section remain nonmutating with respect to Activity and GroupPlan state.
 
 Issue #55 owns missing-signal planning disposition.
 
@@ -588,7 +591,7 @@ zero grouping signals.
 Issue #53 does not alter their lifecycle, roster refresh, direct CLI, or
 teacher-menu behavior.
 
-The later signal-backed strategies will preserve only:
+The implemented #54 signal-backed strategies preserve only:
 
 ```text
 source_signal_set_id
@@ -641,7 +644,7 @@ No physical paper round trip is required for issue #53.
 ## Handoffs
 
 ```text
-Issue #54 -> deterministic similar-signal and mixed-signal GroupPlan algorithms
+Issue #54 -> deterministic similar-signal and mixed-signal GroupPlan algorithms — implemented
 Issue #55 -> explicit teacher decisions for missing signal coverage
 Issue #56 -> approved GroupPlan application to Group/GroupMembership
 ```

--- a/docs/v0.3.0-random-group-planning.md
+++ b/docs/v0.3.0-random-group-planning.md
@@ -79,6 +79,11 @@ N=10, S=4 -> K=3 -> sizes 4,3,3
 N=8,  S=3 -> K=3 -> sizes 3,3,2
 ```
 
+Issue #54 extracts/reuses the same pure target-count and balanced-size helpers for
+signal-backed planning. This is an implementation-sharing boundary only: the #52
+random ranking, seed contract, generated membership, and documented fixtures remain
+unchanged. Signal-backed targets are likewise resolved against the full Core roster.
+
 ## Deterministic random v1 contract
 
 The algorithm contract is versioned by this exact domain separator:
@@ -173,10 +178,11 @@ arguments. Success reports compact counts and explicitly states:
 Canonical Groups created: no
 ```
 
-The bounded `Plan groups` menu now exposes manual, random, and arrangement-import
-creation. The random path asks for target type/value and exact seed, reviews the
-inputs, and requires `CREATE`. The exact seed prompt preserves whitespace so
-invalid leading/trailing whitespace is rejected rather than silently normalized.
+The bounded `Plan groups` menu now exposes manual, random, arrangement-import, and
+signal-backed creation. The random path asks for target type/value and exact seed,
+reviews the inputs, and requires `CREATE`. The exact seed prompt preserves
+whitespace so invalid leading/trailing whitespace is rejected rather than silently
+normalized.
 
 ## Privacy and dependency boundary
 
@@ -216,7 +222,7 @@ Deferred work remains:
 
 ```text
 Issue #53 grouping-signal discovery/import/dimension diagnostics — implemented
-Issue #54 similar-signal and mixed-signal planners
+Issue #54 similar-signal and mixed-signal planners — implemented
 Issue #55 explicit missing-signal teacher disposition
 Issue #56 approved-plan application to Group/GroupMembership
 #65 guided Activity setup

--- a/docs/v0.3.0-signal-group-planning.md
+++ b/docs/v0.3.0-signal-group-planning.md
@@ -1,0 +1,537 @@
+# Concord v0.3.0 Signal-Backed Group Planning
+
+**Issue:** #54 — Implement bounded similar-signal and mixed-signal planners  
+**Status:** Implemented on the v0.3.0 development line  
+**Development version:** `pds-concord 0.3.0.dev0`  
+**Core requirement:** `pds-core>=0.6.1,<0.7`  
+**Exact Core qualification release:** `pds-core` v0.6.1
+
+## Purpose
+
+Issue #54 implements Concord's first two signal-dependent `GroupPlan` strategies:
+
+```text
+similar_signal
+mixed_signal
+```
+
+They consume one explicitly selected immutable Core `grouping_signal_set_v1`
+snapshot and one explicitly selected dimension. They generate only a deterministic,
+teacher-restricted `GroupPlan(status=draft)` proposal. They do not create canonical
+`Group` or `GroupMembership` state and do not interpret the educational meaning of
+the signal.
+
+The implemented lifecycle boundary is:
+
+```text
+Core grouping_signal_set_v1
+        |
+        | exact #53 selection
+        v
+explicit signal set + explicit dimension
+        |
+        | #54 deterministic proposal
+        v
+similar_signal / mixed_signal GroupPlan draft
+        |
+        | optional #51 teacher edits / roster refresh
+        | #55 missing-signal disposition
+        v
+preview -> approve
+        |
+        | #56 only
+        v
+canonical Group + GroupMembership
+```
+
+The permanent distinctions remain:
+
+```text
+GroupingSignalSet != GroupPlan
+GroupPlan != Group
+PlannedGroup != Group
+GroupPlan != GroupMembership
+band != Score
+band != Grade
+band != proficiency
+missing signal != lowest band
+```
+
+## Ownership boundary
+
+Core remains authoritative for signal structure, canonical JSON, canonical SHA-256,
+immutable exchange storage, class/student identity, dimension/band validation, and
+roster diagnostics. Concord #54 consumes the typed #53 selection boundary rather
+than walking `exchange/grouping-signals`, opening digest sidecars, parsing signal
+JSON/CSV itself, or calculating a competing signal digest.
+
+A producer such as Meridian remains authoritative for why an academic or other
+contextual signal was generated and how its bands were derived. `source.module_id`
+is provenance, not dispatch. Concord does not import Meridian, query Meridian's
+workspace, reconstruct producer-native evidence, calculate proficiency, or derive a
+new signal from Grades or Scores.
+
+Concord #54 owns only deterministic planning strategy, target resolution,
+plan-local membership proposal construction, exact signal binding, and bounded
+CLI/menu presentation.
+
+## Public workflow surface
+
+The presentation-neutral creation service is exported through `concord.workflows`:
+
+```python
+CreateSignalGroupPlanRequest
+SignalGroupPlanCreationResult
+create_signal_group_plan
+```
+
+The request requires:
+
+```text
+class_id
+activity_id
+group_plan_id
+expected_snapshot_revision
+actor
+strategy = similar_signal | mixed_signal
+signal_set_id
+dimension_id
+exactly one of target_group_size | target_group_count
+```
+
+It accepts no seed. `seed` remains exclusive to deterministic random planning.
+There is no `latest` signal, default dimension, implicit producer policy, or hidden
+fallback.
+
+The service resolves the signal only through:
+
+```python
+select_grouping_signal_dimension(
+    class_id,
+    signal_set_id,
+    dimension_id,
+)
+```
+
+and persists exactly:
+
+```text
+selection.signal_set_id  -> GroupPlan.source_signal_set_id
+selection.digest         -> GroupPlan.source_signal_set_digest
+selection.dimension_id   -> GroupPlan.source_signal_dimension_id
+```
+
+`source_signal_set_digest` is Core's canonical `grouping_signal_set_v1` digest. It
+is never populated from producer `source.snapshot_digest`.
+
+## Shared target semantics
+
+Issue #54 and issue #52 use the same pure target-resolution helpers. Random planning
+behavior is unchanged; the extraction prevents size/count arithmetic from drifting
+between generated strategies.
+
+Let:
+
+```text
+N = exact current Core roster size
+```
+
+The target is always resolved against `N`, not only against students represented in
+the selected signal dimension.
+
+For an explicit target group count `K`:
+
+```text
+1 <= K <= N
+```
+
+and Concord creates exactly `K` plan-local groups.
+
+For an explicit target group size `S`:
+
+```text
+S >= 1
+K = ceil(N / S)
+K = (N + S - 1) // S
+```
+
+and Concord creates exactly `K` plan-local groups while preserving the original
+`target_group_size` in the `GroupPlan`.
+
+For example:
+
+```text
+roster N = 10
+selected-dimension matched students = 8
+missing students = 2
+target group size S = 4
+
+K = ceil(N / S) = 3
+```
+
+The proposal contains three planned groups. The two missing students remain
+unresolved; they do not cause the planner to reduce the target to two groups.
+
+## Exact represented and unresolved sets
+
+Let:
+
+```text
+R = exact current Core roster student IDs
+S = student IDs represented in the selected dimension
+M = R intersect S
+U = R - M
+```
+
+Core #53 diagnostics reject class mismatch, wrong-class students, and unknown
+students before planning. Missing selected-dimension coverage remains a valid
+warning.
+
+The draft therefore satisfies:
+
+```text
+assigned students   = M
+unresolved students = U
+assigned union unresolved = R
+assigned intersect unresolved = empty
+```
+
+A missing signal is never synthesized as Band 0, Band 1, an average/median band, a
+random band, or a neighboring student's band. `GroupPlan.unresolved_student_ids`
+records the exact missing current-roster IDs for later teacher action.
+
+## Deterministic planner layer
+
+The pure planner lives outside workspace I/O. Its principal operations are:
+
+```python
+generate_similar_signal_group_plan_proposal
+generate_mixed_signal_group_plan_proposal
+```
+
+For the same exact roster, selected signal contents, selected dimension, strategy,
+and target, planned membership is invariant to input roster order, signal-entry
+order, dictionary/set iteration, actor, timestamp, `group_plan_id`, process,
+supported Python version, and Windows versus Linux.
+
+Tie-breaking uses exact lexical `student_id`. That ordering is a deterministic
+technical tie-breaker only; it has no pedagogical meaning.
+
+The planners do not use Python `hash()`, `random.shuffle()`, `random.sample()`, UUID
+randomness, wall-clock time, filesystem ordering, optimization search, or hidden
+state.
+
+## `similar_signal` v1
+
+`similar_signal` narrowly clusters equal or nearby ordinal bands into balanced
+plan-local groups. It does not claim ability grouping or pedagogical optimality.
+
+Given target-resolved group count `K`, canonicalize represented students by:
+
+```text
+(band ascending, student_id ascending)
+```
+
+Let:
+
+```text
+m = number of represented students
+base, extra = divmod(m, K)
+```
+
+The first `extra` groups receive `base + 1` represented students and the remaining
+groups receive `base`. Partition the canonical sequence contiguously by those
+sizes.
+
+Plan-local identities are exactly:
+
+```text
+similar-1 -> Group 1
+similar-2 -> Group 2
+...
+similar-K -> Group K
+```
+
+Group number is algorithmic position, not academic rank. Where a target boundary
+falls inside a band, adjacent groups may split students from the same band; where a
+boundary spans two bands, a group may contain adjacent bands. No distance optimizer
+or permutation search is performed.
+
+## `mixed_signal` v1
+
+`mixed_signal` narrowly distributes selected-dimension ordinal bands across the
+same target-resolved number of plan-local groups. It does not claim social,
+academic, statistical, or pedagogical fairness.
+
+Canonicalize represented students by:
+
+```text
+(band descending, student_id ascending)
+```
+
+Then assign cyclically:
+
+```text
+group_index = position % K
+```
+
+Plan-local identities are exactly:
+
+```text
+mixed-1 -> Group 1
+mixed-2 -> Group 2
+...
+mixed-K -> Group K
+```
+
+No variance minimization, mean/median balancing, constraint solver, fairness score,
+pairwise search, or optimization metric is part of the contract.
+
+## Partial coverage and group sizes
+
+For either strategy, represented-student group sizes are left-balanced so:
+
+```text
+max(group size) - min(group size) <= 1
+```
+
+including empty groups when represented students are fewer than target-resolved
+groups. For a size target, no represented-student group exceeds the requested size.
+
+Missing students remain unresolved and therefore do not consume a generated
+assignment slot. It is valid for a signal-backed draft to retain empty groups. This
+preserves the teacher's full-roster target for #55 rather than silently changing the
+requested shape.
+
+## Fail-closed roster and review races
+
+Creation protects against roster drift in two places.
+
+The service sequence is:
+
+```text
+1. load exact current Core roster IDs;
+2. resolve exact signal + dimension through #53;
+3. re-read the Core roster and reject drift;
+4. generate the pure deterministic proposal;
+5. call create_group_plan with expected_roster_student_ids;
+6. let the existing Activity expected-snapshot write guard concurrency.
+```
+
+The teacher-menu path additionally creates an in-memory preview before `CREATE`.
+That preview records two explicit preconditions passed to the service:
+
+```text
+expected_roster_student_ids
+expected_signal_set_digest
+```
+
+If the roster or immutable selected signal identity/digest observed at persistence
+differs from the reviewed preview, creation fails closed. Concord does not silently
+refresh, silently rerun against a different roster, or persist an unreviewed
+proposal.
+
+## Persistence contract
+
+A successful signal-backed creation persists:
+
+```text
+strategy = similar_signal | mixed_signal
+status = draft
+seed = None
+exactly one target field
+source_signal_set_id = exact selected signal ID
+source_signal_set_digest = exact Core canonical signal digest
+source_signal_dimension_id = exact selected dimension ID
+roster_student_ids = exact current roster
+proposed_groups = deterministic generated proposal
+unresolved_student_ids = exact missing selected-dimension roster students
+```
+
+It does not persist:
+
+```text
+student -> band mappings
+raw grades
+percentages
+proficiency values
+producer-native evidence
+producer snapshot contents
+optimization scores
+fairness scores
+```
+
+## Editing, refresh, preview, and approval
+
+Signal plans reuse the #50/#51 lifecycle and editor without a second proposal model.
+Teachers may rename/add/remove planned groups and place/move/unassign students.
+Material edits preserve the original strategy, target, and exact signal binding and
+return a previewed plan to `draft`. Editing does not rerun the signal planner.
+
+Explicit roster refresh preserves still-rostered placements, drops departed
+students, adds newcomers as unresolved, preserves plan-local group identities and
+empty groups, preserves strategy/target/signal binding, and returns a changed
+previewed plan to `draft`. Refresh does not select a newer signal and does not rerun
+the algorithm. A teacher who wants a proposal from a different signal creates a new
+GroupPlan.
+
+A draft with unresolved students may be previewed. Under the current lifecycle,
+approval requires every roster student to be resolved. Issue #55 owns the explicit
+missing-signal disposition workflow; #54 does not invent a policy for those students.
+
+Approval remains planning-only. Issue #56 alone owns the transaction that creates
+canonical `Group`/`GroupMembership` state and marks an approved plan applied.
+
+## Direct CLI
+
+Issue #54 adds:
+
+```text
+concord group-plan create-similar-signal
+concord group-plan create-mixed-signal
+```
+
+Both require the normal explicit class, Activity, GroupPlan ID, actor, and expected
+Activity snapshot arguments plus:
+
+```text
+--signal-set-id
+--dimension-id
+exactly one of --target-group-size | --target-group-count
+```
+
+Neither command accepts `--seed`.
+
+Success output is bounded to persistence identity/provenance and aggregate proposal
+shape: GroupPlan ID, strategy, `draft` status, selected signal ID, Core canonical
+digest, dimension, target, group count, assigned count, unresolved count, group
+sizes, and:
+
+```text
+Canonical Groups created: no
+```
+
+The create commands do not emit per-student bands or planned student IDs.
+Missing-only partial coverage is a successful draft creation with a nonzero
+unresolved count.
+
+## Teacher menu
+
+The existing `Groups and Participants -> Plan groups` menu retains its established
+choices for manual/random/import/signal inspection/opening and adds:
+
+```text
+7. Create similar-signal plan
+8. Create mixed-signal plan
+```
+
+The workflow requires explicit signal selection even when only one signal exists and
+explicit dimension selection even when only one dimension exists. It then presents:
+
+```text
+exact signal ID
+Core canonical signal digest
+exact dimension
+roster / matched / missing counts
+neutral Band 1..N distribution counts
+target selection
+in-memory deterministic planned memberships
+unresolved IDs when present
+```
+
+It does not present a default per-student band table. Planned memberships are shown
+because they are the proposal the teacher is reviewing; band values are not attached
+to those student IDs.
+
+Persistence requires the exact confirmation word:
+
+```text
+CREATE
+```
+
+and the review explicitly states that no canonical Groups or Memberships are being
+created.
+
+## Privacy and terminology
+
+Grouping signals and signal-backed GroupPlans are teacher-restricted educational
+planning data. Signal bands must not leak into default logs, crash reports, passive
+attention summaries, PDS2 routes, Route Registrations, packet/template metadata,
+Artifact metadata, Artifact Reviews, Moderation Records, Score Records, Academic
+Result Manifests, Publication Records, or canonical Group/Membership records.
+
+Normal #54 output uses neutral terms such as grouping signal, signal set, dimension,
+ordinal band, Band N, similar-signal, mixed-signal, matched, missing, unresolved,
+cluster, and distribute.
+
+The implementation makes no claim of ability, proficiency, readiness, permanent
+learner status, optimality, fairness, or pedagogical superiority. Group numbers and
+band numbers are not learner labels.
+
+## Explicit non-goals and handoffs
+
+Issue #54 does not implement:
+
+```text
+missing-signal disposition policy          -> Issue #55
+approved-plan application                  -> Issue #56
+automatic signal generation
+automatic/latest signal selection
+automatic/default dimension selection
+multi-dimensional optimization
+social/demographic balancing
+role/language/behavior/attendance balancing
+academic interpretation
+constraint solving
+machine-learning grouping
+fairness optimization
+packet/template/PDS2/publication changes
+```
+
+Manual, imported-arrangement, deterministic random, and direct operational Group
+work remain valid with zero grouping signals.
+
+## Qualification
+
+Focused #54 coverage includes:
+
+```text
+shared full-roster size/count target semantics
+similar_signal canonical ordering and contiguous partition
+mixed_signal descending ordering and cyclic distribution
+stable tie-breaking by exact student_id
+input-order and actor/time/plan-ID independence
+partial coverage and empty-group behavior
+exact unresolved-set coverage
+Core canonical digest binding
+producer source-digest distinction
+roster-race rejection
+menu preview roster/digest race rejection
+stale Activity snapshot rejection
+manual editing and preview-to-draft behavior
+explicit roster refresh without replanning
+preview with unresolved students
+approval rejection while unresolved
+resolved approval without canonical Group creation
+privacy-bounded CLI output
+explicit menu signal/dimension selection
+neutral band-distribution presentation
+CREATE confirmation
+absence of Meridian runtime dependency
+absence of unrelated collaboration/scoring/publication state
+```
+
+Repository qualification remains:
+
+```text
+python -m pytest
+python -m ruff check .
+python -m mypy
+python scripts/check_documentation.py
+python scripts/verify_release_compatibility.py
+python scripts/validate_repository.py --core-wheel <authenticated-pds-core-0.6.1-wheel> --allow-dirty
+git diff --check
+git status --short
+```
+
+No physical paper round trip is required for issue #54.

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -44,6 +44,7 @@ RANDOM_GROUP_PLAN_DOC = ROOT / "docs" / "v0.3.0-random-group-planning.md"
 GROUPING_SIGNAL_WORKFLOW_DOC = (
     ROOT / "docs" / "v0.3.0-grouping-signal-workflows.md"
 )
+SIGNAL_GROUP_PLAN_DOC = ROOT / "docs" / "v0.3.0-signal-group-planning.md"
 REQUIRED_GROUP_PLAN_DOC_PHRASES = (
     "GroupPlan != Group",
     "record kind: group_plan",
@@ -86,6 +87,22 @@ REQUIRED_GROUPING_SIGNAL_WORKFLOW_DOC_PHRASES = (
     "expected_signal_digest",
     "Meridian",
     "Issue #54",
+    "Issue #55",
+    "Issue #56",
+)
+REQUIRED_SIGNAL_GROUP_PLAN_DOC_PHRASES = (
+    "create_signal_group_plan",
+    "generate_similar_signal_group_plan_proposal",
+    "generate_mixed_signal_group_plan_proposal",
+    "ceil(N / S)",
+    "similar-1",
+    "mixed-1",
+    "source_signal_set_digest",
+    "concord group-plan create-similar-signal",
+    "concord group-plan create-mixed-signal",
+    "Canonical Groups created: no",
+    "missing signal != lowest band",
+    "Meridian",
     "Issue #55",
     "Issue #56",
 )
@@ -313,6 +330,23 @@ def check_documentation() -> None:
             failures.append(
                 "Documentation index does not link the grouping-signal "
                 "workflow document."
+            )
+    if not SIGNAL_GROUP_PLAN_DOC.is_file():
+        failures.append(
+            "Current v0.3.0 signal-backed Group planning document is missing."
+        )
+    else:
+        signal_group_plan_doc = SIGNAL_GROUP_PLAN_DOC.read_text(encoding="utf-8")
+        for phrase in REQUIRED_SIGNAL_GROUP_PLAN_DOC_PHRASES:
+            if phrase not in signal_group_plan_doc:
+                failures.append(
+                    "Signal-backed Group planning document is missing required "
+                    f"boundary wording {phrase!r}."
+                )
+        if SIGNAL_GROUP_PLAN_DOC.name not in docs_index:
+            failures.append(
+                "Documentation index does not link the signal-backed Group "
+                "planning document."
             )
     for active_path in (
         ROOT / "README.md",

--- a/tests/test_group_plan_signal_boundaries_issue54.py
+++ b/tests/test_group_plan_signal_boundaries_issue54.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import concord.workflows as workflows
+from scripts.verify_release_compatibility import validate_sibling_import_isolation
+
+
+def test_issue54_signal_workflow_is_exported_from_public_workflow_surface() -> None:
+    assert workflows.CreateSignalGroupPlanRequest.__module__ == (
+        "concord.workflows.group_plan_signal"
+    )
+    assert workflows.SignalGroupPlanCreationResult.__module__ == (
+        "concord.workflows.group_plan_signal"
+    )
+    assert workflows.create_signal_group_plan.__module__ == (
+        "concord.workflows.group_plan_signal"
+    )
+
+
+def test_issue54_production_preserves_sibling_import_isolation() -> None:
+    validate_sibling_import_isolation()
+
+    root = Path(__file__).resolve().parents[1]
+    issue54_sources = (
+        root / "concord" / "group_plan_targets.py",
+        root / "concord" / "group_plan_signal.py",
+        root / "concord" / "workflows" / "group_plan_signal.py",
+        root / "concord" / "cli_app" / "handlers" / "group_plan.py",
+        root / "concord" / "menu_group_plan_signal.py",
+        root / "concord" / "menu_group_plan.py",
+    )
+    forbidden = (
+        "import meridian",
+        "from meridian",
+        "import scoreform",
+        "from scoreform",
+        "import quillan",
+        "from quillan",
+        "import vitrine",
+        "from vitrine",
+        "import portia",
+        "from portia",
+    )
+    for source in issue54_sources:
+        text = source.read_text(encoding="utf-8").casefold()
+        assert not any(token in text for token in forbidden)
+
+
+def test_issue54_uses_core_signal_digest_not_producer_snapshot_digest() -> None:
+    root = Path(__file__).resolve().parents[1]
+    source = (
+        root / "concord" / "workflows" / "group_plan_signal.py"
+    ).read_text(encoding="utf-8")
+
+    assert "source_signal_set_digest=selection.digest" in source
+    assert "source.snapshot_digest" not in source

--- a/tests/test_group_plan_signal_cli_issue54.py
+++ b/tests/test_group_plan_signal_cli_issue54.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.grouping_signal_storage import (
+    calculate_grouping_signal_digest,
+    write_grouping_signal,
+)
+from pds_core.grouping_signals import (
+    GroupingSignalDimension,
+    GroupingSignalSet,
+    GroupingSignalSource,
+    GroupingSignalStudentBand,
+)
+from pds_core.rosters import create_roster
+from pds_core.workspace import ensure_workspace_root
+
+from concord.cli import main
+from concord.cli_app.parser import build_parser
+from concord.workflows.group_plan import show_group_plan
+
+
+def _workspace(tmp_path: Path) -> Path:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata(
+            "class-1",
+            "2026-2027",
+            created_at=datetime(2026, 8, 20, tzinfo=timezone.utc),
+        ),
+    )
+    write_class_roster(
+        root,
+        create_roster(
+            "class-1",
+            tuple(
+                {
+                    "student_id": f"student-{index}",
+                    "last_name": f"Last-{index}",
+                    "first_name": f"First-{index}",
+                    "period": "1",
+                }
+                for index in range(1, 6)
+            ),
+        ),
+    )
+    assert (
+        main(
+            [
+                "activity",
+                "create",
+                "--workspace-root",
+                str(root),
+                "--class-id",
+                "class-1",
+                "--activity-id",
+                "activity-1",
+                "--title",
+                "Signal Planning CLI",
+                "--activity-type",
+                "project",
+                "--scoring-orientation",
+                "evidence_only",
+                "--session-id",
+                "session-1",
+                "--actor-id",
+                "teacher-1",
+            ]
+        )
+        == 0
+    )
+    return root
+
+
+def _signal() -> GroupingSignalSet:
+    return GroupingSignalSet(
+        schema_version="1",
+        record_type="grouping_signal_set",
+        signal_set_id="signal-54",
+        class_id="class-1",
+        created_at=datetime(2026, 8, 20, 19, 0, tzinfo=timezone.utc),
+        source=GroupingSignalSource(
+            kind="module_generated",
+            module_id="synthetic_module",
+            snapshot_id="snapshot-54",
+            snapshot_digest_algorithm="sha256",
+            snapshot_digest="b" * 64,
+        ),
+        dimensions=(
+            GroupingSignalDimension(
+                dimension_id="collaboration-context",
+                band_count=4,
+            ),
+        ),
+        student_bands=(
+            GroupingSignalStudentBand(
+                student_id="student-1",
+                dimension_id="collaboration-context",
+                band=1,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-2",
+                dimension_id="collaboration-context",
+                band=4,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-3",
+                dimension_id="collaboration-context",
+                band=2,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-4",
+                dimension_id="collaboration-context",
+                band=3,
+            ),
+        ),
+    )
+
+
+def _base(root: Path, command: str, plan_id: str) -> list[str]:
+    return [
+        "group-plan",
+        command,
+        "--workspace-root",
+        str(root),
+        "--class-id",
+        "class-1",
+        "--activity-id",
+        "activity-1",
+        "--group-plan-id",
+        plan_id,
+        "--expected-snapshot",
+        "1",
+        "--actor-id",
+        "teacher-1",
+        "--actor-label",
+        "Synthetic Teacher",
+        "--actor-role",
+        "teacher",
+        "--signal-set-id",
+        "signal-54",
+        "--dimension-id",
+        "collaboration-context",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("command", "strategy", "plan_id"),
+    (
+        ("create-similar-signal", "similar_signal", "similar-plan"),
+        ("create-mixed-signal", "mixed_signal", "mixed-plan"),
+    ),
+)
+def test_signal_create_cli_is_explicit_bounded_and_planning_only(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    command: str,
+    strategy: str,
+    plan_id: str,
+) -> None:
+    root = _workspace(tmp_path)
+    signal = _signal()
+    write_grouping_signal(root, signal)
+    digest = calculate_grouping_signal_digest(signal)
+    capsys.readouterr()
+
+    assert main(_base(root, command, plan_id) + ["--target-group-count", "3"]) == 0
+    output = capsys.readouterr().out
+
+    assert "Committed snapshot 2." in output
+    assert f"GroupPlan: {plan_id}" in output
+    assert f"Strategy: {strategy}" in output
+    assert "Status: draft" in output
+    assert "Target group count: 3" in output
+    assert "Signal set: signal-54" in output
+    assert f"Signal digest: {digest}" in output
+    assert "Signal dimension: collaboration-context" in output
+    assert "Generated groups: 3" in output
+    assert "Assigned students: 4" in output
+    assert "Unresolved students: 1" in output
+    assert "Group sizes: 2,1,1" in output
+    assert "Canonical Groups created: no" in output
+    assert "student-1" not in output
+    assert "student-5" not in output
+    assert signal.source.snapshot_digest not in output
+
+    detail = show_group_plan(
+        "class-1",
+        "activity-1",
+        plan_id,
+        workspace_root=root,
+    )
+    assert detail.plan.strategy == strategy
+    assert detail.plan.status == "draft"
+    assert detail.plan.seed is None
+    assert detail.plan.source_signal_set_id == "signal-54"
+    assert detail.plan.source_signal_set_digest == digest
+    assert detail.plan.source_signal_dimension_id == "collaboration-context"
+    assert detail.plan.unresolved_student_ids == ("student-5",)
+
+    assert (
+        main(
+            [
+                "group",
+                "list",
+                "--workspace-root",
+                str(root),
+                "--class-id",
+                "class-1",
+                "--activity-id",
+                "activity-1",
+            ]
+        )
+        == 0
+    )
+    assert "No Groups found." in capsys.readouterr().out
+
+
+def test_signal_cli_size_target_uses_full_roster_count(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    root = _workspace(tmp_path)
+    write_grouping_signal(root, _signal())
+    capsys.readouterr()
+
+    assert (
+        main(
+            _base(root, "create-similar-signal", "size-plan")
+            + ["--target-group-size", "2"]
+        )
+        == 0
+    )
+    output = capsys.readouterr().out
+    assert "Target group size: 2" in output
+    assert "Generated groups: 3" in output
+    assert "Assigned students: 4" in output
+    assert "Unresolved students: 1" in output
+    assert "Group sizes: 2,1,1" in output
+
+
+@pytest.mark.parametrize(
+    "command",
+    ("create-similar-signal", "create-mixed-signal"),
+)
+def test_signal_cli_parser_requires_exactly_one_target_and_has_no_seed(
+    tmp_path: Path,
+    command: str,
+) -> None:
+    root = _workspace(tmp_path)
+    parser = build_parser()
+    base = _base(root, command, "parser-plan")
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(base)
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            base
+            + [
+                "--target-group-size",
+                "2",
+                "--target-group-count",
+                "3",
+            ]
+        )
+    with pytest.raises(SystemExit):
+        parser.parse_args(base + ["--target-group-count", "3", "--seed", "no"])

--- a/tests/test_group_plan_signal_issue54.py
+++ b/tests/test_group_plan_signal_issue54.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+
+from concord.group_plan_signal import (
+    SignalGroupPlanningError,
+    generate_mixed_signal_group_plan_proposal,
+    generate_similar_signal_group_plan_proposal,
+)
+
+
+def _students(count: int) -> tuple[str, ...]:
+    return tuple(f"student-{index}" for index in range(1, count + 1))
+
+
+def _bands() -> dict[str, int]:
+    return {
+        "student-1": 1,
+        "student-2": 1,
+        "student-3": 1,
+        "student-4": 2,
+        "student-5": 2,
+        "student-6": 3,
+        "student-7": 3,
+        "student-8": 4,
+    }
+
+
+def _memberships(proposal) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    return tuple(
+        (group.planned_group_key, group.student_ids)
+        for group in proposal.proposed_groups
+    )
+
+
+def test_similar_signal_has_exact_contiguous_balanced_membership() -> None:
+    proposal = generate_similar_signal_group_plan_proposal(
+        _students(10),
+        _bands(),
+        target_group_count=3,
+    )
+
+    assert proposal.group_count == 3
+    assert proposal.group_sizes == (3, 3, 2)
+    assert proposal.assigned_student_count == 8
+    assert proposal.unresolved_student_ids == ("student-10", "student-9")
+    assert _memberships(proposal) == (
+        ("similar-1", ("student-1", "student-2", "student-3")),
+        ("similar-2", ("student-4", "student-5", "student-6")),
+        ("similar-3", ("student-7", "student-8")),
+    )
+
+
+def test_mixed_signal_has_exact_descending_band_cyclic_membership() -> None:
+    proposal = generate_mixed_signal_group_plan_proposal(
+        _students(10),
+        _bands(),
+        target_group_count=3,
+    )
+
+    assert proposal.group_count == 3
+    assert proposal.group_sizes == (3, 3, 2)
+    assert proposal.assigned_student_count == 8
+    assert proposal.unresolved_student_ids == ("student-10", "student-9")
+    assert _memberships(proposal) == (
+        ("mixed-1", ("student-2", "student-4", "student-8")),
+        ("mixed-2", ("student-3", "student-5", "student-6")),
+        ("mixed-3", ("student-1", "student-7")),
+    )
+
+
+def test_roster_and_mapping_input_order_do_not_change_either_strategy() -> None:
+    roster = _students(10)
+    bands = _bands()
+    reversed_bands = dict(reversed(tuple(bands.items())))
+
+    for planner in (
+        generate_similar_signal_group_plan_proposal,
+        generate_mixed_signal_group_plan_proposal,
+    ):
+        forward = planner(roster, bands, target_group_count=3)
+        reversed_input = planner(
+            tuple(reversed(roster)),
+            reversed_bands,
+            target_group_count=3,
+        )
+        assert forward == reversed_input
+
+
+def test_target_size_resolves_group_count_from_full_roster() -> None:
+    proposal = generate_similar_signal_group_plan_proposal(
+        _students(10),
+        _bands(),
+        target_group_size=4,
+    )
+
+    assert proposal.group_count == 3
+    assert proposal.group_sizes == (3, 3, 2)
+    assert max(proposal.group_sizes) <= 4
+    assert proposal.unresolved_student_count == 2
+
+
+def test_matched_less_than_target_count_preserves_empty_groups() -> None:
+    proposal = generate_mixed_signal_group_plan_proposal(
+        _students(5),
+        {"student-1": 2, "student-2": 1},
+        target_group_count=4,
+    )
+
+    assert proposal.group_count == 4
+    assert proposal.group_sizes == (1, 1, 0, 0)
+    assert tuple(group.planned_group_key for group in proposal.proposed_groups) == (
+        "mixed-1",
+        "mixed-2",
+        "mixed-3",
+        "mixed-4",
+    )
+    assert proposal.unresolved_student_ids == (
+        "student-3",
+        "student-4",
+        "student-5",
+    )
+
+
+def test_same_band_ties_use_exact_student_id() -> None:
+    bands = {
+        "student-3": 2,
+        "student-1": 2,
+        "student-2": 2,
+    }
+    similar = generate_similar_signal_group_plan_proposal(
+        ("student-3", "student-1", "student-2"),
+        bands,
+        target_group_count=2,
+    )
+    mixed = generate_mixed_signal_group_plan_proposal(
+        ("student-3", "student-1", "student-2"),
+        bands,
+        target_group_count=2,
+    )
+
+    assert _memberships(similar) == (
+        ("similar-1", ("student-1", "student-2")),
+        ("similar-2", ("student-3",)),
+    )
+    assert _memberships(mixed) == (
+        ("mixed-1", ("student-1", "student-3")),
+        ("mixed-2", ("student-2",)),
+    )
+
+
+def test_similar_and_mixed_strategies_are_behaviorally_distinct() -> None:
+    similar = generate_similar_signal_group_plan_proposal(
+        _students(8),
+        _bands(),
+        target_group_count=2,
+    )
+    mixed = generate_mixed_signal_group_plan_proposal(
+        _students(8),
+        _bands(),
+        target_group_count=2,
+    )
+
+    assert _memberships(similar) != _memberships(mixed)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    (
+        {},
+        {"target_group_size": 2, "target_group_count": 2},
+        {"target_group_size": 0},
+        {"target_group_count": 0},
+        {"target_group_count": 4},
+    ),
+)
+def test_invalid_target_requests_fail(kwargs: dict[str, int]) -> None:
+    with pytest.raises(SignalGroupPlanningError):
+        generate_similar_signal_group_plan_proposal(
+            _students(3),
+            {"student-1": 1},
+            **kwargs,
+        )
+
+
+def test_non_roster_signal_student_fails_closed() -> None:
+    with pytest.raises(SignalGroupPlanningError, match="current-roster student IDs"):
+        generate_similar_signal_group_plan_proposal(
+            _students(3),
+            {"student-1": 1, "student-4": 2},
+            target_group_count=2,
+        )
+
+
+@pytest.mark.parametrize("band", (0, -1, True, 1.5))
+def test_invalid_band_value_fails(band: object) -> None:
+    with pytest.raises(SignalGroupPlanningError, match="positive integer"):
+        generate_mixed_signal_group_plan_proposal(
+            _students(3),
+            {"student-1": cast(int, band)},
+            target_group_count=2,
+        )
+
+
+def test_all_missing_is_explicit_and_keeps_full_target_shape() -> None:
+    proposal = generate_similar_signal_group_plan_proposal(
+        _students(4),
+        {},
+        target_group_count=3,
+    )
+
+    assert proposal.group_sizes == (0, 0, 0)
+    assert proposal.assigned_student_count == 0
+    assert proposal.unresolved_student_ids == _students(4)
+    assert len(proposal.proposed_groups) == 3

--- a/tests/test_group_plan_signal_lifecycle_issue54.py
+++ b/tests/test_group_plan_signal_lifecycle_issue54.py
@@ -1,0 +1,514 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.grouping_signal_storage import (
+    calculate_grouping_signal_digest,
+    write_grouping_signal,
+)
+from pds_core.grouping_signals import (
+    GroupingSignalDimension,
+    GroupingSignalSet,
+    GroupingSignalSource,
+    GroupingSignalStudentBand,
+)
+from pds_core.rosters import create_roster
+from pds_core.workspace import ensure_workspace_root
+
+from concord.storage import load_current_record_graph
+from concord.workflows import (
+    ApproveGroupPlanRequest,
+    CreateActivityContextRequest,
+    EditPlannedGroupRequest,
+    PlaceStudentInPlanRequest,
+    PreviewGroupPlanRequest,
+    RefreshGroupPlanRosterRequest,
+    WorkflowActor,
+    approve_group_plan,
+    create_activity_context,
+    edit_planned_group,
+    place_student_in_plan,
+    preview_group_plan,
+    refresh_group_plan_roster,
+    show_group_plan,
+)
+from concord.workflows.errors import ConcordWorkflowValidationError
+from concord.workflows.group_plan_signal import (
+    CreateSignalGroupPlanRequest,
+    create_signal_group_plan,
+)
+
+
+def _clock(day: int) -> datetime:
+    return datetime(2026, 8, day, 19, 0, tzinfo=timezone.utc)
+
+
+def _actor(actor_id: str = "teacher-1") -> WorkflowActor:
+    return WorkflowActor(
+        actor_id=actor_id,
+        display_label="Synthetic Teacher",
+        role_label="teacher",
+    )
+
+
+def _roster(*student_ids: str):
+    return create_roster(
+        "class-1",
+        tuple(
+            {
+                "student_id": student_id,
+                "last_name": f"Last-{index}",
+                "first_name": f"First-{index}",
+                "period": "1",
+            }
+            for index, student_id in enumerate(student_ids, start=1)
+        ),
+    )
+
+
+def _workspace(tmp_path: Path, *student_ids: str) -> tuple[Path, int]:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata("class-1", "2026-2027", created_at=_clock(1)),
+    )
+    write_class_roster(root, _roster(*student_ids))
+    created = create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            title="Signal Plan Lifecycle",
+            activity_type="project",
+            scoring_orientation="evidence_only",
+            session_id="session-1",
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(2),
+    )
+    return root, created.commit.snapshot_revision
+
+
+def _signal(
+    bands: tuple[tuple[str, int], ...],
+    *,
+    signal_set_id: str = "signal-1",
+) -> GroupingSignalSet:
+    dimension_id = "collaboration-context"
+    return GroupingSignalSet(
+        schema_version="1",
+        record_type="grouping_signal_set",
+        signal_set_id=signal_set_id,
+        class_id="class-1",
+        created_at=_clock(2),
+        source=GroupingSignalSource(
+            kind="module_generated",
+            module_id="synthetic_module",
+            snapshot_id=f"snapshot-{signal_set_id}",
+            snapshot_digest_algorithm="sha256",
+            snapshot_digest="b" * 64,
+        ),
+        dimensions=(
+            GroupingSignalDimension(
+                dimension_id=dimension_id,
+                band_count=4,
+            ),
+        ),
+        student_bands=tuple(
+            GroupingSignalStudentBand(
+                student_id=student_id,
+                dimension_id=dimension_id,
+                band=band,
+            )
+            for student_id, band in bands
+        ),
+    )
+
+
+def _create_signal_plan(
+    root: Path,
+    revision: int,
+    signal: GroupingSignalSet,
+    *,
+    strategy: str = "similar_signal",
+    group_plan_id: str = "signal-plan",
+    target_group_count: int = 2,
+):
+    write_grouping_signal(root, signal)
+    return create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id=group_plan_id,
+            strategy=strategy,
+            signal_set_id=signal.signal_set_id,
+            dimension_id="collaboration-context",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            target_group_count=target_group_count,
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(3),
+    )
+
+
+def _locations(detail) -> dict[str, str]:
+    return {
+        student_id: group.planned_group_key
+        for group in detail.plan.proposed_groups
+        for student_id in group.student_ids
+    }
+
+
+def _assert_signal_origin(detail, signal: GroupingSignalSet) -> None:
+    assert detail.plan.source_signal_set_id == signal.signal_set_id
+    assert detail.plan.source_signal_set_digest == calculate_grouping_signal_digest(
+        signal
+    )
+    assert detail.plan.source_signal_dimension_id == "collaboration-context"
+    assert detail.plan.seed is None
+
+
+def test_previewed_signal_plan_edit_returns_to_draft_and_preserves_origin(
+    tmp_path: Path,
+) -> None:
+    students = tuple(f"student-{index}" for index in range(1, 7))
+    root, revision = _workspace(tmp_path, *students)
+    signal = _signal(
+        (
+            ("student-1", 1),
+            ("student-2", 1),
+            ("student-3", 2),
+            ("student-4", 2),
+            ("student-5", 3),
+            ("student-6", 4),
+        )
+    )
+    created = _create_signal_plan(root, revision, signal)
+    before = show_group_plan(
+        "class-1", "activity-1", "signal-plan", workspace_root=root
+    )
+    before_locations = _locations(before)
+
+    previewed = preview_group_plan(
+        PreviewGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=created.mutation.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(4),
+    )
+    edited = edit_planned_group(
+        EditPlannedGroupRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            planned_group_key=previewed.plan.proposed_groups[0].planned_group_key,
+            label="Teacher Table",
+            expected_snapshot_revision=previewed.summary.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(5),
+    )
+
+    assert edited.detail.plan.status == "draft"
+    assert edited.detail.plan.strategy == "similar_signal"
+    assert edited.detail.plan.target_group_count == 2
+    assert edited.detail.plan.proposed_groups[0].label == "Teacher Table"
+    assert _locations(edited.detail) == before_locations
+    _assert_signal_origin(edited.detail, signal)
+
+
+def test_existing_manual_editor_can_place_unresolved_student_without_losing_origin(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(
+        tmp_path,
+        "student-1",
+        "student-2",
+        "student-3",
+        "student-4",
+    )
+    signal = _signal(
+        (("student-1", 4), ("student-2", 2), ("student-3", 1))
+    )
+    created = _create_signal_plan(
+        root,
+        revision,
+        signal,
+        strategy="mixed_signal",
+    )
+    before = show_group_plan(
+        "class-1", "activity-1", "signal-plan", workspace_root=root
+    )
+    assert before.plan.unresolved_student_ids == ("student-4",)
+
+    placed = place_student_in_plan(
+        PlaceStudentInPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            student_id="student-4",
+            planned_group_key=before.plan.proposed_groups[0].planned_group_key,
+            expected_snapshot_revision=created.mutation.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(4),
+    )
+
+    assert placed.detail.plan.strategy == "mixed_signal"
+    assert placed.detail.plan.target_group_count == 2
+    assert placed.detail.plan.unresolved_student_ids == ()
+    assert "student-4" in placed.detail.plan.proposed_groups[0].student_ids
+    _assert_signal_origin(placed.detail, signal)
+
+
+def test_refresh_preserves_survivor_placements_empty_groups_and_exact_signal_binding(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(
+        tmp_path,
+        "student-1",
+        "student-2",
+        "student-3",
+        "student-4",
+        "student-5",
+    )
+    signal = _signal(
+        (("student-1", 1), ("student-2", 2), ("student-3", 4))
+    )
+    created = _create_signal_plan(
+        root,
+        revision,
+        signal,
+        strategy="mixed_signal",
+        target_group_count=4,
+    )
+    before = show_group_plan(
+        "class-1", "activity-1", "signal-plan", workspace_root=root
+    )
+    assert tuple(len(group.student_ids) for group in before.plan.proposed_groups) == (
+        1,
+        1,
+        1,
+        0,
+    )
+    survivor_locations = {
+        student_id: group_key
+        for student_id, group_key in _locations(before).items()
+        if student_id != "student-2"
+    }
+    original_keys = tuple(
+        group.planned_group_key for group in before.plan.proposed_groups
+    )
+
+    newer_signal = _signal(
+        (("student-1", 4), ("student-3", 1), ("student-6", 2)),
+        signal_set_id="signal-2",
+    )
+    write_grouping_signal(root, newer_signal)
+    write_class_roster(
+        root,
+        _roster("student-1", "student-3", "student-4", "student-5", "student-6"),
+        overwrite=True,
+    )
+
+    refreshed = refresh_group_plan_roster(
+        RefreshGroupPlanRosterRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=created.mutation.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(4),
+    )
+
+    assert refreshed.detail.plan.status == "draft"
+    assert refreshed.detail.plan.strategy == "mixed_signal"
+    assert refreshed.detail.plan.target_group_count == 4
+    assert tuple(
+        group.planned_group_key for group in refreshed.detail.plan.proposed_groups
+    ) == original_keys
+    assert _locations(refreshed.detail) == survivor_locations
+    assert refreshed.detail.plan.unresolved_student_ids == (
+        "student-4",
+        "student-5",
+        "student-6",
+    )
+    assert any(not group.student_ids for group in refreshed.detail.plan.proposed_groups)
+    _assert_signal_origin(refreshed.detail, signal)
+    assert refreshed.detail.plan.source_signal_set_id != newer_signal.signal_set_id
+
+
+def test_refresh_of_previewed_signal_plan_returns_to_draft(tmp_path: Path) -> None:
+    root, revision = _workspace(
+        tmp_path,
+        "student-1",
+        "student-2",
+        "student-3",
+    )
+    signal = _signal(
+        (("student-1", 1), ("student-2", 2), ("student-3", 3))
+    )
+    created = _create_signal_plan(root, revision, signal)
+    previewed = preview_group_plan(
+        PreviewGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=created.mutation.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+    write_class_roster(
+        root,
+        _roster("student-1", "student-2", "student-3", "student-4"),
+        overwrite=True,
+    )
+
+    refreshed = refresh_group_plan_roster(
+        RefreshGroupPlanRosterRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=previewed.summary.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+
+    assert refreshed.detail.plan.status == "draft"
+    assert refreshed.detail.plan.previewed_provenance is None
+    assert refreshed.detail.plan.unresolved_student_ids == ("student-4",)
+    _assert_signal_origin(refreshed.detail, signal)
+
+
+def test_unresolved_signal_plan_may_preview_but_cannot_be_approved(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(
+        tmp_path,
+        "student-1",
+        "student-2",
+        "student-3",
+    )
+    signal = _signal((("student-1", 1), ("student-2", 4)))
+    created = _create_signal_plan(root, revision, signal)
+
+    previewed = preview_group_plan(
+        PreviewGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=created.mutation.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+    assert previewed.plan.status == "previewed"
+    assert previewed.plan.unresolved_student_ids == ("student-3",)
+    _assert_signal_origin(previewed, signal)
+
+    with pytest.raises(
+        ConcordWorkflowValidationError,
+        match="every roster student to be resolved",
+    ):
+        approve_group_plan(
+            ApproveGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="signal-plan",
+                expected_snapshot_revision=previewed.summary.snapshot_revision,
+                actor=_actor(),
+            ),
+            workspace_root=root,
+        )
+
+    after = show_group_plan(
+        "class-1", "activity-1", "signal-plan", workspace_root=root
+    )
+    assert after.plan.status == "previewed"
+    _assert_signal_origin(after, signal)
+
+
+def test_resolved_signal_plan_approval_preserves_binding_and_creates_no_groups(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(
+        tmp_path,
+        "student-1",
+        "student-2",
+        "student-3",
+        "student-4",
+    )
+    signal = _signal(
+        (
+            ("student-1", 1),
+            ("student-2", 2),
+            ("student-3", 3),
+            ("student-4", 4),
+        )
+    )
+    created = _create_signal_plan(
+        root,
+        revision,
+        signal,
+        strategy="mixed_signal",
+    )
+    previewed = preview_group_plan(
+        PreviewGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=created.mutation.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(4),
+    )
+    approved = approve_group_plan(
+        ApproveGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=previewed.summary.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(5),
+    )
+    detail = show_group_plan(
+        "class-1", "activity-1", "signal-plan", workspace_root=root
+    )
+
+    assert approved.status == "approved"
+    assert detail.plan.status == "approved"
+    assert detail.plan.strategy == "mixed_signal"
+    _assert_signal_origin(detail, signal)
+
+    graph = load_current_record_graph(root, approved.commit.work).graph
+    assert len(graph.group_plans) == 1
+    assert graph.groups == ()
+    assert graph.memberships == ()
+    assert graph.role_assignments == ()
+    assert graph.responsibility_assignments == ()
+    assert graph.artifact_instances == ()
+    assert graph.artifact_pages == ()
+    assert graph.artifact_reviews == ()
+    assert graph.moderation_records == ()
+    assert graph.score_records == ()

--- a/tests/test_group_plan_signal_menu_issue54.py
+++ b/tests/test_group_plan_signal_menu_issue54.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from pds_core.routing_models import ModuleWorkRef
+
+import concord.menu_group_plan as plan_menu
+import concord.menu_group_plan_signal as signal_menu
+from concord.group_plan_signal import SignalGroupPlanProposal
+from concord.menu_context import MenuSessionContext
+from concord.models import PlannedGroup
+from concord.workflows import (
+    ActivitySummary,
+    GroupingSignalDimensionSelection,
+    WorkflowActor,
+    WorkflowCommitResult,
+)
+
+
+def _activity(snapshot: int = 7) -> ActivitySummary:
+    return ActivitySummary(
+        class_id="class-1",
+        activity_id="activity-1",
+        title="Planning Activity",
+        status="draft",
+        scoring_orientation="evidence_only",
+        session_count=1,
+        group_count=0,
+        snapshot_revision=snapshot,
+    )
+
+
+def _state() -> MenuSessionContext:
+    return MenuSessionContext(actor=WorkflowActor(actor_id="teacher-1"))
+
+
+def _commit(snapshot: int = 8) -> WorkflowCommitResult:
+    return WorkflowCommitResult(
+        work=ModuleWorkRef(
+            module_id="concord",
+            class_id="class-1",
+            work_id="activity-1",
+        ),
+        snapshot_revision=snapshot,
+        snapshot_sha256="a" * 64,
+        changed_records=(),
+        no_op=False,
+    )
+
+
+def _selection() -> GroupingSignalDimensionSelection:
+    diagnostics = SimpleNamespace(
+        roster_student_count=4,
+        matched_student_count=3,
+        missing_student_count=1,
+        band_counts=((1, 1), (2, 1), (3, 1)),
+    )
+    signal = SimpleNamespace(student_bands=())
+    return cast(
+        GroupingSignalDimensionSelection,
+        SimpleNamespace(
+            signal_set_id="signal-1",
+            digest="d" * 64,
+            dimension_id="collaboration-context",
+            dimension_diagnostics=diagnostics,
+            inspection=SimpleNamespace(stored=SimpleNamespace(signal=signal)),
+        ),
+    )
+
+
+def _proposal() -> SignalGroupPlanProposal:
+    return cast(
+        SignalGroupPlanProposal,
+        SimpleNamespace(
+            roster_student_ids=(
+                "student-1",
+                "student-2",
+                "student-3",
+                "student-4",
+            ),
+            proposed_groups=(
+                PlannedGroup(
+                    planned_group_key="similar-1",
+                    label="Group 1",
+                    student_ids=("student-1", "student-2"),
+                ),
+                PlannedGroup(
+                    planned_group_key="similar-2",
+                    label="Group 2",
+                    student_ids=("student-3",),
+                ),
+            ),
+            unresolved_student_ids=("student-4",),
+            group_count=2,
+            assigned_student_count=3,
+            unresolved_student_count=1,
+            group_sizes=(2, 1),
+        ),
+    )
+
+
+def test_signal_menu_creation_carries_exact_preview_preconditions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    current = _activity(11)
+    selection = _selection()
+    proposal = _proposal()
+    captured: list[object] = []
+    shown: list[tuple[str, tuple[str, ...]]] = []
+    previewed: list[SignalGroupPlanProposal] = []
+    diagnosed: list[GroupingSignalDimensionSelection] = []
+
+    monkeypatch.setattr(signal_menu, "_latest", lambda _activity: current)
+    monkeypatch.setattr(
+        signal_menu,
+        "prompt_text",
+        lambda *a, **k: "activity-1-similar",
+    )
+    monkeypatch.setattr(
+        signal_menu,
+        "_select_signal_dimension",
+        lambda _activity: (selection, proposal.roster_student_ids),
+    )
+    monkeypatch.setattr(
+        signal_menu,
+        "_show_signal_diagnostics",
+        lambda selected: diagnosed.append(selected),
+    )
+    monkeypatch.setattr(
+        signal_menu,
+        "_choose_target",
+        lambda _strategy, _count: (None, 2, "Target group count: 2"),
+    )
+    monkeypatch.setattr(signal_menu, "_proposal", lambda *a, **k: proposal)
+    monkeypatch.setattr(
+        signal_menu,
+        "_show_preview",
+        lambda _strategy, _selection, item, _target: previewed.append(item),
+    )
+    monkeypatch.setattr(signal_menu, "confirm_write", lambda *a, **k: True)
+    monkeypatch.setattr(
+        signal_menu,
+        "show_result",
+        lambda title, lines: shown.append((title, tuple(lines))),
+    )
+
+    def fake_create(request: object) -> object:
+        captured.append(request)
+        return SimpleNamespace(
+            mutation=SimpleNamespace(
+                commit=_commit(12),
+                group_plan_id="activity-1-similar",
+                status="draft",
+            ),
+            strategy="similar_signal",
+            signal_set_id="signal-1",
+            signal_set_digest="d" * 64,
+            dimension_id="collaboration-context",
+            group_count=2,
+            assigned_student_count=3,
+            unresolved_student_count=1,
+            group_sizes=(2, 1),
+        )
+
+    monkeypatch.setattr(signal_menu, "create_signal_group_plan", fake_create)
+
+    signal_menu.create_signal_group_plan_from_menu(
+        current,
+        _state(),
+        "similar_signal",
+    )
+
+    assert diagnosed == [selection]
+    assert previewed == [proposal]
+    request = captured[0]
+    assert getattr(request, "expected_snapshot_revision") == 11
+    assert getattr(request, "strategy") == "similar_signal"
+    assert getattr(request, "signal_set_id") == "signal-1"
+    assert getattr(request, "dimension_id") == "collaboration-context"
+    assert getattr(request, "target_group_size") is None
+    assert getattr(request, "target_group_count") == 2
+    assert getattr(request, "expected_roster_student_ids") == (
+        "student-1",
+        "student-2",
+        "student-3",
+        "student-4",
+    )
+    assert getattr(request, "expected_signal_set_digest") == "d" * 64
+
+    lines = shown[0][1]
+    assert "Similar-signal GroupPlan created." in lines
+    assert "Signal set: signal-1" in lines
+    assert f"Core signal digest: {'d' * 64}" in lines
+    assert "Unresolved students: 1" in lines
+    assert "Group sizes: 2,1" in lines
+    assert "Canonical Groups created: no" in lines
+    assert not any("student-1" in line for line in lines)
+
+
+def test_signal_diagnostics_show_distribution_without_student_band_table(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(signal_menu, "clear_screen", lambda: None)
+    monkeypatch.setattr(
+        signal_menu,
+        "print_menu_header",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(signal_menu, "pause_for_user", lambda: None)
+
+    signal_menu._show_signal_diagnostics(_selection())
+    output = capsys.readouterr().out
+
+    assert "Matched students: 3" in output
+    assert "Missing students: 1" in output
+    assert "Band 1: 1" in output
+    assert "Band 2: 1" in output
+    assert "Band 3: 1" in output
+    assert "student-1" not in output
+    assert "Missing signal coverage remains unresolved" in output
+
+
+def test_signal_preview_shows_planned_memberships_not_student_bands(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(signal_menu, "clear_screen", lambda: None)
+    monkeypatch.setattr(
+        signal_menu,
+        "print_menu_header",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(signal_menu, "pause_for_user", lambda: None)
+
+    signal_menu._show_preview(
+        "similar_signal",
+        _selection(),
+        _proposal(),
+        "Target group count: 2",
+    )
+    output = capsys.readouterr().out
+
+    assert "Planned memberships:" in output
+    assert "Group 1 (similar-1): student-1, student-2" in output
+    assert "Unresolved IDs: student-4" in output
+    assert "Band 1:" not in output
+    assert "academic rank" in output
+    assert "No canonical Groups or Memberships have been created." in output
+
+
+def test_plan_groups_menu_exposes_both_signal_creation_choices(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    values = iter(["7", "8", "b"])
+
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(values))
+    monkeypatch.setattr(plan_menu, "clear_screen", lambda: None)
+    monkeypatch.setattr(
+        plan_menu,
+        "print_menu_header",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        plan_menu,
+        "print_navigation",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(plan_menu, "_latest", lambda activity: activity)
+    monkeypatch.setattr(
+        plan_menu,
+        "create_signal_group_plan_from_menu",
+        lambda _activity, _state, strategy: calls.append(strategy),
+    )
+
+    plan_menu.launch_group_plan_menu(_activity(), _state())
+    assert calls == ["similar_signal", "mixed_signal"]

--- a/tests/test_group_plan_signal_workflow_issue54.py
+++ b/tests/test_group_plan_signal_workflow_issue54.py
@@ -1,0 +1,564 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.grouping_signal_storage import (
+    calculate_grouping_signal_digest,
+    write_grouping_signal,
+)
+from pds_core.grouping_signals import (
+    GroupingSignalDimension,
+    GroupingSignalSet,
+    GroupingSignalSource,
+    GroupingSignalStudentBand,
+)
+from pds_core.rosters import create_roster
+from pds_core.workspace import ensure_workspace_root
+
+from concord.storage import load_current_record_graph
+from concord.workflows import (
+    CreateActivityContextRequest,
+    CreateSignalGroupPlanRequest,
+    WorkflowActor,
+    create_activity_context,
+    create_signal_group_plan,
+)
+from concord.workflows.errors import (
+    ConcordWorkflowConflictError,
+    ConcordWorkflowValidationError,
+)
+from concord.workflows.group_plan import list_group_plans, show_group_plan
+
+
+def _clock(day: int) -> datetime:
+    return datetime(2026, 8, day, 18, 0, tzinfo=timezone.utc)
+
+
+def _actor(actor_id: str = "teacher-1") -> WorkflowActor:
+    return WorkflowActor(
+        actor_id=actor_id,
+        display_label="Synthetic Teacher",
+        role_label="teacher",
+    )
+
+
+def _roster(*student_ids: str):
+    return create_roster(
+        "class-1",
+        tuple(
+            {
+                "student_id": student_id,
+                "last_name": f"Last-{index}",
+                "first_name": f"First-{index}",
+                "period": "1",
+            }
+            for index, student_id in enumerate(student_ids, start=1)
+        ),
+    )
+
+
+def _workspace(
+    tmp_path: Path,
+    *student_ids: str,
+    name: str = "workspace",
+) -> tuple[Path, int]:
+    root = ensure_workspace_root(tmp_path / name)
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata("class-1", "2026-2027", created_at=_clock(1)),
+    )
+    write_class_roster(root, _roster(*student_ids))
+    created = create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            title="Synthetic Signal Planning Activity",
+            activity_type="project",
+            scoring_orientation="evidence_only",
+            session_id="session-1",
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(2),
+    )
+    return root, created.commit.snapshot_revision
+
+
+def _signal(
+    bands: tuple[tuple[str, int], ...],
+    *,
+    signal_set_id: str = "signal-1",
+    dimension_id: str = "collaboration-context",
+) -> GroupingSignalSet:
+    return GroupingSignalSet(
+        schema_version="1",
+        record_type="grouping_signal_set",
+        signal_set_id=signal_set_id,
+        class_id="class-1",
+        created_at=_clock(2),
+        source=GroupingSignalSource(
+            kind="module_generated",
+            module_id="synthetic_module",
+            snapshot_id="snapshot-1",
+            snapshot_digest_algorithm="sha256",
+            snapshot_digest="b" * 64,
+        ),
+        dimensions=(
+            GroupingSignalDimension(
+                dimension_id=dimension_id,
+                band_count=4,
+            ),
+        ),
+        student_bands=tuple(
+            GroupingSignalStudentBand(
+                student_id=student_id,
+                dimension_id=dimension_id,
+                band=band,
+            )
+            for student_id, band in bands
+        ),
+    )
+
+
+def _memberships(detail) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    return tuple(
+        (group.planned_group_key, group.student_ids)
+        for group in detail.plan.proposed_groups
+    )
+
+
+def test_similar_workflow_persists_exact_core_signal_binding(tmp_path: Path) -> None:
+    students = tuple(f"student-{index}" for index in range(1, 7))
+    root, revision = _workspace(tmp_path, *students)
+    signal = _signal(
+        (
+            ("student-1", 1),
+            ("student-2", 1),
+            ("student-3", 2),
+            ("student-4", 2),
+            ("student-5", 3),
+            ("student-6", 3),
+        )
+    )
+    write_grouping_signal(root, signal)
+    canonical_digest = calculate_grouping_signal_digest(signal)
+
+    result = create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="similar-plan",
+            strategy="similar_signal",
+            signal_set_id=signal.signal_set_id,
+            dimension_id="collaboration-context",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            target_group_count=2,
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(3),
+    )
+    detail = show_group_plan(
+        "class-1",
+        "activity-1",
+        "similar-plan",
+        workspace_root=root,
+    )
+
+    assert result.strategy == "similar_signal"
+    assert result.group_count == 2
+    assert result.assigned_student_count == 6
+    assert result.unresolved_student_count == 0
+    assert result.group_sizes == (3, 3)
+    assert result.signal_set_digest == canonical_digest
+    assert result.signal_set_digest != signal.source.snapshot_digest
+    assert detail.plan.status == "draft"
+    assert detail.plan.strategy == "similar_signal"
+    assert detail.plan.seed is None
+    assert detail.plan.source_signal_set_id == signal.signal_set_id
+    assert detail.plan.source_signal_set_digest == canonical_digest
+    assert detail.plan.source_signal_dimension_id == "collaboration-context"
+    assert detail.plan.unresolved_student_ids == ()
+    assert _memberships(detail) == (
+        ("similar-1", ("student-1", "student-2", "student-3")),
+        ("similar-2", ("student-4", "student-5", "student-6")),
+    )
+
+
+def test_partial_mixed_plan_uses_full_roster_target_and_keeps_missing_unresolved(
+    tmp_path: Path,
+) -> None:
+    students = tuple(f"student-{index}" for index in range(1, 6))
+    root, revision = _workspace(tmp_path, *students)
+    signal = _signal((("student-1", 4), ("student-2", 1)))
+    write_grouping_signal(root, signal)
+
+    result = create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="mixed-plan",
+            strategy="mixed_signal",
+            signal_set_id=signal.signal_set_id,
+            dimension_id="collaboration-context",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            target_group_size=2,
+        ),
+        workspace_root=root,
+    )
+    detail = show_group_plan(
+        "class-1",
+        "activity-1",
+        "mixed-plan",
+        workspace_root=root,
+    )
+
+    assert result.group_count == 3
+    assert result.group_sizes == (1, 1, 0)
+    assert result.assigned_student_count == 2
+    assert result.unresolved_student_count == 3
+    assert detail.plan.target_group_size == 2
+    assert detail.plan.target_group_count is None
+    assert detail.plan.unresolved_student_ids == (
+        "student-3",
+        "student-4",
+        "student-5",
+    )
+    assert tuple(len(group.student_ids) for group in detail.plan.proposed_groups) == (
+        1,
+        1,
+        0,
+    )
+
+
+def test_signal_membership_is_independent_of_actor_clock_and_plan_id(
+    tmp_path: Path,
+) -> None:
+    students = tuple(f"student-{index}" for index in range(1, 7))
+    signal = _signal(
+        (
+            ("student-1", 1),
+            ("student-2", 4),
+            ("student-3", 2),
+            ("student-4", 3),
+            ("student-5", 1),
+            ("student-6", 4),
+        )
+    )
+    root_a, revision_a = _workspace(tmp_path, *students, name="a")
+    root_b, revision_b = _workspace(tmp_path, *students, name="b")
+    write_grouping_signal(root_a, signal)
+    write_grouping_signal(root_b, signal)
+
+    create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="plan-a",
+            strategy="mixed_signal",
+            signal_set_id=signal.signal_set_id,
+            dimension_id="collaboration-context",
+            expected_snapshot_revision=revision_a,
+            actor=_actor("teacher-a"),
+            target_group_count=3,
+        ),
+        workspace_root=root_a,
+        clock=lambda: _clock(3),
+    )
+    create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="different-plan-id",
+            strategy="mixed_signal",
+            signal_set_id=signal.signal_set_id,
+            dimension_id="collaboration-context",
+            expected_snapshot_revision=revision_b,
+            actor=_actor("teacher-b"),
+            target_group_count=3,
+        ),
+        workspace_root=root_b,
+        clock=lambda: _clock(9),
+    )
+
+    a = show_group_plan("class-1", "activity-1", "plan-a", workspace_root=root_a)
+    b = show_group_plan(
+        "class-1",
+        "activity-1",
+        "different-plan-id",
+        workspace_root=root_b,
+    )
+    assert _memberships(a) == _memberships(b)
+
+
+def test_unsupported_strategy_and_unknown_dimension_create_no_plan(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path, "student-1", "student-2")
+    signal = _signal((("student-1", 1), ("student-2", 2)))
+    write_grouping_signal(root, signal)
+
+    with pytest.raises(ConcordWorkflowValidationError, match="strategy"):
+        create_signal_group_plan(
+            CreateSignalGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="bad-strategy",
+                strategy="random",
+                signal_set_id=signal.signal_set_id,
+                dimension_id="collaboration-context",
+                expected_snapshot_revision=revision,
+                actor=_actor(),
+                target_group_count=1,
+            ),
+            workspace_root=root,
+        )
+
+    with pytest.raises(ConcordWorkflowValidationError, match="not available"):
+        create_signal_group_plan(
+            CreateSignalGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="bad-dimension",
+                strategy="similar_signal",
+                signal_set_id=signal.signal_set_id,
+                dimension_id="missing-dimension",
+                expected_snapshot_revision=revision,
+                actor=_actor(),
+                target_group_count=1,
+            ),
+            workspace_root=root,
+        )
+    assert list_group_plans("class-1", "activity-1", workspace_root=root) == ()
+
+
+def test_core_diagnostic_error_is_rejected_through_selection(tmp_path: Path) -> None:
+    root, revision = _workspace(tmp_path, "student-1", "student-2")
+    signal = _signal((("student-1", 1), ("student-999", 2)))
+    write_grouping_signal(root, signal)
+
+    with pytest.raises(ConcordWorkflowValidationError, match="unknown_student"):
+        create_signal_group_plan(
+            CreateSignalGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="invalid-signal-plan",
+                strategy="similar_signal",
+                signal_set_id=signal.signal_set_id,
+                dimension_id="collaboration-context",
+                expected_snapshot_revision=revision,
+                actor=_actor(),
+                target_group_count=1,
+            ),
+            workspace_root=root,
+        )
+    assert list_group_plans("class-1", "activity-1", workspace_root=root) == ()
+
+
+def test_roster_change_during_signal_selection_fails_before_proposal_persistence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, revision = _workspace(tmp_path, "student-1", "student-2", "student-3")
+    signal = _signal((("student-1", 1), ("student-2", 2), ("student-3", 3)))
+    write_grouping_signal(root, signal)
+
+    import concord.workflows.group_plan_signal as workflow_module
+
+    original_select = workflow_module.select_grouping_signal_dimension
+
+    def select_then_mutate(*args, **kwargs):
+        selection = original_select(*args, **kwargs)
+        write_class_roster(
+            root,
+            _roster("student-1", "student-2", "student-3", "student-4"),
+            overwrite=True,
+        )
+        return selection
+
+    monkeypatch.setattr(
+        workflow_module,
+        "select_grouping_signal_dimension",
+        select_then_mutate,
+    )
+    with pytest.raises(ConcordWorkflowConflictError, match="while selecting"):
+        create_signal_group_plan(
+            CreateSignalGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="race-plan",
+                strategy="similar_signal",
+                signal_set_id=signal.signal_set_id,
+                dimension_id="collaboration-context",
+                expected_snapshot_revision=revision,
+                actor=_actor(),
+                target_group_count=2,
+            ),
+            workspace_root=root,
+        )
+    assert list_group_plans("class-1", "activity-1", workspace_root=root) == ()
+
+
+def test_roster_change_between_proposal_and_create_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, revision = _workspace(tmp_path, "student-1", "student-2", "student-3")
+    signal = _signal((("student-1", 1), ("student-2", 2), ("student-3", 3)))
+    write_grouping_signal(root, signal)
+
+    import concord.workflows.group_plan_signal as workflow_module
+
+    original_create = workflow_module.create_group_plan
+
+    def mutate_roster_then_create(request, **kwargs):
+        write_class_roster(
+            root,
+            _roster("student-1", "student-2", "student-3", "student-4"),
+            overwrite=True,
+        )
+        return original_create(request, **kwargs)
+
+    monkeypatch.setattr(workflow_module, "create_group_plan", mutate_roster_then_create)
+    with pytest.raises(ConcordWorkflowConflictError, match="roster changed"):
+        create_signal_group_plan(
+            CreateSignalGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="race-plan",
+                strategy="mixed_signal",
+                signal_set_id=signal.signal_set_id,
+                dimension_id="collaboration-context",
+                expected_snapshot_revision=revision,
+                actor=_actor(),
+                target_group_count=2,
+            ),
+            workspace_root=root,
+        )
+    assert list_group_plans("class-1", "activity-1", workspace_root=root) == ()
+
+
+def test_stale_activity_snapshot_creates_no_plan(tmp_path: Path) -> None:
+    root, revision = _workspace(tmp_path, "student-1", "student-2")
+    signal = _signal((("student-1", 1), ("student-2", 2)))
+    write_grouping_signal(root, signal)
+
+    with pytest.raises(ConcordWorkflowConflictError, match="expected snapshot"):
+        create_signal_group_plan(
+            CreateSignalGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="stale-plan",
+                strategy="similar_signal",
+                signal_set_id=signal.signal_set_id,
+                dimension_id="collaboration-context",
+                expected_snapshot_revision=revision + 1,
+                actor=_actor(),
+                target_group_count=1,
+            ),
+            workspace_root=root,
+        )
+    assert list_group_plans("class-1", "activity-1", workspace_root=root) == ()
+
+
+def test_signal_plan_creation_creates_no_canonical_collaboration_state(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path, "student-1", "student-2", "student-3")
+    signal = _signal((("student-1", 1), ("student-2", 2), ("student-3", 3)))
+    write_grouping_signal(root, signal)
+
+    created = create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            strategy="mixed_signal",
+            signal_set_id=signal.signal_set_id,
+            dimension_id="collaboration-context",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            target_group_count=2,
+        ),
+        workspace_root=root,
+    )
+
+    graph = load_current_record_graph(root, created.mutation.commit.work).graph
+    assert len(graph.group_plans) == 1
+    assert graph.groups == ()
+    assert graph.memberships == ()
+    assert graph.role_assignments == ()
+    assert graph.responsibility_assignments == ()
+
+
+def test_preview_roster_precondition_rejects_changed_roster(tmp_path: Path) -> None:
+    root, revision = _workspace(tmp_path, "student-1", "student-2", "student-3")
+    signal = _signal(
+        (("student-1", 1), ("student-2", 2), ("student-3", 3))
+    )
+    write_grouping_signal(root, signal)
+
+    with pytest.raises(ConcordWorkflowConflictError, match="since the signal"):
+        create_signal_group_plan(
+            CreateSignalGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="stale-preview-roster",
+                strategy="similar_signal",
+                signal_set_id=signal.signal_set_id,
+                dimension_id="collaboration-context",
+                expected_snapshot_revision=revision,
+                actor=_actor(),
+                target_group_count=2,
+                expected_roster_student_ids=("student-1", "student-2"),
+            ),
+            workspace_root=root,
+        )
+
+    assert list_group_plans("class-1", "activity-1", workspace_root=root) == ()
+
+
+def test_preview_signal_digest_precondition_rejects_mismatch(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path, "student-1", "student-2", "student-3")
+    signal = _signal(
+        (
+            ("student-1", 1),
+            ("student-2", 2),
+            ("student-3", 3),
+        )
+    )
+    write_grouping_signal(root, signal)
+
+    with pytest.raises(ConcordWorkflowConflictError, match="signal changed"):
+        create_signal_group_plan(
+            CreateSignalGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="stale-preview-signal",
+                strategy="mixed_signal",
+                signal_set_id=signal.signal_set_id,
+                dimension_id="collaboration-context",
+                expected_snapshot_revision=revision,
+                actor=_actor(),
+                target_group_count=2,
+                expected_roster_student_ids=(
+                    "student-1",
+                    "student-2",
+                    "student-3",
+                ),
+                expected_signal_set_digest="0" * 64,
+            ),
+            workspace_root=root,
+        )
+
+    assert list_group_plans("class-1", "activity-1", workspace_root=root) == ()


### PR DESCRIPTION
## Summary

Implements Concord issue #54: bounded deterministic `similar_signal` and `mixed_signal` `GroupPlan` strategies over the exact Core `grouping_signal_set_v1` selection boundary established in #53.

This adds signal-backed planning while preserving Concord's existing planning lifecycle and ownership boundaries:

```text
Core grouping_signal_set_v1
        |
        v
explicit signal + dimension selection
        |
        v
similar_signal / mixed_signal draft
        |
        v
manual editing / missing-signal disposition
        |
        v
preview -> approve
        |
        v
#56 canonical Group + GroupMembership application