### PR TITLE
Implement explicit missing-signal GroupPlan decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Explicit missing-signal `manual`, seeded `random`, and `leave_unassigned`
+  GroupPlan dispositions with exact Core `missing_student_signal` authority,
+  canonical-digest revalidation, structured provenance, preview invalidation,
+  and the narrow approved-unresolved exception for deliberate leave-unassigned.
+- Direct `confirm-missing-manual`, `distribute-missing-random`, and
+  `leave-missing-unassigned` GroupPlan commands plus a teacher-menu decision
+  workflow with missing-only seeded placement preview and no canonical Group or
+  Membership creation.
 - Deterministic `similar_signal` and `mixed_signal` GroupPlan generation from one
   explicitly selected Core signal/dimension, with shared full-roster size/count
   targets, exact canonical-digest binding, balanced represented-student placement,
@@ -52,6 +60,9 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Signal-backed approval now revalidates the frozen Core signal/dimension/digest
+  and current missing set; ordinary plan edits preserve the explicit disposition,
+  while changed roster refresh invalidates it for a fresh teacher decision.
 - Random and signal-backed generated planning now share one pure full-roster target
   resolution/balanced-size implementation while preserving the frozen #52 random
   ranking and seed behavior.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ line now also provides Core grouping-signal discovery, exact signal/dimension
 diagnostics, teacher-controlled `grouping_signal_csv_v1` import, and deterministic
 `similar_signal` / `mixed_signal` GroupPlan drafts with exact signal provenance,
 full-roster target semantics, explicit unresolved missing coverage, and no Meridian
-runtime dependency. Signal-plan generation remains separate from missing-signal
-disposition (#55) and canonical Group/Membership application (#56). The same typed
+runtime dependency. Issue #55 now adds explicit manual/random/leave-unassigned
+missing-signal decisions with exact Core revalidation; canonical Group/Membership
+application remains reserved for #56. The same typed
 service layer supports a fully
 noninteractive direct CLI and a teacher-facing low-information-density menu.
 Canonical state remains protected by immutable history, exact expected-snapshot
@@ -94,8 +95,9 @@ Q. Quit
 ```
 
 Every menu write shows a focused review screen and requires the operation word
-`CREATE`, `RENDER`, `ASSEMBLE`, `ROUTE`, `RESOLVE`, `UPDATE`, `ADD`,
-`CORRECT`, `REVIEW`, `MODERATE`, `SCORE`, `REVISE`, `END`, `REASSIGN`,
+`CREATE`, `RENDER`, `ASSEMBLE`, `ROUTE`, `RESOLVE`, `CONFIRM`,
+`DISTRIBUTE`, `LEAVE`, `UPDATE`, `ADD`, `CORRECT`, `REVIEW`,
+`MODERATE`, `SCORE`, `REVISE`, `END`, `REASSIGN`,
 `REGISTER`, `GENERATE`, `PUBLISH`, `WITHDRAW`, or `REBUILD`.
 The menu clears between stages,
 paginates long selections after ten items, and does not display raw record
@@ -114,6 +116,7 @@ concord group create|list|show|update|set-status
 concord group member add|list|end|reassign
 concord group-plan list|show|create-manual|create-random|add-group|edit-group|remove-group
 concord group-plan create-similar-signal|create-mixed-signal
+concord group-plan confirm-missing-manual|distribute-missing-random|leave-missing-unassigned
 concord group-plan place-student|unassign-student|refresh-roster
 concord group-plan import-arrangement|replace-arrangement|preview|approve|cancel
 concord grouping-signal list|show|diagnose|import-csv
@@ -208,6 +211,9 @@ Issue #54's deterministic similar/mixed algorithms, full-roster targets, exact C
 signal binding, partial-coverage behavior, direct CLI/menu creation, lifecycle reuse,
 and privacy/dependency boundaries are documented in the
 [signal-backed Group planning guide](docs/v0.3.0-signal-group-planning.md).
+Issue #55's explicit missing-signal decisions, deterministic missing-only random
+distribution, approval exception, privacy boundary, and #56 handoff are documented
+in the [missing-signal disposition guide](docs/v0.3.0-missing-signal-disposition.md).
 The clean installed-wheel producer lifecycle and its Core verification,
 authorization, audit, and immutability boundaries are documented in the
 [installed acceptance guide](docs/implementation/installed-end-to-end-acceptance.md).

--- a/concord/cli_app/handlers/group_plan.py
+++ b/concord/cli_app/handlers/group_plan.py
@@ -24,11 +24,13 @@ from concord.workflows import (
     GroupPlanEditResult,
     GroupPlanSummary,
     ImportArrangementGroupPlanRequest,
+    MissingSignalDispositionResult,
     PlaceStudentInPlanRequest,
     PreviewGroupPlanRequest,
     RefreshGroupPlanRosterRequest,
     RemovePlannedGroupRequest,
     ReplaceArrangementGroupPlanRequest,
+    SetMissingSignalDispositionRequest,
     SignalGroupPlanCreationResult,
     UnassignStudentFromPlanRequest,
     add_planned_group,
@@ -45,6 +47,7 @@ from concord.workflows import (
     refresh_group_plan_roster,
     remove_planned_group,
     replace_group_plan_from_arrangement,
+    set_missing_signal_disposition,
     show_group_plan,
     unassign_student_from_plan,
 )
@@ -82,6 +85,10 @@ def _print_detail(detail: GroupPlanDetail) -> None:
         print(f"Signal set: {plan.source_signal_set_id}")
         print(f"Signal digest: {plan.source_signal_set_digest}")
         print(f"Signal dimension: {plan.source_signal_dimension_id}")
+    if plan.missing_signal_disposition is not None:
+        print(f"Missing-signal disposition: {plan.missing_signal_disposition}")
+    if plan.missing_signal_random_seed is not None:
+        print(f"Missing-signal random seed: {plan.missing_signal_random_seed}")
     for group in plan.proposed_groups:
         students = ",".join(group.student_ids) or "-"
         print(
@@ -235,6 +242,65 @@ def handle_create_similar_signal(args: argparse.Namespace) -> int:
 
 def handle_create_mixed_signal(args: argparse.Namespace) -> int:
     return _handle_create_signal(args, "mixed_signal")
+
+
+def _print_missing_signal_result(
+    result: MissingSignalDispositionResult,
+    *,
+    strategy: str,
+) -> None:
+    print_commit(result.mutation.commit)
+    print(f"GroupPlan: {result.mutation.group_plan_id}")
+    print(f"Strategy: {strategy}")
+    print(f"Status: {result.mutation.status}")
+    print(f"Missing-signal disposition: {result.disposition}")
+    print(f"Missing-signal students: {result.missing_student_count}")
+    print(f"Assigned students: {result.assigned_student_count}")
+    print(f"Unresolved students: {result.unresolved_student_count}")
+    print(f"Group sizes: {','.join(str(size) for size in result.group_sizes)}")
+    if result.random_seed is not None:
+        print(f"Random seed: {result.random_seed}")
+    print(f"Snapshot revision: {result.mutation.commit.snapshot_revision}")
+    print("Canonical Groups created: no")
+
+
+def _handle_missing_signal_disposition(
+    args: argparse.Namespace,
+    disposition: str,
+) -> int:
+    result = set_missing_signal_disposition(
+        SetMissingSignalDispositionRequest(
+            class_id=args.class_id,
+            activity_id=args.activity_id,
+            group_plan_id=args.group_plan_id,
+            disposition=disposition,
+            random_seed=getattr(args, "seed", None),
+            expected_snapshot_revision=args.expected_snapshot,
+            actor=workflow_actor(args),
+        ),
+        workspace_root=workspace_arg(args),
+        standards_library=load_command_standards_library(args),
+    )
+    detail = show_group_plan(
+        args.class_id,
+        args.activity_id,
+        args.group_plan_id,
+        workspace_root=workspace_arg(args),
+    )
+    _print_missing_signal_result(result, strategy=detail.plan.strategy)
+    return 0
+
+
+def handle_confirm_missing_manual(args: argparse.Namespace) -> int:
+    return _handle_missing_signal_disposition(args, "manual")
+
+
+def handle_distribute_missing_random(args: argparse.Namespace) -> int:
+    return _handle_missing_signal_disposition(args, "random")
+
+
+def handle_leave_missing_unassigned(args: argparse.Namespace) -> int:
+    return _handle_missing_signal_disposition(args, "leave_unassigned")
 
 
 def handle_add_group(args: argparse.Namespace) -> int:

--- a/concord/cli_app/parser.py
+++ b/concord/cli_app/parser.py
@@ -453,6 +453,40 @@ def _group_plan_commands(
     mixed_target.add_argument("--target-group-count", type=int)
     mixed_create.set_defaults(handler=group_plan.handle_create_mixed_signal)
 
+    confirm_missing_manual = actions.add_parser(
+        "confirm-missing-manual",
+        help="Confirm prior manual placement of exact missing-signal students.",
+    )
+    _mutating_options(confirm_missing_manual)
+    _class_activity(confirm_missing_manual)
+    confirm_missing_manual.add_argument("--group-plan-id", required=True)
+    confirm_missing_manual.set_defaults(
+        handler=group_plan.handle_confirm_missing_manual
+    )
+
+    distribute_missing_random = actions.add_parser(
+        "distribute-missing-random",
+        help="Deterministically place exact missing-signal students with a seed.",
+    )
+    _mutating_options(distribute_missing_random)
+    _class_activity(distribute_missing_random)
+    distribute_missing_random.add_argument("--group-plan-id", required=True)
+    distribute_missing_random.add_argument("--seed", required=True)
+    distribute_missing_random.set_defaults(
+        handler=group_plan.handle_distribute_missing_random
+    )
+
+    leave_missing_unassigned = actions.add_parser(
+        "leave-missing-unassigned",
+        help="Explicitly keep exact missing-signal students visibly unresolved.",
+    )
+    _mutating_options(leave_missing_unassigned)
+    _class_activity(leave_missing_unassigned)
+    leave_missing_unassigned.add_argument("--group-plan-id", required=True)
+    leave_missing_unassigned.set_defaults(
+        handler=group_plan.handle_leave_missing_unassigned
+    )
+
     add = actions.add_parser("add-group", help="Add an empty plan-local group.")
     _mutating_options(add)
     _class_activity(add)

--- a/concord/group_plan_missing_signal.py
+++ b/concord/group_plan_missing_signal.py
@@ -1,0 +1,169 @@
+"""Pure deterministic placement for #55 missing-signal students."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+from dataclasses import dataclass, replace
+
+from pds_core.identifiers import IdentifierValidationError, validate_identifier
+
+from concord.models import PlannedGroup
+
+MISSING_SIGNAL_RANDOM_DOMAIN = (
+    "pds-concord:group-plan-missing-signal-random:v1"
+)
+
+
+class MissingSignalRandomizationError(ValueError):
+    """Raised when deterministic missing-signal placement inputs are invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class MissingSignalRandomizationResult:
+    """Pure deterministic transformation of existing PlannedGroups."""
+
+    proposed_groups: tuple[PlannedGroup, ...]
+    placements: tuple[tuple[str, str], ...]
+    group_sizes: tuple[int, ...]
+
+
+def _require_seed(seed: str) -> str:
+    if not isinstance(seed, str) or not seed.strip() or seed != seed.strip():
+        raise MissingSignalRandomizationError(
+            "seed must be a nonempty string without surrounding whitespace."
+        )
+    return seed
+
+
+def _student_ids(values: Iterable[str]) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)):
+        raise MissingSignalRandomizationError(
+            "missing_student_ids must be an iterable of student IDs."
+        )
+    try:
+        raw = tuple(values)
+    except TypeError as error:
+        raise MissingSignalRandomizationError(
+            "missing_student_ids must be iterable."
+        ) from error
+
+    normalized: list[str] = []
+    for index, value in enumerate(raw):
+        try:
+            normalized.append(
+                validate_identifier(
+                    value,
+                    f"missing_student_ids[{index}]",
+                )
+            )
+        except IdentifierValidationError as error:
+            raise MissingSignalRandomizationError(str(error)) from error
+    if len(set(normalized)) != len(normalized):
+        raise MissingSignalRandomizationError(
+            "missing_student_ids must not contain duplicates."
+        )
+    return tuple(normalized)
+
+
+def _groups(values: Iterable[PlannedGroup]) -> tuple[PlannedGroup, ...]:
+    if isinstance(values, (str, bytes)):
+        raise MissingSignalRandomizationError(
+            "proposed_groups must be an iterable of PlannedGroup values."
+        )
+    try:
+        groups = tuple(values)
+    except TypeError as error:
+        raise MissingSignalRandomizationError(
+            "proposed_groups must be iterable."
+        ) from error
+    if not groups:
+        raise MissingSignalRandomizationError(
+            "random missing-signal distribution requires at least one PlannedGroup."
+        )
+    if any(not isinstance(group, PlannedGroup) for group in groups):
+        raise MissingSignalRandomizationError(
+            "proposed_groups must contain only PlannedGroup values."
+        )
+    keys = tuple(group.planned_group_key for group in groups)
+    if len(set(keys)) != len(keys):
+        raise MissingSignalRandomizationError(
+            "proposed_groups must not duplicate planned_group_key."
+        )
+    return groups
+
+
+def _rank(seed: str, student_id: str) -> bytes:
+    payload = (
+        MISSING_SIGNAL_RANDOM_DOMAIN.encode("utf-8")
+        + b"\0"
+        + seed.encode("utf-8")
+        + b"\0"
+        + student_id.encode("utf-8")
+    )
+    return hashlib.sha256(payload).digest()
+
+
+def distribute_missing_signal_students(
+    proposed_groups: Iterable[PlannedGroup],
+    missing_student_ids: Iterable[str],
+    *,
+    seed: str,
+) -> MissingSignalRandomizationResult:
+    """Distribute exact missing students by frozen SHA-256 rank and smallest group.
+
+    Existing memberships and PlannedGroup metadata are preserved. The function
+    performs no workspace I/O, signal lookup, provenance creation, or randomness.
+    """
+
+    normalized_seed = _require_seed(seed)
+    groups = _groups(proposed_groups)
+    missing = _student_ids(missing_student_ids)
+
+    assigned = {
+        student_id
+        for group in groups
+        for student_id in group.student_ids
+    }
+    overlap = tuple(sorted(set(missing) & assigned))
+    if overlap:
+        raise MissingSignalRandomizationError(
+            "missing students must be unresolved before random distribution: "
+            + ", ".join(overlap)
+        )
+
+    ordered = tuple(
+        sorted(
+            missing,
+            key=lambda student_id: (
+                _rank(normalized_seed, student_id),
+                student_id,
+            ),
+        )
+    )
+    result = list(groups)
+    placements: list[tuple[str, str]] = []
+
+    for student_id in ordered:
+        index = min(
+            range(len(result)),
+            key=lambda item: (
+                len(result[item].student_ids),
+                result[item].planned_group_key,
+            ),
+        )
+        group = result[index]
+        result[index] = replace(
+            group,
+            student_ids=group.student_ids + (student_id,),
+        )
+        placements.append((student_id, group.planned_group_key))
+
+    transformed = tuple(result)
+    return MissingSignalRandomizationResult(
+        proposed_groups=transformed,
+        placements=tuple(placements),
+        group_sizes=tuple(
+            len(group.student_ids) for group in transformed
+        ),
+    )

--- a/concord/menu_group_plan.py
+++ b/concord/menu_group_plan.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from pds_core.workspace import resolve_workspace_root
 
 from concord.menu_context import CancelMenuAction, MenuSessionContext
+from concord.menu_group_plan_missing_signal import resolve_missing_signal_from_menu
 from concord.menu_group_plan_signal import create_signal_group_plan_from_menu
 from concord.menu_grouping_signal import launch_grouping_signal_menu
 from concord.menu_navigation import (
@@ -141,6 +142,10 @@ def _show_detail(detail: GroupPlanDetail) -> None:
         print(f"Signal set: {plan.source_signal_set_id}")
         print(f"Core signal digest: {plan.source_signal_set_digest}")
         print(f"Signal dimension: {plan.source_signal_dimension_id}")
+    if plan.missing_signal_disposition is not None:
+        print(f"Missing-signal disposition: {plan.missing_signal_disposition}")
+    if plan.missing_signal_random_seed is not None:
+        print(f"Missing-signal random seed: {plan.missing_signal_random_seed}")
     print()
     for group in plan.proposed_groups:
         print(
@@ -733,7 +738,10 @@ def _approve(detail: GroupPlanDetail, state: MenuSessionContext) -> None:
         "APPROVE",
         (
             f"GroupPlan: {detail.plan.group_plan_id}",
-            "Every roster student must already be resolved.",
+            (
+                "Approval revalidates roster coverage and any exact "
+                "missing-signal disposition."
+            ),
             "Approval freezes this proposal but does not apply it.",
             "Canonical Groups created: no",
         ),
@@ -811,9 +819,16 @@ def _open_plan(
         print("4. Unassign a student")
         print("5. Refresh roster")
         print("6. Replace from arrangement CSV")
-        print("7. Preview")
-        print("8. Approve")
-        print("9. Cancel")
+        is_signal_plan = detail.plan.strategy in {"similar_signal", "mixed_signal"}
+        if is_signal_plan:
+            print("7. Resolve missing-signal students")
+            print("8. Preview")
+            print("9. Approve")
+            print("10. Cancel")
+        else:
+            print("7. Preview")
+            print("8. Approve")
+            print("9. Cancel")
         print_navigation()
         print()
         choice = input("Select an option: ").strip()
@@ -842,11 +857,22 @@ def _open_plan(
                     _refresh_roster(detail, state)
                 elif choice == "6":
                     _replace_arrangement(detail, state)
-                elif choice == "7":
+                elif is_signal_plan and choice == "7":
+                    resolve_missing_signal_from_menu(detail, state)
+                elif (
+                    (is_signal_plan and choice == "8")
+                    or (not is_signal_plan and choice == "7")
+                ):
                     _preview(detail, state)
-                elif choice == "8":
+                elif (
+                    (is_signal_plan and choice == "9")
+                    or (not is_signal_plan and choice == "8")
+                ):
                     _approve(detail, state)
-                elif choice == "9":
+                elif (
+                    (is_signal_plan and choice == "10")
+                    or (not is_signal_plan and choice == "9")
+                ):
                     _cancel(detail, state)
                 else:
                     print(navigation_hint_with_help())

--- a/concord/menu_group_plan_missing_signal.py
+++ b/concord/menu_group_plan_missing_signal.py
@@ -1,0 +1,193 @@
+"""Teacher-facing explicit decisions for signal-plan coverage gaps."""
+
+from __future__ import annotations
+
+from concord.group_plan_missing_signal import distribute_missing_signal_students
+from concord.menu_context import CancelMenuAction, MenuSessionContext
+from concord.menu_prompts import (
+    confirm_write,
+    prompt_exact_text,
+    select_one,
+    show_result,
+)
+from concord.menu_ui import clear_screen, pause_for_user, print_menu_header
+from concord.workflows import (
+    GroupPlanDetail,
+    MissingSignalDispositionResult,
+    MissingSignalPlanInspection,
+    SetMissingSignalDispositionRequest,
+    inspect_group_plan_missing_signal,
+    set_missing_signal_disposition,
+)
+
+
+def _group_sizes(detail: GroupPlanDetail) -> tuple[int, ...]:
+    return tuple(len(group.student_ids) for group in detail.plan.proposed_groups)
+
+
+def _show_context(inspection: MissingSignalPlanInspection) -> None:
+    clear_screen()
+    print_menu_header("Resolve Missing-Signal Students")
+    print(f"GroupPlan: {inspection.detail.plan.group_plan_id}")
+    print(f"Signal set: {inspection.signal_set_id}")
+    print(f"Core signal digest: {inspection.signal_set_digest}")
+    print(f"Signal dimension: {inspection.dimension_id}")
+    print(f"Roster students: {len(inspection.detail.plan.roster_student_ids)}")
+    print(f"Missing-signal students: {len(inspection.missing_student_ids)}")
+    print(f"Missing IDs: {', '.join(inspection.missing_student_ids) or '-'}")
+    print(
+        "Currently unresolved students: "
+        f"{len(inspection.detail.plan.unresolved_student_ids)}"
+    )
+    if inspection.detail.plan.missing_signal_disposition is not None:
+        print(
+            "Current missing-signal disposition: "
+            f"{inspection.detail.plan.missing_signal_disposition}"
+        )
+    print()
+    print("No student band values are displayed or copied into the GroupPlan.")
+    print()
+
+
+def _show_random_preview(
+    inspection: MissingSignalPlanInspection,
+    *,
+    seed: str,
+) -> None:
+    randomized = distribute_missing_signal_students(
+        inspection.detail.plan.proposed_groups,
+        inspection.missing_student_ids,
+        seed=seed,
+    )
+    clear_screen()
+    print_menu_header("Missing-Signal Random Distribution Preview")
+    print(f"GroupPlan: {inspection.detail.plan.group_plan_id}")
+    print(f"Signal set: {inspection.signal_set_id}")
+    print(f"Core signal digest: {inspection.signal_set_digest}")
+    print(f"Signal dimension: {inspection.dimension_id}")
+    print(f"Affected missing-signal students: {len(inspection.missing_student_ids)}")
+    print(f"Seed: {seed}")
+    current_sizes = ",".join(str(size) for size in _group_sizes(inspection.detail))
+    result_sizes = ",".join(str(size) for size in randomized.group_sizes)
+    print(f"Current group sizes: {current_sizes}")
+    print(f"Result group sizes: {result_sizes}")
+    print("Resulting placements for affected students:")
+    for student_id, planned_group_key in randomized.placements:
+        print(f"  {student_id} -> {planned_group_key}")
+    print()
+    print("Students already represented by the selected signal will not move.")
+    print("No canonical Groups or Memberships have been created.")
+    print()
+    pause_for_user()
+
+
+def _result_lines(result: MissingSignalDispositionResult) -> tuple[str, ...]:
+    lines = [
+        f"GroupPlan: {result.mutation.group_plan_id}",
+        f"Status: {result.mutation.status}",
+        f"Missing-signal disposition: {result.disposition}",
+        f"Missing-signal students: {result.missing_student_count}",
+        f"Assigned students: {result.assigned_student_count}",
+        f"Unresolved students: {result.unresolved_student_count}",
+        f"Group sizes: {','.join(str(size) for size in result.group_sizes)}",
+        f"Snapshot: {result.mutation.commit.snapshot_revision}",
+    ]
+    if result.random_seed is not None:
+        lines.append(f"Random seed: {result.random_seed}")
+    lines.append("Canonical Groups created: no")
+    return tuple(lines)
+
+
+def resolve_missing_signal_from_menu(
+    detail: GroupPlanDetail,
+    state: MenuSessionContext,
+) -> None:
+    """Require one explicit teacher decision for the exact current missing set."""
+
+    try:
+        inspection = inspect_group_plan_missing_signal(
+            detail.summary.class_id,
+            detail.summary.activity_id,
+            detail.summary.group_plan_id,
+        )
+        _show_context(inspection)
+        choice = select_one(
+            "Resolve Missing-Signal Students",
+            ("manual", "random", "leave_unassigned"),
+            (
+                "Confirm manual placement",
+                "Distribute missing students randomly",
+                "Leave missing students unassigned",
+            ),
+            help_text=(
+                "The decision applies only to students Core diagnoses as missing "
+                "from this GroupPlan's exact bound signal and dimension."
+            ),
+        )
+
+        random_seed: str | None = None
+        if choice == "manual":
+            if not confirm_write(
+                "Confirm Manual Missing-Signal Placement",
+                "CONFIRM",
+                (
+                    f"GroupPlan: {inspection.detail.plan.group_plan_id}",
+                    f"Missing IDs: {', '.join(inspection.missing_student_ids)}",
+                    "Every exact missing-signal student must already be placed.",
+                    "This records the explicit manual disposition only.",
+                    "Canonical Groups created: no",
+                ),
+            ):
+                return
+        elif choice == "random":
+            random_seed = prompt_exact_text(
+                "Distribute Missing Students Randomly",
+                "Seed",
+                help_text=(
+                    "Enter a nonblank reproducibility seed without surrounding "
+                    "whitespace. Only currently unresolved missing-signal students "
+                    "will be placed."
+                ),
+            )
+            assert random_seed is not None
+            _show_random_preview(inspection, seed=random_seed)
+            if not confirm_write(
+                "Distribute Missing Students Randomly",
+                "DISTRIBUTE",
+                (
+                    f"GroupPlan: {inspection.detail.plan.group_plan_id}",
+                    f"Affected students: {len(inspection.missing_student_ids)}",
+                    f"Seed: {random_seed}",
+                    "Existing represented-student placements will not move.",
+                    "No canonical Groups or Memberships will be created.",
+                ),
+            ):
+                return
+        else:
+            if not confirm_write(
+                "Leave Missing Students Unassigned",
+                "LEAVE",
+                (
+                    f"GroupPlan: {inspection.detail.plan.group_plan_id}",
+                    f"Missing IDs: {', '.join(inspection.missing_student_ids)}",
+                    "These students remain rostered and visibly unresolved.",
+                    "No signal band will be inferred or synthesized.",
+                    "Canonical Groups created: no",
+                ),
+            ):
+                return
+
+        result = set_missing_signal_disposition(
+            SetMissingSignalDispositionRequest(
+                class_id=inspection.detail.summary.class_id,
+                activity_id=inspection.detail.summary.activity_id,
+                group_plan_id=inspection.detail.summary.group_plan_id,
+                disposition=choice,
+                random_seed=random_seed,
+                expected_snapshot_revision=inspection.detail.summary.snapshot_revision,
+                actor=state.require_actor(),
+            )
+        )
+        show_result("Missing-Signal Decision Result", _result_lines(result))
+    except CancelMenuAction:
+        return

--- a/concord/models/group_planning.py
+++ b/concord/models/group_planning.py
@@ -39,6 +39,9 @@ GROUP_PLAN_STATUSES = frozenset(
     }
 )
 _SIGNAL_STRATEGIES = frozenset({"similar_signal", "mixed_signal"})
+MISSING_SIGNAL_DISPOSITIONS = frozenset(
+    {"manual", "random", "leave_unassigned"}
+)
 _SHA256 = re.compile(r"^[0-9a-f]{64}$")
 
 
@@ -98,6 +101,9 @@ class GroupPlan:
     source_signal_set_id: str | None = None
     source_signal_set_digest: str | None = None
     source_signal_dimension_id: str | None = None
+    missing_signal_disposition: str | None = None
+    missing_signal_random_seed: str | None = None
+    missing_signal_disposition_provenance: Provenance | None = None
     updated_provenance: Provenance | None = None
     previewed_provenance: Provenance | None = None
     approved_provenance: Provenance | None = None
@@ -246,11 +252,51 @@ class GroupPlan:
                 "previewed/terminal signal plans require an exact signal binding."
             )
 
+        disposition = self.missing_signal_disposition
+        if disposition is not None:
+            disposition = controlled(
+                disposition,
+                "missing_signal_disposition",
+                MISSING_SIGNAL_DISPOSITIONS,
+            )
+            if strategy not in _SIGNAL_STRATEGIES:
+                raise ConcordModelError(
+                    "missing-signal disposition is reserved for "
+                    "signal-dependent strategies."
+                )
+            if self.source_signal_set_id is None:
+                raise ConcordModelError(
+                    "missing-signal disposition requires an exact signal binding."
+                )
+            if self.missing_signal_disposition_provenance is None:
+                raise ConcordModelError(
+                    "missing-signal disposition requires disposition provenance."
+                )
+        elif self.missing_signal_disposition_provenance is not None:
+            raise ConcordModelError(
+                "missing-signal disposition provenance requires a disposition."
+            )
+
+        optional_text(
+            self.missing_signal_random_seed,
+            "missing_signal_random_seed",
+        )
+        if disposition == "random":
+            if self.missing_signal_random_seed is None:
+                raise ConcordModelError(
+                    "random missing-signal disposition requires an explicit seed."
+                )
+        elif self.missing_signal_random_seed is not None:
+            raise ConcordModelError(
+                "missing-signal random seed is allowed only for random disposition."
+            )
+
         if not isinstance(self.created_provenance, Provenance):
             raise ConcordModelError(
                 "created_provenance must be Provenance."
             )
         for field_name in (
+            "missing_signal_disposition_provenance",
             "updated_provenance",
             "previewed_provenance",
             "approved_provenance",
@@ -260,6 +306,16 @@ class GroupPlan:
             _optional_provenance(getattr(self, field_name), field_name)
 
         self._validate_status_provenance(status)
+
+        if status in {"approved", "applied"} and unresolved:
+            if not (
+                strategy in _SIGNAL_STRATEGIES
+                and disposition == "leave_unassigned"
+            ):
+                raise ConcordModelError(
+                    "approved/applied plans may retain unresolved students only "
+                    "for leave_unassigned missing-signal disposition."
+                )
 
     def _validate_status_provenance(self, status: str) -> None:
         if status == "draft":

--- a/concord/workflows/__init__.py
+++ b/concord/workflows/__init__.py
@@ -150,6 +150,13 @@ from concord.workflows.group_plan_manual import (
     replace_group_plan_from_arrangement,
     unassign_student_from_plan,
 )
+from concord.workflows.group_plan_missing_signal import (
+    MissingSignalDispositionResult,
+    MissingSignalPlanInspection,
+    SetMissingSignalDispositionRequest,
+    inspect_group_plan_missing_signal,
+    set_missing_signal_disposition,
+)
 from concord.workflows.group_plan_random import (
     CreateRandomGroupPlanRequest,
     RandomGroupPlanCreationResult,
@@ -501,6 +508,11 @@ __all__ = [
     "remove_planned_group",
     "replace_group_plan_from_arrangement",
     "unassign_student_from_plan",
+    "MissingSignalDispositionResult",
+    "MissingSignalPlanInspection",
+    "SetMissingSignalDispositionRequest",
+    "inspect_group_plan_missing_signal",
+    "set_missing_signal_disposition",
     "CreateRandomGroupPlanRequest",
     "RandomGroupPlanCreationResult",
     "create_random_group_plan",

--- a/concord/workflows/group_plan.py
+++ b/concord/workflows/group_plan.py
@@ -35,8 +35,11 @@ from concord.workflows.errors import (
     ConcordWorkflowNotFoundError,
     ConcordWorkflowValidationError,
 )
+from concord.workflows.grouping_signal import select_grouping_signal_dimension
 from concord.workflows.models import WorkflowActor, WorkflowCommitResult
 from concord.workflows.participants import load_required_roster
+
+_SIGNAL_STRATEGIES = frozenset({"similar_signal", "mixed_signal"})
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -76,6 +79,7 @@ class ReplaceGroupPlanProposalRequest:
     source_signal_set_id: str | None = None
     source_signal_set_digest: str | None = None
     source_signal_dimension_id: str | None = None
+    clear_missing_signal_disposition: bool = False
 
 
 @dataclass(frozen=True, slots=True, kw_only=True)
@@ -264,6 +268,62 @@ def _require_current_roster(
         )
 
 
+def _current_signal_missing_student_ids(
+    root: Path,
+    class_id: str,
+    plan: GroupPlan,
+) -> tuple[str, ...]:
+    # Revalidate the exact bound signal and selected-dimension missing IDs.
+    if plan.strategy not in _SIGNAL_STRATEGIES:
+        return ()
+
+    signal_set_id = plan.source_signal_set_id
+    signal_set_digest = plan.source_signal_set_digest
+    dimension_id = plan.source_signal_dimension_id
+    if (
+        signal_set_id is None
+        or signal_set_digest is None
+        or dimension_id is None
+    ):
+        raise ConcordWorkflowValidationError(
+            "Signal-backed GroupPlan is missing its exact signal binding."
+        )
+
+    selection = select_grouping_signal_dimension(
+        class_id,
+        signal_set_id,
+        dimension_id,
+        workspace_root=root,
+    )
+    if selection.digest != signal_set_digest:
+        raise ConcordWorkflowConflictError(
+            "Grouping signal canonical digest does not match the exact signal "
+            "binding stored on this GroupPlan."
+        )
+
+    if _roster_student_ids(root, class_id) != plan.roster_student_ids:
+        raise ConcordWorkflowConflictError(
+            "Core roster changed while validating the GroupPlan signal binding; "
+            "refresh and preview the plan again."
+        )
+
+    missing = tuple(
+        sorted(
+            finding.student_id
+            for finding in selection.inspection.diagnostics.findings
+            if finding.code == "missing_student_signal"
+            and finding.dimension_id == dimension_id
+            and finding.student_id is not None
+        )
+    )
+    if len(missing) != selection.dimension_diagnostics.missing_student_count:
+        raise ConcordWorkflowValidationError(
+            "Core grouping-signal diagnostics returned inconsistent "
+            "missing-student detail."
+        )
+    return missing
+
+
 def _require_preview_is_latest_work_change(
     root: Path,
     class_id: str,
@@ -418,6 +478,19 @@ def replace_group_plan_proposal(
         request.proposed_groups,
         roster_student_ids,
     )
+    if not isinstance(request.clear_missing_signal_disposition, bool):
+        raise ConcordWorkflowValidationError(
+            "clear_missing_signal_disposition must be a boolean."
+        )
+    if request.clear_missing_signal_disposition:
+        disposition = None
+        disposition_seed = None
+        disposition_provenance = None
+    else:
+        disposition = current.missing_signal_disposition
+        disposition_seed = current.missing_signal_random_seed
+        disposition_provenance = current.missing_signal_disposition_provenance
+
     candidate = GroupPlan(
         group_plan_id=current.group_plan_id,
         activity_id=current.activity_id,
@@ -433,6 +506,9 @@ def replace_group_plan_proposal(
         source_signal_set_id=request.source_signal_set_id,
         source_signal_set_digest=request.source_signal_set_digest,
         source_signal_dimension_id=request.source_signal_dimension_id,
+        missing_signal_disposition=disposition,
+        missing_signal_random_seed=disposition_seed,
+        missing_signal_disposition_provenance=disposition_provenance,
         created_provenance=current.created_provenance,
         updated_provenance=provenance(request.actor, clock=clock),
     )
@@ -576,7 +652,41 @@ def approve_group_plan(
         request.activity_id,
         request.group_plan_id,
     )
-    if current.unresolved_student_ids:
+    if current.strategy in _SIGNAL_STRATEGIES:
+        missing_student_ids = _current_signal_missing_student_ids(
+            root,
+            request.class_id,
+            current,
+        )
+        if missing_student_ids:
+            disposition = current.missing_signal_disposition
+            if disposition is None:
+                raise ConcordWorkflowValidationError(
+                    "Signal-backed GroupPlan approval requires an explicit "
+                    "missing-signal disposition."
+                )
+            if disposition in {"manual", "random"}:
+                if current.unresolved_student_ids:
+                    raise ConcordWorkflowValidationError(
+                        "Manual/random missing-signal disposition requires every "
+                        "roster student to be resolved before approval."
+                    )
+            elif disposition == "leave_unassigned":
+                if set(current.unresolved_student_ids) != set(missing_student_ids):
+                    raise ConcordWorkflowValidationError(
+                        "leave_unassigned approval requires unresolved students "
+                        "to exactly equal the current missing-signal population."
+                    )
+            else:
+                raise ConcordWorkflowValidationError(
+                    "Signal-backed GroupPlan has an invalid missing-signal "
+                    "disposition."
+                )
+        elif current.unresolved_student_ids:
+            raise ConcordWorkflowValidationError(
+                "GroupPlan approval requires every roster student to be resolved."
+            )
+    elif current.unresolved_student_ids:
         raise ConcordWorkflowValidationError(
             "GroupPlan approval requires every roster student to be resolved."
         )

--- a/concord/workflows/group_plan_manual.py
+++ b/concord/workflows/group_plan_manual.py
@@ -215,6 +215,7 @@ def _replace_preserving_origin(
     root: Path,
     standards_library: StandardsLibrary | None,
     clock: Clock | None,
+    clear_missing_signal_disposition: bool = False,
 ) -> GroupPlanEditResult:
     plan = detail.plan
     result = replace_group_plan_proposal(
@@ -232,6 +233,7 @@ def _replace_preserving_origin(
             source_signal_set_id=plan.source_signal_set_id,
             source_signal_set_digest=plan.source_signal_set_digest,
             source_signal_dimension_id=plan.source_signal_dimension_id,
+            clear_missing_signal_disposition=clear_missing_signal_disposition,
         ),
         workspace_root=root,
         standards_library=standards_library,
@@ -578,6 +580,7 @@ def refresh_group_plan_roster(
         root=root,
         standards_library=standards_library,
         clock=clock,
+        clear_missing_signal_disposition=True,
     )
 
 

--- a/concord/workflows/group_plan_missing_signal.py
+++ b/concord/workflows/group_plan_missing_signal.py
@@ -1,0 +1,389 @@
+"""Explicit #55 dispositions for students missing a selected grouping signal."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from pds_core.standards import StandardsLibrary
+
+from concord.group_plan_missing_signal import (
+    MissingSignalRandomizationError,
+    distribute_missing_signal_students,
+)
+from concord.models import GroupPlan, PlannedGroup
+from concord.storage import commit_record_batch
+from concord.workflows._collaboration import work_ref
+from concord.workflows.context import (
+    Clock,
+    ensure_mutating_workspace_root,
+    provenance,
+    require_core_class,
+    resolve_read_workspace_root,
+)
+from concord.workflows.errors import (
+    ConcordWorkflowConflictError,
+    ConcordWorkflowNotFoundError,
+    ConcordWorkflowValidationError,
+)
+from concord.workflows.group_plan import (
+    GroupPlanDetail,
+    GroupPlanMutationResult,
+    show_group_plan,
+)
+from concord.workflows.grouping_signal import (
+    select_grouping_signal_dimension,
+)
+from concord.workflows.models import WorkflowActor, WorkflowCommitResult
+from concord.workflows.participants import load_required_roster
+
+_SIGNAL_STRATEGIES = frozenset({"similar_signal", "mixed_signal"})
+_DISPOSITIONS = frozenset({"manual", "random", "leave_unassigned"})
+
+
+@dataclass(frozen=True, slots=True)
+class MissingSignalPlanInspection:
+    """Exact teacher-restricted #55 planning context without student-band values."""
+
+    detail: GroupPlanDetail
+    signal_set_id: str
+    signal_set_digest: str
+    dimension_id: str
+    missing_student_ids: tuple[str, ...]
+    missing_assigned_student_ids: tuple[str, ...]
+    missing_unresolved_student_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class SetMissingSignalDispositionRequest:
+    """Record one explicit plan-level decision for the current missing population."""
+
+    class_id: str
+    activity_id: str
+    group_plan_id: str
+    disposition: str
+    expected_snapshot_revision: int
+    actor: WorkflowActor
+    random_seed: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class MissingSignalDispositionResult:
+    """Privacy-bounded persisted #55 mutation result."""
+
+    mutation: GroupPlanMutationResult
+    disposition: str
+    missing_student_count: int
+    assigned_student_count: int
+    unresolved_student_count: int
+    group_sizes: tuple[int, ...]
+    random_seed: str | None
+
+
+def _required_root(workspace_root: str | Path | None) -> Path:
+    root = resolve_read_workspace_root(workspace_root)
+    if root is None:
+        raise ConcordWorkflowNotFoundError(
+            "Paper Data Suite workspace does not exist."
+        )
+    return root
+
+
+def _roster_student_ids(root: Path, class_id: str) -> tuple[str, ...]:
+    roster = load_required_roster(root, class_id)
+    return tuple(sorted(student.student_id for student in roster.students))
+
+
+def _require_signal_binding(plan: GroupPlan) -> tuple[str, str, str]:
+    if plan.strategy not in _SIGNAL_STRATEGIES:
+        raise ConcordWorkflowValidationError(
+            "Missing-signal disposition is available only for "
+            "similar_signal or mixed_signal GroupPlans."
+        )
+    signal_set_id = plan.source_signal_set_id
+    signal_set_digest = plan.source_signal_set_digest
+    dimension_id = plan.source_signal_dimension_id
+    if (
+        signal_set_id is None
+        or signal_set_digest is None
+        or dimension_id is None
+    ):
+        raise ConcordWorkflowValidationError(
+            "Signal-backed GroupPlan is missing its exact signal binding."
+        )
+    return signal_set_id, signal_set_digest, dimension_id
+
+
+def _missing_student_ids(
+    *,
+    dimension_id: str,
+    findings: tuple[object, ...],
+) -> tuple[str, ...]:
+    missing: list[str] = []
+    for finding in findings:
+        code = getattr(finding, "code", None)
+        finding_dimension = getattr(finding, "dimension_id", None)
+        student_id = getattr(finding, "student_id", None)
+        if (
+            code == "missing_student_signal"
+            and finding_dimension == dimension_id
+            and isinstance(student_id, str)
+        ):
+            missing.append(student_id)
+    return tuple(sorted(missing))
+
+
+def _inspect(
+    class_id: str,
+    activity_id: str,
+    group_plan_id: str,
+    *,
+    expected_snapshot_revision: int | None,
+    workspace_root: str | Path | None,
+) -> tuple[Path, MissingSignalPlanInspection]:
+    root = _required_root(workspace_root)
+    require_core_class(root, class_id)
+    detail = show_group_plan(
+        class_id,
+        activity_id,
+        group_plan_id,
+        workspace_root=root,
+    )
+    if (
+        expected_snapshot_revision is not None
+        and detail.summary.snapshot_revision != expected_snapshot_revision
+    ):
+        raise ConcordWorkflowConflictError(
+            "Activity changed since the caller's expected snapshot."
+        )
+
+    plan = detail.plan
+    signal_set_id, signal_set_digest, dimension_id = _require_signal_binding(plan)
+
+    roster_before = _roster_student_ids(root, class_id)
+    if roster_before != plan.roster_student_ids:
+        raise ConcordWorkflowConflictError(
+            "Core roster changed since this GroupPlan proposal revision; "
+            "refresh the GroupPlan roster explicitly before deciding how to "
+            "handle missing-signal students."
+        )
+
+    selection = select_grouping_signal_dimension(
+        class_id,
+        signal_set_id,
+        dimension_id,
+        workspace_root=root,
+    )
+    if selection.digest != signal_set_digest:
+        raise ConcordWorkflowConflictError(
+            "Grouping signal canonical digest does not match the exact signal "
+            "binding stored on this GroupPlan."
+        )
+
+    roster_after = _roster_student_ids(root, class_id)
+    if roster_after != roster_before:
+        raise ConcordWorkflowConflictError(
+            "Core roster changed while checking missing-signal students; "
+            "reload and retry."
+        )
+
+    missing = _missing_student_ids(
+        dimension_id=dimension_id,
+        findings=selection.inspection.diagnostics.findings,
+    )
+    if (
+        len(missing)
+        != selection.dimension_diagnostics.missing_student_count
+    ):
+        raise ConcordWorkflowValidationError(
+            "Core grouping-signal diagnostics returned inconsistent "
+            "missing-student detail."
+        )
+
+    unresolved = set(plan.unresolved_student_ids)
+    missing_set = set(missing)
+    missing_unresolved = tuple(sorted(missing_set & unresolved))
+    missing_assigned = tuple(sorted(missing_set - unresolved))
+
+    return root, MissingSignalPlanInspection(
+        detail=detail,
+        signal_set_id=signal_set_id,
+        signal_set_digest=signal_set_digest,
+        dimension_id=dimension_id,
+        missing_student_ids=missing,
+        missing_assigned_student_ids=missing_assigned,
+        missing_unresolved_student_ids=missing_unresolved,
+    )
+
+
+def inspect_group_plan_missing_signal(
+    class_id: str,
+    activity_id: str,
+    group_plan_id: str,
+    *,
+    workspace_root: str | Path | None = None,
+) -> MissingSignalPlanInspection:
+    """Revalidate the exact bound signal and return current missing-student context."""
+
+    _, inspection = _inspect(
+        class_id,
+        activity_id,
+        group_plan_id,
+        expected_snapshot_revision=None,
+        workspace_root=workspace_root,
+    )
+    return inspection
+
+
+def _validate_choice(
+    request: SetMissingSignalDispositionRequest,
+    inspection: MissingSignalPlanInspection,
+) -> None:
+    if request.disposition not in _DISPOSITIONS:
+        raise ConcordWorkflowValidationError(
+            "disposition must be one of: leave_unassigned, manual, random."
+        )
+    if inspection.detail.plan.status not in {"draft", "previewed"}:
+        raise ConcordWorkflowConflictError(
+            "Only draft or previewed GroupPlans may record a missing-signal "
+            "disposition."
+        )
+    if not inspection.missing_student_ids:
+        raise ConcordWorkflowValidationError(
+            "The selected signal dimension has no missing roster students; "
+            "no missing-signal disposition is required."
+        )
+
+    if request.disposition == "random":
+        if request.random_seed is None:
+            raise ConcordWorkflowValidationError(
+                "random missing-signal disposition requires an explicit seed."
+            )
+    elif request.random_seed is not None:
+        raise ConcordWorkflowValidationError(
+            "random_seed is allowed only for random missing-signal disposition."
+        )
+
+    if request.disposition == "manual":
+        if inspection.missing_unresolved_student_ids:
+            raise ConcordWorkflowValidationError(
+                "Manual missing-signal disposition requires every exact "
+                "missing-signal student to be placed first."
+            )
+    elif request.disposition == "leave_unassigned":
+        if inspection.missing_assigned_student_ids:
+            raise ConcordWorkflowValidationError(
+                "leave_unassigned requires every exact missing-signal student "
+                "to remain unresolved."
+            )
+    elif inspection.missing_assigned_student_ids:
+        raise ConcordWorkflowValidationError(
+            "Random missing-signal distribution requires every exact "
+            "missing-signal student to be unresolved first."
+        )
+
+
+def _candidate_groups_and_unresolved(
+    request: SetMissingSignalDispositionRequest,
+    inspection: MissingSignalPlanInspection,
+) -> tuple[tuple[PlannedGroup, ...], tuple[str, ...]]:
+    plan = inspection.detail.plan
+    if request.disposition != "random":
+        return plan.proposed_groups, plan.unresolved_student_ids
+
+    assert request.random_seed is not None
+    try:
+        randomized = distribute_missing_signal_students(
+            plan.proposed_groups,
+            inspection.missing_student_ids,
+            seed=request.random_seed,
+        )
+    except MissingSignalRandomizationError as error:
+        raise ConcordWorkflowValidationError(str(error)) from error
+
+    missing = set(inspection.missing_student_ids)
+    unresolved = tuple(
+        sorted(
+            student_id
+            for student_id in plan.unresolved_student_ids
+            if student_id not in missing
+        )
+    )
+    return randomized.proposed_groups, unresolved
+
+
+def set_missing_signal_disposition(
+    request: SetMissingSignalDispositionRequest,
+    *,
+    workspace_root: str | Path | None = None,
+    standards_library: StandardsLibrary | None = None,
+    clock: Clock | None = None,
+) -> MissingSignalDispositionResult:
+    """Persist one explicit #55 decision without creating canonical Groups."""
+
+    bootstrap = ensure_mutating_workspace_root(workspace_root)
+    root, inspection = _inspect(
+        request.class_id,
+        request.activity_id,
+        request.group_plan_id,
+        expected_snapshot_revision=request.expected_snapshot_revision,
+        workspace_root=bootstrap.root,
+    )
+    _validate_choice(request, inspection)
+
+    plan = inspection.detail.plan
+    groups, unresolved = _candidate_groups_and_unresolved(
+        request,
+        inspection,
+    )
+    decision_provenance = provenance(request.actor, clock=clock)
+    candidate = replace(
+        plan,
+        status="draft",
+        proposed_groups=groups,
+        unresolved_student_ids=unresolved,
+        missing_signal_disposition=request.disposition,
+        missing_signal_random_seed=request.random_seed,
+        missing_signal_disposition_provenance=decision_provenance,
+        updated_provenance=decision_provenance,
+        previewed_provenance=None,
+        approved_provenance=None,
+        cancelled_provenance=None,
+        applied_provenance=None,
+    )
+
+    if _roster_student_ids(root, request.class_id) != plan.roster_student_ids:
+        raise ConcordWorkflowConflictError(
+            "Core roster changed while preparing the missing-signal decision; "
+            "reload and retry."
+        )
+
+    storage_result = commit_record_batch(
+        root,
+        work_ref(request.class_id, request.activity_id),
+        (candidate,),
+        expected_snapshot_revision=request.expected_snapshot_revision,
+        standards_library=standards_library,
+    )
+    mutation = GroupPlanMutationResult(
+        commit=WorkflowCommitResult.from_storage(
+            storage_result,
+            workspace_created=bootstrap.created,
+        ),
+        group_plan_id=candidate.group_plan_id,
+        status=candidate.status,
+    )
+    assigned_count = sum(
+        len(group.student_ids) for group in candidate.proposed_groups
+    )
+    return MissingSignalDispositionResult(
+        mutation=mutation,
+        disposition=request.disposition,
+        missing_student_count=len(inspection.missing_student_ids),
+        assigned_student_count=assigned_count,
+        unresolved_student_count=len(candidate.unresolved_student_ids),
+        group_sizes=tuple(
+            len(group.student_ids) for group in candidate.proposed_groups
+        ),
+        random_seed=request.random_seed,
+    )

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,8 @@ dimension selection, and teacher-controlled `grouping_signal_csv_v1` import.
 Issue #54 now implements deterministic `similar_signal` and `mixed_signal` drafts
 with full-roster targets, exact Core signal/dimension binding, explicit unresolved
 missing coverage, bounded direct/menu UX, and no Meridian runtime dependency.
-Missing-signal disposition remains reserved for #55 and canonical plan application
+Issue #55 now implements explicit manual/random/leave-unassigned missing-signal
+decisions and approval revalidation; canonical plan application remains reserved
 for #56.
 
 The repository now contains:
@@ -65,6 +66,9 @@ The repository now contains:
 * deterministic similar-signal and mixed-signal GroupPlan generation with shared
   full-roster target semantics, exact signal provenance, visible unresolved missing
   coverage, explicit teacher review, and no canonical Group/Membership side effects;
+* explicit missing-signal `manual`, seeded `random`, and `leave_unassigned`
+  dispositions with exact Core-diagnostic authority, preview invalidation, narrow
+  approval semantics, and no canonical Group/Membership side effects;
 * contextual Membership, Role, and Responsibility workflow services;
 * a fully noninteractive direct CLI;
 * a teacher-facing H/B/M/Q menu with low-information-density screens;
@@ -190,13 +194,22 @@ partial-coverage and unresolved semantics, roster/preview race protection, direc
 CLI and explicit teacher-menu review, lifecycle reuse, privacy constraints, sibling
 isolation, and the #55/#56 handoffs.
 
+### 31. v0.3.0 missing-signal disposition
+
+[`v0.3.0-missing-signal-disposition.md`](v0.3.0-missing-signal-disposition.md)
+
+Documents issue #55's exact Core `missing_student_signal` authority, structured
+`manual`/`random`/`leave_unassigned` state, versioned missing-only seeded random
+placement, edit/refresh/preview lifecycle behavior, narrow approval exception,
+direct CLI and teacher-menu decisions, privacy exclusions, and the #56 boundary.
+
 ### Future v0.3.0 Group Planning / Template / Packet plan
 
 [`pds-group-planning-interoperability-development-plan.md`](pds-group-planning-interoperability-development-plan.md)
 
 This remains the roadmap for future v0.3.0 issues beyond the implemented
-#48-#54 foundations. It does not make #55 missing-signal policy or #56 canonical
-application implemented, nor does it make Template, Packet, guided Activity setup,
+#48-#55 foundations. It does not make #56 canonical application implemented,
+nor does it make Template, Packet, guided Activity setup,
 or final integrated teacher UI behavior implemented merely because their contracts
 are documented.
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented through the v0.3.0 signal-backed GroupPlan workflow in issue #54.
+Implemented through the v0.3.0 missing-signal disposition workflow in issue #55.
 
 ## Two interfaces, one service layer
 
@@ -63,6 +63,9 @@ concord group-plan create-manual
 concord group-plan create-random
 concord group-plan create-similar-signal
 concord group-plan create-mixed-signal
+concord group-plan confirm-missing-manual
+concord group-plan distribute-missing-random
+concord group-plan leave-missing-unassigned
 concord group-plan add-group
 concord group-plan edit-group
 concord group-plan remove-group
@@ -282,14 +285,25 @@ Core canonical signal digest and aggregate group/coverage counts without emittin
 student-band rows. Both commands create only a `draft` GroupPlan and explicitly
 report `Canonical Groups created: no`.
 
+For a signal-backed plan with current Core `missing_student_signal` findings,
+`confirm-missing-manual`, `distribute-missing-random`, and
+`leave-missing-unassigned` record the teacher's explicit disposition. These
+commands use the signal ID/digest/dimension already frozen into the GroupPlan;
+they do not accept signal reselection arguments. Random disposition requires
+its own explicit `--seed`, separate from `GroupPlan.seed`. All three mutations
+return a previewed plan to `draft` and report `Canonical Groups created: no`.
+
 Targeted plan edits reject Core-roster drift instead of silently refreshing it.
 `refresh-roster` is the explicit operation that preserves remaining placements,
 drops departed students, adds newcomers unresolved, preserves empty planned
 groups, and creates a draft revision when the roster changed.
 
-Preview and approval remain separate writes. Approval creates no canonical Group
-or Membership, and there is no `group-plan apply` command in issue #51. The
-`approved -> applied` transaction remains reserved for issue #56.
+Preview and approval remain separate writes. Signal-plan approval revalidates the
+exact bound Core signal/dimension/digest and current missing set. `manual` and
+`random` require zero unresolved students; `leave_unassigned` is the sole narrow
+exception and requires the unresolved set to equal the exact current missing set.
+Approval creates no canonical Group or Membership, and there is no `group-plan
+apply` command. The `approved -> applied` transaction remains reserved for issue #56.
 
 Within the teacher menu, `Groups and Participants` exposes separate `Plan groups`
 and `Manage Groups and Memberships` paths over the same shared service layer.
@@ -319,7 +333,8 @@ Review, evidence Moderation, Criterion/Scale/Score workflows, and an explicit
 Publication surface immediately after Scoring. Teacher writes require
 operation-specific words such as `CREATE`, `RENDER`, `ASSEMBLE`, `ADD`,
 `UPDATE`, `CORRECT`, `REVIEW`, `MODERATE`, `SCORE`, `REVISE`, `REGISTER`,
-`GENERATE`, `PUBLISH`, `WITHDRAW`, and `REBUILD`.
+`GENERATE`, `CONFIRM`, `DISTRIBUTE`, `LEAVE`, `PUBLISH`, `WITHDRAW`, and
+`REBUILD`.
 Global routing review remains
 available when a failed scan has no trustworthy Activity locator.
 

--- a/docs/v0.3.0-group-plan-contract.md
+++ b/docs/v0.3.0-group-plan-contract.md
@@ -221,10 +221,12 @@ validate exact student identities, and validate all Activity/Session context.
 
 ### Approved
 
-Approval is a separate explicit mutation from `previewed`. Under the #50
-baseline, approval requires no unresolved students and at least one nonempty
-proposed group. #55 may later introduce an explicit teacher disposition that
-permits deliberately unassigned missing-signal students.
+Approval is a separate explicit mutation from `previewed`. Issue #55 now
+revalidates signal-backed plans against the exact bound Core signal/dimension,
+canonical digest, current roster, and current `missing_student_signal` findings.
+Non-signal plans and signal plans using `manual` or `random` still require zero
+unresolved students. A signal plan using `leave_unassigned` is the sole narrow
+exception: its unresolved set must exactly equal Core's current missing set.
 
 Approved proposal content is frozen against ordinary editing.
 
@@ -327,7 +329,7 @@ Existing direct Group workflows remain unchanged.
 #52 deterministic random planning — implemented
 #53 signal discovery/import/dimension diagnostics — implemented
 #54 similar-signal and mixed-signal algorithms — implemented
-#55 explicit missing-signal teacher decisions
+#55 explicit missing-signal teacher decisions — implemented
 #56 approved-plan application to Group/GroupMembership
 ```
 
@@ -351,8 +353,9 @@ cancel
 Reads are side-effect free. Proposal replacement is a full replacement boundary
 that later #51/#52/#54 planners can target. Preview revalidates the exact Core
 roster. Approval requires the previewed revision to remain the latest Activity
-work change, requires zero unresolved students under the #50 baseline, and
-creates no Group or GroupMembership.
+work change. Issue #55 adds exact signal revalidation plus the explicit
+`leave_unassigned` unresolved-set exception; all other approval paths require
+zero unresolved students. Approval creates no Group or GroupMembership.
 
 Issue #51 now layers teacher-controlled manual authoring and direct
 `student_id,group` arrangement import on this contract. It adds plan-local group
@@ -374,6 +377,12 @@ ID/Core-digest/dimension provenance, leave missing selected-dimension roster
 students unresolved, and reuse #51 editing/refresh without rerunning the planner.
 Direct CLI and teacher-menu creation remain draft-only and create no canonical
 Group or GroupMembership.
+
+Issue #55 now adds structured `missing_signal_disposition`, separate seeded
+missing-only random distribution, explicit manual confirmation, deliberate
+`leave_unassigned`, edit preservation, roster-refresh invalidation, and exact
+approval-time Core revalidation. The disposition workflow does not copy bands or
+a cached missing-student set into GroupPlan and never creates canonical state.
 
 Canonical application remains reserved for #56; there is intentionally no
 generic `apply_group_plan`, `mark_group_plan_applied`, or status setter.

--- a/docs/v0.3.0-grouping-signal-workflows.md
+++ b/docs/v0.3.0-grouping-signal-workflows.md
@@ -217,7 +217,8 @@ low proficiency
 permission to omit a student
 ```
 
-Missing-signal planning policy belongs to issue #55.
+Issue #55 now consumes these exact `missing_student_signal` findings as the
+authority for explicit manual/random/leave-unassigned planning disposition.
 
 Diagnostics use exact Core `student_id`. Names, email, case folding, fuzzy
 matching, and roster position are not identity authorities.
@@ -538,7 +539,8 @@ Issue #54 now creates signal-backed GroupPlan drafts through a separate planning
 workflow. The #53 discovery/inspection/diagnostic/import operations documented in
 this section remain nonmutating with respect to Activity and GroupPlan state.
 
-Issue #55 owns missing-signal planning disposition.
+Issue #55 now implements missing-signal planning disposition while reusing this
+exact #53 selection and Core diagnostic boundary.
 
 Issue #56 owns approved-plan application to canonical Group/Membership state.
 
@@ -645,7 +647,7 @@ No physical paper round trip is required for issue #53.
 
 ```text
 Issue #54 -> deterministic similar-signal and mixed-signal GroupPlan algorithms — implemented
-Issue #55 -> explicit teacher decisions for missing signal coverage
+Issue #55 -> explicit teacher decisions for missing signal coverage — implemented
 Issue #56 -> approved GroupPlan application to Group/GroupMembership
 ```
 

--- a/docs/v0.3.0-missing-signal-disposition.md
+++ b/docs/v0.3.0-missing-signal-disposition.md
@@ -1,0 +1,441 @@
+# Concord v0.3.0 Missing-Signal Disposition
+
+**Issue:** #55 — Require explicit missing-signal decisions  
+**Status:** Implemented on the v0.3.0 development line  
+**Development version:** `pds-concord 0.3.0.dev0`  
+**Core requirement:** `pds-core>=0.6.1,<0.7`  
+**Exact Core qualification release:** `pds-core` v0.6.1
+
+## Purpose
+
+Signal-backed planning must never silently omit roster students who are absent
+from the selected signal dimension. Issue #55 adds an explicit teacher decision
+between the deterministic #54 proposal and approval:
+
+```text
+Core grouping_signal_set_v1
+        |
+        | exact signal + dimension
+        v
+similar_signal / mixed_signal GroupPlan
+        |
+        | missing_student_signal findings
+        v
+explicit teacher disposition
+        |
+        v
+preview -> approve
+        |
+        | Issue #56 only
+        v
+canonical Group + GroupMembership
+```
+
+The supported dispositions are exactly:
+
+```text
+manual
+random
+leave_unassigned
+```
+
+A missing signal is not Band 0, Band 1, a low score, a proficiency label, an
+absence, unenrollment, or permission to drop a student from the roster.
+
+## Core is the missing-set authority
+
+Every #55 inspection, mutation, and signal-plan approval re-resolves the exact
+signal binding already frozen into the GroupPlan through:
+
+```python
+select_grouping_signal_dimension(
+    class_id,
+    source_signal_set_id,
+    source_signal_dimension_id,
+)
+```
+
+Concord requires the returned Core canonical digest to equal:
+
+```text
+GroupPlan.source_signal_set_digest
+```
+
+The exact missing set is derived only from Core diagnostic findings whose:
+
+```text
+code == "missing_student_signal"
+dimension_id == GroupPlan.source_signal_dimension_id
+```
+
+Concord does not maintain a second roster/signal diagnostics engine. It does not
+persist a `missing_signal_student_ids` copy, because the exact current set is
+reproducible from the immutable signal identity/digest/dimension plus the current
+Core roster and diagnostics.
+
+Core diagnostic errors, unavailable signals/dimensions, canonical-digest
+mismatch, or roster drift fail closed.
+
+## Native GroupPlan state
+
+Issue #55 adds structured plan state:
+
+```text
+missing_signal_disposition
+missing_signal_random_seed
+missing_signal_disposition_provenance
+```
+
+`missing_signal_disposition` is either `manual`, `random`, `leave_unassigned`,
+or absent.
+
+The disposition and its provenance are all-or-none. The random seed is required
+only for disposition `random` and forbidden for the other dispositions.
+
+These fields are valid only for:
+
+```text
+similar_signal
+mixed_signal
+```
+
+Non-signal GroupPlans keep all three fields absent.
+
+The existing `GroupPlan.seed` remains reserved for the independent `random`
+planning strategy. Signal-backed plans continue to keep:
+
+```text
+GroupPlan.seed = None
+```
+
+Issue #55 never parses a free-form provenance note to recover policy state.
+
+## Manual disposition
+
+`manual` means the teacher used the existing #51 editor to place the missing
+students deliberately and then explicitly confirmed that choice.
+
+Confirmation requires:
+
+1. an editable `draft` or `previewed` signal-backed GroupPlan;
+2. successful exact signal/dimension/digest/roster revalidation;
+3. every exact current missing-signal student already assigned to a
+   `PlannedGroup`.
+
+Manual placement by itself is not the disposition decision.
+
+Confirming `manual` records structured disposition state and provenance in one
+new GroupPlan revision. A previously previewed plan returns to `draft` and must
+be previewed again.
+
+Other unresolved students can still exist structurally, but approval will reject
+that plan until every unresolved student is resolved.
+
+## Deterministic random disposition
+
+`random` places only the exact current missing-signal students. It never reruns
+the #54 similar/mixed planner and never moves a student already represented by
+the selected signal.
+
+It requires:
+
+```text
+explicit nonblank seed
+at least one current missing-signal student
+at least one existing PlannedGroup
+every exact missing-signal student currently unresolved
+```
+
+If the teacher already placed even one missing-signal student manually, the
+random operation rejects the plan. The teacher must confirm `manual` or
+explicitly return the affected student to unresolved state before requesting
+random distribution.
+
+The versioned ranking domain is exactly:
+
+```text
+pds-concord:group-plan-missing-signal-random:v1
+```
+
+For each exact missing student:
+
+```python
+payload = (
+    b"pds-concord:group-plan-missing-signal-random:v1\0"
+    + seed.encode("utf-8")
+    + b"\0"
+    + student_id.encode("utf-8")
+)
+rank = sha256(payload).digest()
+```
+
+Students are ordered by:
+
+```text
+(rank, student_id)
+```
+
+Each student is then placed sequentially into the existing PlannedGroup that
+minimizes:
+
+```text
+(current_group_size, planned_group_key)
+```
+
+Group sizes are updated after every placement.
+
+This contract uses no Python `random`, process hash, UUID randomness, clock, or
+filesystem ordering. The explicit seed is stored only as
+`missing_signal_random_seed`.
+
+## Leave unassigned disposition
+
+`leave_unassigned` is an affirmative teacher decision to keep the exact current
+missing-signal students rostered but visibly unresolved.
+
+It requires:
+
+```text
+at least one current missing-signal student
+every exact missing-signal student currently unresolved
+```
+
+No placeholder group, synthetic band, inferred band, or fake membership is
+created.
+
+The disposition mutation preserves the unresolved IDs and returns a previewed
+plan to `draft`.
+
+## Changing the disposition
+
+A teacher may explicitly replace one disposition with another while the plan is
+editable. The new choice creates a new native revision and new provenance and
+must satisfy the eligibility rules of the requested disposition.
+
+Historical native revisions retain the prior decision.
+
+Ordinary plan edits do not silently alter:
+
+```text
+missing_signal_disposition
+missing_signal_random_seed
+missing_signal_disposition_provenance
+```
+
+To rerandomize after a random distribution, the missing students must first be
+returned to unresolved state.
+
+## Roster refresh
+
+Explicit `refresh_group_plan_roster` invalidates any existing missing-signal
+decision whenever it creates a changed roster revision.
+
+The refresh preserves the #54 strategy, target, exact signal binding,
+still-rostered placements, and plan-local group identities, but clears:
+
+```text
+missing_signal_disposition
+missing_signal_random_seed
+missing_signal_disposition_provenance
+```
+
+The refreshed plan returns to `draft`. Concord does not select a newer signal or
+rerun the planner.
+
+## Preview and approval
+
+A signal-backed plan may be previewed before a disposition is chosen. Preview
+remains an exact persisted teacher-review state.
+
+Any disposition mutation is material and therefore returns a previewed plan to
+`draft`. The teacher must preview the resulting plan again before approval.
+
+Approval re-runs exact Core signal/dimension/digest/roster validation. It never
+relies only on cached #54 diagnostics or cached #55 inspection data.
+
+The approval matrix is:
+
+| Current exact missing set | Disposition | Approval condition |
+| --- | --- | --- |
+| empty | none required | `unresolved_student_ids` must be empty |
+| nonempty | `manual` | all roster students resolved |
+| nonempty | `random` | all roster students resolved; seed and disposition provenance present |
+| nonempty | `leave_unassigned` | `set(unresolved_student_ids)` exactly equals the exact current missing set |
+| nonempty | absent | reject |
+
+The `leave_unassigned` row is the only #55 exception that permits an approved
+GroupPlan to retain unresolved students.
+
+Non-signal `manual`, `imported_arrangement`, and `random` plans keep the previous
+zero-unresolved approval rule.
+
+## Direct CLI
+
+Issue #55 adds:
+
+```text
+concord group-plan confirm-missing-manual
+concord group-plan distribute-missing-random
+concord group-plan leave-missing-unassigned
+```
+
+All use the normal explicit class, Activity, GroupPlan ID, actor, and expected
+Activity snapshot arguments.
+
+`distribute-missing-random` additionally requires:
+
+```text
+--seed
+```
+
+None accepts `--signal-set-id` or `--dimension-id`; the immutable signal binding
+is already part of the GroupPlan and is revalidated before mutation.
+
+Successful output is bounded to:
+
+```text
+GroupPlan ID
+strategy
+status
+missing-signal disposition
+missing count
+assigned count
+unresolved count
+group sizes
+snapshot revision
+random seed when applicable
+Canonical Groups created: no
+```
+
+The direct decision commands do not emit band values.
+
+## Teacher menu
+
+Opening a `similar_signal` or `mixed_signal` GroupPlan exposes:
+
+```text
+Resolve missing-signal students
+```
+
+The screen shows the exact:
+
+```text
+signal set ID
+Core canonical digest
+dimension
+roster count
+missing count
+missing student IDs
+current unresolved count
+```
+
+It does not display a student-band table.
+
+The teacher chooses one of:
+
+```text
+1. Confirm manual placement
+2. Distribute missing students randomly
+3. Leave missing students unassigned
+```
+
+Random distribution requires an explicit seed and presents an in-memory preview
+before persistence. The preview includes the affected count, seed, current and
+resulting group sizes, and the resulting affected student-to-planned-group
+placements. It states that represented students will not move and that no
+canonical Groups or Memberships are being created.
+
+Leaving students unassigned shows the exact missing IDs and explicitly warns
+that they remain rostered/unassigned and receive no inferred band.
+
+All three paths require an explicit write confirmation and preserve the existing
+H/B/M/Q navigation model.
+
+## Privacy and publication boundary
+
+Missing-signal decision state is teacher-restricted planning state.
+
+The following must not leak into default logs, crash reports, passive attention
+summaries, PDS2 routes, Route Registrations, Template/Packet metadata, Artifact
+metadata, Artifact Reviews, Moderation Records, Score Records, Academic Result
+Manifests, or Publication Records:
+
+```text
+student band values
+missing_signal_disposition
+missing_signal_random_seed
+missing_signal_disposition_provenance
+signal-planning provenance not required by the target record
+```
+
+Canonical `GroupMembership` records must not receive the disposition, random
+seed, band, or signal history.
+
+The direct CLI and teacher menu may show exact missing student IDs only inside
+the explicit teacher-controlled correction/decision workflow where those IDs are
+necessary to make the requested decision.
+
+## Issue #56 boundary
+
+Issue #55 stops at an approved GroupPlan.
+
+It does not create:
+
+```text
+Group
+GroupMembership
+RoleAssignment
+ResponsibilityAssignment
+Artifact
+PDS2 route
+ScoreRecord
+Academic Result Manifest
+Publication Record
+```
+
+It does not mark the plan `applied`.
+
+Issue #56 alone owns the guarded transaction that applies an approved plan to
+canonical Group/GroupMembership state. For an approved `leave_unassigned` plan,
+#56 must create canonical state only for the proposed groups and must not invent
+memberships for unresolved students. The exact application transaction remains
+an issue #56 concern.
+
+## Qualification
+
+Focused issue #55 coverage includes:
+
+```text
+native model vocabulary and coherence
+serialization round trip without copied missing set/bands
+Core missing_student_signal authority
+canonical digest revalidation
+manual confirmation
+versioned SHA-256 random ranking
+dynamic smallest-group placement and planned_group_key tie-breaks
+leave_unassigned persistence
+explicit disposition replacement
+preview-to-draft behavior
+ordinary-edit preservation
+roster-refresh invalidation
+narrow approval exception
+direct CLI commands and frozen signal binding
+teacher-menu context and random preview
+GroupMembership/privacy/publication boundary regression
+no canonical Group or Membership creation
+```
+
+Repository qualification remains:
+
+```text
+python -m pytest
+python -m ruff check .
+python -m mypy
+python scripts/check_documentation.py
+python scripts/verify_release_compatibility.py
+python scripts/validate_repository.py --core-wheel <authenticated-Core-0.6.1-wheel> --allow-dirty
+git diff --check
+git status --short
+```
+
+No physical paper round trip is required for issue #55.

--- a/docs/v0.3.0-signal-group-planning.md
+++ b/docs/v0.3.0-signal-group-planning.md
@@ -375,9 +375,11 @@ previewed plan to `draft`. Refresh does not select a newer signal and does not r
 the algorithm. A teacher who wants a proposal from a different signal creates a new
 GroupPlan.
 
-A draft with unresolved students may be previewed. Under the current lifecycle,
-approval requires every roster student to be resolved. Issue #55 owns the explicit
-missing-signal disposition workflow; #54 does not invent a policy for those students.
+A draft with unresolved students may be previewed. Issue #55 now owns the explicit
+missing-signal disposition workflow. `manual` and seeded missing-only `random`
+resolve the exact missing students before approval; `leave_unassigned` is the sole
+narrow approval exception and requires unresolved IDs to equal Core's exact current
+missing set. Any disposition mutation returns a previewed plan to `draft`.
 
 Approval remains planning-only. Issue #56 alone owns the transaction that creates
 canonical `Group`/`GroupMembership` state and marks an approved plan applied.
@@ -473,7 +475,7 @@ band numbers are not learner labels.
 Issue #54 does not implement:
 
 ```text
-missing-signal disposition policy          -> Issue #55
+missing-signal disposition policy          -> Issue #55 (implemented separately)
 approved-plan application                  -> Issue #56
 automatic signal generation
 automatic/latest signal selection
@@ -511,7 +513,7 @@ stale Activity snapshot rejection
 manual editing and preview-to-draft behavior
 explicit roster refresh without replanning
 preview with unresolved students
-approval rejection while unresolved
+#55 disposition required for current missing coverage
 resolved approval without canonical Group creation
 privacy-bounded CLI output
 explicit menu signal/dimension selection

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -45,6 +45,23 @@ GROUPING_SIGNAL_WORKFLOW_DOC = (
     ROOT / "docs" / "v0.3.0-grouping-signal-workflows.md"
 )
 SIGNAL_GROUP_PLAN_DOC = ROOT / "docs" / "v0.3.0-signal-group-planning.md"
+MISSING_SIGNAL_DISPOSITION_DOC = (
+    ROOT / "docs" / "v0.3.0-missing-signal-disposition.md"
+)
+REQUIRED_MISSING_SIGNAL_DISPOSITION_DOC_PHRASES = (
+    "missing_signal_disposition",
+    "missing_signal_random_seed",
+    "missing_signal_disposition_provenance",
+    "missing_student_signal",
+    "select_grouping_signal_dimension",
+    "pds-concord:group-plan-missing-signal-random:v1",
+    "leave_unassigned",
+    "concord group-plan confirm-missing-manual",
+    "concord group-plan distribute-missing-random",
+    "concord group-plan leave-missing-unassigned",
+    "Canonical Groups created: no",
+    "Issue #56",
+)
 REQUIRED_GROUP_PLAN_DOC_PHRASES = (
     "GroupPlan != Group",
     "record kind: group_plan",
@@ -348,6 +365,25 @@ def check_documentation() -> None:
                 "Documentation index does not link the signal-backed Group "
                 "planning document."
             )
+    if not MISSING_SIGNAL_DISPOSITION_DOC.is_file():
+        failures.append(
+            "Current v0.3.0 missing-signal disposition document is missing."
+        )
+    else:
+        missing_signal_doc = MISSING_SIGNAL_DISPOSITION_DOC.read_text(
+            encoding="utf-8"
+        )
+        for phrase in REQUIRED_MISSING_SIGNAL_DISPOSITION_DOC_PHRASES:
+            if phrase not in missing_signal_doc:
+                failures.append(
+                    "Missing-signal disposition document is missing required "
+                    f"boundary wording {phrase!r}."
+                )
+        if MISSING_SIGNAL_DISPOSITION_DOC.name not in docs_index:
+            failures.append(
+                "Documentation index does not link the missing-signal "
+                "disposition document."
+            )
     for active_path in (
         ROOT / "README.md",
         ROOT / "docs" / "cli-contract.md",
@@ -366,6 +402,8 @@ def check_documentation() -> None:
         "lifecycle application services remain staged within #50",
         "does not make GroupPlan lifecycle/application services",
         "make the #51-#56 planning algorithms",
+        "Missing-signal disposition remains reserved for #55",
+        "#48-#54 foundations",
     ):
         if stale_phrase in docs_index:
             failures.append(

--- a/tests/test_group_plan_contract_issue50.py
+++ b/tests/test_group_plan_contract_issue50.py
@@ -320,8 +320,19 @@ def test_group_plan_status_provenance_is_coherent() -> None:
     )
     with pytest.raises(ConcordModelError, match="requires preview and approval"):
         replace(previewed, status="approved")
-    approved = replace(
+    resolved_previewed = replace(
         previewed,
+        proposed_groups=(
+            PlannedGroup(
+                planned_group_key="group-a",
+                label="Group A",
+                student_ids=("student-1", "student-2", "student-3"),
+            ),
+        ),
+        unresolved_student_ids=(),
+    )
+    approved = replace(
+        resolved_previewed,
         status="approved",
         approved_provenance=_native_provenance(3),
     )

--- a/tests/test_group_plan_missing_signal_cli_issue55.py
+++ b/tests/test_group_plan_missing_signal_cli_issue55.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.grouping_signal_storage import write_grouping_signal
+from pds_core.grouping_signals import (
+    GroupingSignalDimension,
+    GroupingSignalSet,
+    GroupingSignalSource,
+    GroupingSignalStudentBand,
+)
+from pds_core.rosters import create_roster
+from pds_core.workspace import ensure_workspace_root
+
+from concord.cli import main
+from concord.cli_app.parser import build_parser
+from concord.workflows import show_group_plan
+
+
+def _workspace(tmp_path: Path, name: str) -> Path:
+    root = ensure_workspace_root(tmp_path / name)
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata(
+            "class-1",
+            "2026-2027",
+            created_at=datetime(2026, 8, 22, tzinfo=timezone.utc),
+        ),
+    )
+    write_class_roster(
+        root,
+        create_roster(
+            "class-1",
+            tuple(
+                {
+                    "student_id": f"student-{index}",
+                    "last_name": f"Last-{index}",
+                    "first_name": f"First-{index}",
+                    "period": "1",
+                }
+                for index in range(1, 5)
+            ),
+        ),
+    )
+    assert main(
+        [
+            "activity", "create",
+            "--workspace-root", str(root),
+            "--class-id", "class-1",
+            "--activity-id", "activity-1",
+            "--title", "Missing Signal CLI",
+            "--activity-type", "project",
+            "--scoring-orientation", "evidence_only",
+            "--session-id", "session-1",
+            "--actor-id", "teacher-1",
+        ]
+    ) == 0
+
+    signal = GroupingSignalSet(
+        schema_version="1",
+        record_type="grouping_signal_set",
+        signal_set_id="signal-55",
+        class_id="class-1",
+        created_at=datetime(2026, 8, 22, 19, 0, tzinfo=timezone.utc),
+        source=GroupingSignalSource(
+            kind="module_generated",
+            module_id="synthetic_module",
+            snapshot_id="snapshot-55",
+            snapshot_digest_algorithm="sha256",
+            snapshot_digest="b" * 64,
+        ),
+        dimensions=(
+            GroupingSignalDimension(
+                dimension_id="collaboration-context",
+                band_count=4,
+            ),
+        ),
+        student_bands=(
+            GroupingSignalStudentBand(
+                student_id="student-1",
+                dimension_id="collaboration-context",
+                band=1,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-2",
+                dimension_id="collaboration-context",
+                band=4,
+            ),
+        ),
+    )
+    write_grouping_signal(root, signal)
+    assert main(
+        [
+            "group-plan", "create-similar-signal",
+            "--workspace-root", str(root),
+            "--class-id", "class-1",
+            "--activity-id", "activity-1",
+            "--group-plan-id", "signal-plan",
+            "--expected-snapshot", "1",
+            "--actor-id", "teacher-1",
+            "--signal-set-id", "signal-55",
+            "--dimension-id", "collaboration-context",
+            "--target-group-count", "2",
+        ]
+    ) == 0
+    return root
+
+
+def _decision_args(root: Path, command: str, expected: int) -> list[str]:
+    return [
+        "group-plan", command,
+        "--workspace-root", str(root),
+        "--class-id", "class-1",
+        "--activity-id", "activity-1",
+        "--group-plan-id", "signal-plan",
+        "--expected-snapshot", str(expected),
+        "--actor-id", "teacher-1",
+    ]
+
+
+def test_leave_and_random_missing_cli_are_explicit_and_planning_only(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    leave_root = _workspace(tmp_path, "leave")
+    capsys.readouterr()
+    assert main(_decision_args(leave_root, "leave-missing-unassigned", 2)) == 0
+    leave_output = capsys.readouterr().out
+    assert "Missing-signal disposition: leave_unassigned" in leave_output
+    assert "Missing-signal students: 2" in leave_output
+    assert "Unresolved students: 2" in leave_output
+    assert "Canonical Groups created: no" in leave_output
+    assert "student-3" not in leave_output
+
+    random_root = _workspace(tmp_path, "random")
+    capsys.readouterr()
+    assert main(
+        _decision_args(random_root, "distribute-missing-random", 2)
+        + ["--seed", "missing-seed"]
+    ) == 0
+    random_output = capsys.readouterr().out
+    assert "Missing-signal disposition: random" in random_output
+    assert "Random seed: missing-seed" in random_output
+    assert "Assigned students: 4" in random_output
+    assert "Unresolved students: 0" in random_output
+    assert "Group sizes: 2,2" in random_output
+    detail = show_group_plan(
+        "class-1", "activity-1", "signal-plan", workspace_root=random_root
+    )
+    assert detail.plan.seed is None
+    assert detail.plan.missing_signal_random_seed == "missing-seed"
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "confirm-missing-manual",
+        "distribute-missing-random",
+        "leave-missing-unassigned",
+    ),
+)
+def test_missing_signal_cli_uses_frozen_plan_binding(command: str) -> None:
+    parser = build_parser()
+    args = [
+        "group-plan", command,
+        "--workspace-root", "workspace",
+        "--class-id", "class-1",
+        "--activity-id", "activity-1",
+        "--group-plan-id", "signal-plan",
+        "--expected-snapshot", "2",
+        "--actor-id", "teacher-1",
+    ]
+    if command == "distribute-missing-random":
+        args += ["--seed", "seed"]
+    with pytest.raises(SystemExit):
+        parser.parse_args(args + ["--signal-set-id", "other-signal"])
+
+
+def test_random_missing_cli_requires_seed() -> None:
+    parser = build_parser()
+    common = [
+        "--workspace-root", "workspace",
+        "--class-id", "class-1",
+        "--activity-id", "activity-1",
+        "--group-plan-id", "signal-plan",
+        "--expected-snapshot", "2",
+        "--actor-id", "teacher-1",
+    ]
+    with pytest.raises(SystemExit):
+        parser.parse_args(["group-plan", "distribute-missing-random", *common])
+    parser.parse_args(["group-plan", "confirm-missing-manual", *common])
+    parser.parse_args(["group-plan", "leave-missing-unassigned", *common])

--- a/tests/test_group_plan_missing_signal_contract_issue55.py
+++ b/tests/test_group_plan_missing_signal_contract_issue55.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+
+import pytest
+from pds_core.routing_models import ModuleRecordRef
+
+from concord.model_conversion import record_from_dict, record_to_dict
+from concord.models import (
+    ActorReference,
+    ConcordModelError,
+    GroupPlan,
+    PlannedGroup,
+    Provenance,
+)
+
+
+def _provenance(day: int = 1) -> Provenance:
+    return Provenance(
+        actor=ActorReference(
+            actor_kind="authorized_adult",
+            actor_id="teacher-1",
+            owning_system="concord",
+        ),
+        timestamp=datetime(
+            2026,
+            8,
+            day,
+            15,
+            0,
+            tzinfo=timezone.utc,
+        ).isoformat(),
+        source_kind="manual",
+        application_version="0.3.0.dev0",
+    )
+
+
+def _signal_plan(*, unresolved: tuple[str, ...] = ("student-3",)) -> GroupPlan:
+    assigned = tuple(
+        student_id
+        for student_id in ("student-1", "student-2", "student-3")
+        if student_id not in unresolved
+    )
+    return GroupPlan(
+        group_plan_id="plan-1",
+        activity_id="activity-1",
+        class_reference=ModuleRecordRef(
+            module_id="core",
+            record_kind="class",
+            record_id="class-1",
+        ),
+        strategy="similar_signal",
+        status="draft",
+        roster_student_ids=("student-1", "student-2", "student-3"),
+        proposed_groups=(
+            PlannedGroup(
+                planned_group_key="similar-1",
+                label="Group 1",
+                student_ids=assigned,
+            ),
+        ),
+        unresolved_student_ids=unresolved,
+        target_group_count=1,
+        source_signal_set_id="signal-1",
+        source_signal_set_digest="a" * 64,
+        source_signal_dimension_id="writing",
+        created_provenance=_provenance(),
+    )
+
+
+def _approved(plan: GroupPlan) -> GroupPlan:
+    return replace(
+        plan,
+        status="approved",
+        previewed_provenance=_provenance(2),
+        approved_provenance=_provenance(3),
+    )
+
+
+@pytest.mark.parametrize("disposition", ("manual", "random", "leave_unassigned"))
+def test_signal_plan_accepts_each_structured_disposition(disposition: str) -> None:
+    seed = "missing-seed" if disposition == "random" else None
+    plan = replace(
+        _signal_plan(),
+        missing_signal_disposition=disposition,
+        missing_signal_random_seed=seed,
+        missing_signal_disposition_provenance=_provenance(4),
+    )
+    assert plan.missing_signal_disposition == disposition
+    assert plan.missing_signal_random_seed == seed
+
+
+def test_missing_signal_disposition_round_trips_as_native_state() -> None:
+    plan = replace(
+        _signal_plan(),
+        missing_signal_disposition="leave_unassigned",
+        missing_signal_disposition_provenance=_provenance(4),
+    )
+    payload = record_to_dict(plan)
+    restored = record_from_dict("group_plan", payload)
+    assert restored == plan
+    assert payload["missing_signal_disposition"] == "leave_unassigned"
+    assert "missing_signal_random_seed" not in payload
+    assert "missing_signal_student_ids" not in payload
+    assert "student_bands" not in payload
+
+
+def test_disposition_is_restricted_to_signal_strategies_and_exact_binding() -> None:
+    with pytest.raises(ConcordModelError, match="signal-dependent strategies"):
+        replace(
+            _signal_plan(),
+            strategy="manual",
+            source_signal_set_id=None,
+            source_signal_set_digest=None,
+            source_signal_dimension_id=None,
+            missing_signal_disposition="manual",
+            missing_signal_disposition_provenance=_provenance(4),
+        )
+
+    with pytest.raises(ConcordModelError, match="exact signal binding"):
+        replace(
+            _signal_plan(),
+            source_signal_set_id=None,
+            source_signal_set_digest=None,
+            source_signal_dimension_id=None,
+            missing_signal_disposition="manual",
+            missing_signal_disposition_provenance=_provenance(4),
+        )
+
+
+def test_disposition_and_provenance_are_all_or_none() -> None:
+    with pytest.raises(ConcordModelError, match="requires disposition provenance"):
+        replace(
+            _signal_plan(),
+            missing_signal_disposition="manual",
+        )
+
+    with pytest.raises(ConcordModelError, match="requires a disposition"):
+        replace(
+            _signal_plan(),
+            missing_signal_disposition_provenance=_provenance(4),
+        )
+
+
+def test_random_disposition_has_separate_explicit_seed_contract() -> None:
+    with pytest.raises(ConcordModelError, match="requires an explicit seed"):
+        replace(
+            _signal_plan(),
+            missing_signal_disposition="random",
+            missing_signal_disposition_provenance=_provenance(4),
+        )
+
+    with pytest.raises(ConcordModelError, match="allowed only for random"):
+        replace(
+            _signal_plan(),
+            missing_signal_disposition="manual",
+            missing_signal_random_seed="unexpected",
+            missing_signal_disposition_provenance=_provenance(4),
+        )
+
+    with pytest.raises(ConcordModelError, match="nonempty string"):
+        replace(
+            _signal_plan(),
+            missing_signal_disposition="random",
+            missing_signal_random_seed="",
+            missing_signal_disposition_provenance=_provenance(4),
+        )
+
+    plan = replace(
+        _signal_plan(),
+        missing_signal_disposition="random",
+        missing_signal_random_seed="missing-seed",
+        missing_signal_disposition_provenance=_provenance(4),
+    )
+    assert plan.seed is None
+    assert plan.missing_signal_random_seed == "missing-seed"
+
+
+def test_invalid_disposition_is_rejected() -> None:
+    with pytest.raises(ConcordModelError, match="missing_signal_disposition must be"):
+        replace(
+            _signal_plan(),
+            missing_signal_disposition="automatic",
+            missing_signal_disposition_provenance=_provenance(4),
+        )
+
+
+def test_approved_unresolved_requires_leave_unassigned_signal_disposition() -> None:
+    with pytest.raises(ConcordModelError, match="leave_unassigned"):
+        _approved(_signal_plan())
+
+    for disposition in ("manual", "random"):
+        plan = replace(
+            _signal_plan(),
+            missing_signal_disposition=disposition,
+            missing_signal_random_seed=(
+                "missing-seed" if disposition == "random" else None
+            ),
+            missing_signal_disposition_provenance=_provenance(4),
+        )
+        with pytest.raises(ConcordModelError, match="leave_unassigned"):
+            _approved(plan)
+
+    leave = replace(
+        _signal_plan(),
+        missing_signal_disposition="leave_unassigned",
+        missing_signal_disposition_provenance=_provenance(4),
+    )
+    approved = _approved(leave)
+    assert approved.unresolved_student_ids == ("student-3",)
+    assert approved.missing_signal_disposition == "leave_unassigned"
+
+
+def test_applied_unresolved_preserves_same_structural_exception() -> None:
+    leave = replace(
+        _signal_plan(),
+        missing_signal_disposition="leave_unassigned",
+        missing_signal_disposition_provenance=_provenance(4),
+    )
+    approved = _approved(leave)
+    applied = replace(
+        approved,
+        status="applied",
+        applied_provenance=_provenance(5),
+    )
+    assert applied.unresolved_student_ids == ("student-3",)
+
+
+def test_resolved_manual_and_random_dispositions_are_structurally_approvable() -> None:
+    resolved = _signal_plan(unresolved=())
+    for disposition in ("manual", "random"):
+        plan = replace(
+            resolved,
+            missing_signal_disposition=disposition,
+            missing_signal_random_seed=(
+                "missing-seed" if disposition == "random" else None
+            ),
+            missing_signal_disposition_provenance=_provenance(4),
+        )
+        assert _approved(plan).status == "approved"

--- a/tests/test_group_plan_missing_signal_lifecycle_issue55.py
+++ b/tests/test_group_plan_missing_signal_lifecycle_issue55.py
@@ -1,0 +1,565 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.grouping_signal_storage import write_grouping_signal
+from pds_core.grouping_signals import (
+    GroupingSignalDimension,
+    GroupingSignalSet,
+    GroupingSignalSource,
+    GroupingSignalStudentBand,
+)
+from pds_core.rosters import create_roster
+from pds_core.workspace import ensure_workspace_root
+
+from concord.storage import commit_record_batch, load_current_record_graph
+from concord.workflows import (
+    ApproveGroupPlanRequest,
+    CreateActivityContextRequest,
+    CreateManualGroupPlanRequest,
+    CreateSignalGroupPlanRequest,
+    EditPlannedGroupRequest,
+    PlaceStudentInPlanRequest,
+    PreviewGroupPlanRequest,
+    RefreshGroupPlanRosterRequest,
+    SetMissingSignalDispositionRequest,
+    UnassignStudentFromPlanRequest,
+    WorkflowActor,
+    approve_group_plan,
+    create_activity_context,
+    create_manual_group_plan,
+    create_signal_group_plan,
+    edit_planned_group,
+    place_student_in_plan,
+    preview_group_plan,
+    refresh_group_plan_roster,
+    set_missing_signal_disposition,
+    show_group_plan,
+    unassign_student_from_plan,
+)
+from concord.workflows._collaboration import work_ref
+from concord.workflows.errors import (
+    ConcordWorkflowConflictError,
+    ConcordWorkflowValidationError,
+)
+
+
+def _clock(day: int) -> datetime:
+    return datetime(2026, 8, day, 18, 0, tzinfo=timezone.utc)
+
+
+def _actor(actor_id: str = "teacher-1") -> WorkflowActor:
+    return WorkflowActor(
+        actor_id=actor_id,
+        display_label="Synthetic Teacher",
+        role_label="teacher",
+    )
+
+
+def _roster(*student_ids: str):
+    return create_roster(
+        "class-1",
+        tuple(
+            {
+                "student_id": student_id,
+                "last_name": f"Last-{index}",
+                "first_name": f"First-{index}",
+                "period": "1",
+            }
+            for index, student_id in enumerate(student_ids, start=1)
+        ),
+    )
+
+
+def _workspace(
+    tmp_path: Path,
+    *student_ids: str,
+    name: str = "workspace",
+) -> tuple[Path, int]:
+    root = ensure_workspace_root(tmp_path / name)
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata("class-1", "2026-2027", created_at=_clock(1)),
+    )
+    write_class_roster(root, _roster(*student_ids))
+    created = create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            title="Synthetic Signal Planning Activity",
+            activity_type="project",
+            scoring_orientation="evidence_only",
+            session_id="session-1",
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(2),
+    )
+    return root, created.commit.snapshot_revision
+
+
+def _signal(
+    bands: tuple[tuple[str, int], ...],
+    *,
+    signal_set_id: str = "signal-1",
+) -> GroupingSignalSet:
+    dimension_id = "collaboration-context"
+    return GroupingSignalSet(
+        schema_version="1",
+        record_type="grouping_signal_set",
+        signal_set_id=signal_set_id,
+        class_id="class-1",
+        created_at=_clock(2),
+        source=GroupingSignalSource(
+            kind="module_generated",
+            module_id="synthetic_module",
+            snapshot_id="snapshot-1",
+            snapshot_digest_algorithm="sha256",
+            snapshot_digest="b" * 64,
+        ),
+        dimensions=(
+            GroupingSignalDimension(
+                dimension_id=dimension_id,
+                band_count=4,
+            ),
+        ),
+        student_bands=tuple(
+            GroupingSignalStudentBand(
+                student_id=student_id,
+                dimension_id=dimension_id,
+                band=band,
+            )
+            for student_id, band in bands
+        ),
+    )
+
+
+def _partial_plan(
+    tmp_path: Path,
+    *,
+    name: str = "partial",
+) -> tuple[Path, int]:
+    root, revision = _workspace(
+        tmp_path,
+        "student-1",
+        "student-2",
+        "student-3",
+        "student-4",
+        name=name,
+    )
+    signal = _signal((("student-1", 4), ("student-2", 1)))
+    write_grouping_signal(root, signal)
+    created = create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            strategy="mixed_signal",
+            signal_set_id=signal.signal_set_id,
+            dimension_id="collaboration-context",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            target_group_count=2,
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(3),
+    )
+    return root, created.mutation.commit.snapshot_revision
+
+
+def _detail(root: Path):
+    return show_group_plan(
+        "class-1",
+        "activity-1",
+        "signal-plan",
+        workspace_root=root,
+    )
+
+
+def _preview(root: Path) -> int:
+    detail = _detail(root)
+    previewed = preview_group_plan(
+        PreviewGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=detail.summary.snapshot_revision,
+            actor=_actor("teacher-preview"),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(8),
+    )
+    return previewed.summary.snapshot_revision
+
+
+def _set_disposition(
+    root: Path,
+    disposition: str,
+    *,
+    seed: str | None = None,
+) -> int:
+    detail = _detail(root)
+    result = set_missing_signal_disposition(
+        SetMissingSignalDispositionRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            disposition=disposition,
+            random_seed=seed,
+            expected_snapshot_revision=detail.summary.snapshot_revision,
+            actor=_actor(f"teacher-{disposition}"),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(5),
+    )
+    return result.mutation.commit.snapshot_revision
+
+
+def test_ordinary_edit_preserves_missing_signal_disposition(tmp_path: Path) -> None:
+    root, _ = _partial_plan(tmp_path)
+    _set_disposition(root, "leave_unassigned")
+    before = _detail(root)
+
+    result = edit_planned_group(
+        EditPlannedGroupRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            planned_group_key="mixed-1",
+            label="Teacher Label",
+            expected_snapshot_revision=before.summary.snapshot_revision,
+            actor=_actor("teacher-editor"),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(6),
+    )
+
+    after = result.detail.plan
+    assert after.status == "draft"
+    assert after.missing_signal_disposition == "leave_unassigned"
+    assert after.missing_signal_random_seed is None
+    assert (
+        after.missing_signal_disposition_provenance
+        == before.plan.missing_signal_disposition_provenance
+    )
+    assert after.source_signal_set_id == before.plan.source_signal_set_id
+    assert after.source_signal_set_digest == before.plan.source_signal_set_digest
+    assert after.source_signal_dimension_id == before.plan.source_signal_dimension_id
+
+
+def test_roster_refresh_clears_disposition_but_preserves_signal_binding(
+    tmp_path: Path,
+) -> None:
+    root, _ = _partial_plan(tmp_path)
+    _set_disposition(root, "leave_unassigned")
+    before = _detail(root)
+
+    write_class_roster(
+        root,
+        _roster(
+            "student-1",
+            "student-2",
+            "student-3",
+            "student-4",
+            "student-5",
+        ),
+        overwrite=True,
+    )
+    result = refresh_group_plan_roster(
+        RefreshGroupPlanRosterRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=before.summary.snapshot_revision,
+            actor=_actor("teacher-refresh"),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(6),
+    )
+
+    after = result.detail.plan
+    assert after.status == "draft"
+    assert after.missing_signal_disposition is None
+    assert after.missing_signal_random_seed is None
+    assert after.missing_signal_disposition_provenance is None
+    assert after.source_signal_set_id == before.plan.source_signal_set_id
+    assert after.source_signal_set_digest == before.plan.source_signal_set_digest
+    assert after.source_signal_dimension_id == before.plan.source_signal_dimension_id
+    assert "student-5" in after.unresolved_student_ids
+
+
+def test_missing_signal_plan_without_disposition_cannot_be_approved(
+    tmp_path: Path,
+) -> None:
+    root, _ = _partial_plan(tmp_path)
+    revision = _preview(root)
+    with pytest.raises(
+        ConcordWorkflowValidationError,
+        match="explicit missing-signal disposition",
+    ):
+        approve_group_plan(
+            ApproveGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="signal-plan",
+                expected_snapshot_revision=revision,
+                actor=_actor("teacher-approve"),
+            ),
+            workspace_root=root,
+        )
+
+
+def test_manual_disposition_approves_only_after_full_resolution(
+    tmp_path: Path,
+) -> None:
+    root, _ = _partial_plan(tmp_path)
+    for student_id, group_key in (
+        ("student-3", "mixed-1"),
+        ("student-4", "mixed-2"),
+    ):
+        detail = _detail(root)
+        place_student_in_plan(
+            PlaceStudentInPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="signal-plan",
+                student_id=student_id,
+                planned_group_key=group_key,
+                expected_snapshot_revision=detail.summary.snapshot_revision,
+                actor=_actor("teacher-place"),
+            ),
+            workspace_root=root,
+        )
+    _set_disposition(root, "manual")
+    revision = _preview(root)
+    result = approve_group_plan(
+        ApproveGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=revision,
+            actor=_actor("teacher-approve"),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(9),
+    )
+    assert result.status == "approved"
+    assert _detail(root).plan.unresolved_student_ids == ()
+
+
+def test_random_disposition_approves_when_every_student_is_resolved(
+    tmp_path: Path,
+) -> None:
+    root, _ = _partial_plan(tmp_path)
+    _set_disposition(root, "random", seed="approval-seed")
+    revision = _preview(root)
+    result = approve_group_plan(
+        ApproveGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=revision,
+            actor=_actor("teacher-approve"),
+        ),
+        workspace_root=root,
+    )
+    approved = _detail(root).plan
+    assert result.status == "approved"
+    assert approved.missing_signal_disposition == "random"
+    assert approved.missing_signal_random_seed == "approval-seed"
+    assert approved.unresolved_student_ids == ()
+
+
+def test_leave_unassigned_approves_exact_missing_population_without_groups(
+    tmp_path: Path,
+) -> None:
+    root, _ = _partial_plan(tmp_path)
+    _set_disposition(root, "leave_unassigned")
+    revision = _preview(root)
+    result = approve_group_plan(
+        ApproveGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=revision,
+            actor=_actor("teacher-approve"),
+        ),
+        workspace_root=root,
+    )
+    approved = _detail(root).plan
+    assert result.status == "approved"
+    assert approved.unresolved_student_ids == ("student-3", "student-4")
+
+    graph = load_current_record_graph(
+        root,
+        work_ref("class-1", "activity-1"),
+    ).graph
+    assert graph.groups == ()
+    assert graph.memberships == ()
+
+
+def test_leave_unassigned_rejects_extra_represented_unresolved_student(
+    tmp_path: Path,
+) -> None:
+    root, _ = _partial_plan(tmp_path)
+    _set_disposition(root, "leave_unassigned")
+    detail = _detail(root)
+    unassign_student_from_plan(
+        UnassignStudentFromPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            student_id="student-1",
+            expected_snapshot_revision=detail.summary.snapshot_revision,
+            actor=_actor("teacher-unassign"),
+        ),
+        workspace_root=root,
+    )
+    revision = _preview(root)
+    with pytest.raises(
+        ConcordWorkflowValidationError,
+        match="exactly equal",
+    ):
+        approve_group_plan(
+            ApproveGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="signal-plan",
+                expected_snapshot_revision=revision,
+                actor=_actor("teacher-approve"),
+            ),
+            workspace_root=root,
+        )
+
+
+def test_complete_coverage_signal_plan_needs_no_disposition(tmp_path: Path) -> None:
+    root, revision = _workspace(
+        tmp_path,
+        "student-1",
+        "student-2",
+        name="complete",
+    )
+    signal = _signal(
+        (("student-1", 1), ("student-2", 2)),
+        signal_set_id="signal-complete",
+    )
+    write_grouping_signal(root, signal)
+    created = create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            strategy="similar_signal",
+            signal_set_id=signal.signal_set_id,
+            dimension_id="collaboration-context",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            target_group_count=1,
+        ),
+        workspace_root=root,
+    )
+    assert created.unresolved_student_count == 0
+    revision = _preview(root)
+    result = approve_group_plan(
+        ApproveGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=revision,
+            actor=_actor("teacher-approve"),
+        ),
+        workspace_root=root,
+    )
+    assert result.status == "approved"
+    assert _detail(root).plan.missing_signal_disposition is None
+
+
+def test_non_signal_unresolved_approval_rule_is_unchanged(tmp_path: Path) -> None:
+    root, revision = _workspace(
+        tmp_path,
+        "student-1",
+        "student-2",
+        name="manual",
+    )
+    created = create_manual_group_plan(
+        CreateManualGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="manual-plan",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+    previewed = preview_group_plan(
+        PreviewGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="manual-plan",
+            expected_snapshot_revision=created.commit.snapshot_revision,
+            actor=_actor("teacher-preview"),
+        ),
+        workspace_root=root,
+    )
+    with pytest.raises(
+        ConcordWorkflowValidationError,
+        match="every roster student",
+    ):
+        approve_group_plan(
+            ApproveGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="manual-plan",
+                expected_snapshot_revision=previewed.summary.snapshot_revision,
+                actor=_actor("teacher-approve"),
+            ),
+            workspace_root=root,
+        )
+
+
+def test_approval_revalidates_exact_core_digest(tmp_path: Path) -> None:
+    root, _ = _partial_plan(tmp_path)
+    _set_disposition(root, "leave_unassigned")
+    detail = _detail(root)
+    corrupted = replace(
+        detail.plan,
+        source_signal_set_digest="c" * 64,
+    )
+    committed = commit_record_batch(
+        root,
+        work_ref("class-1", "activity-1"),
+        (corrupted,),
+        expected_snapshot_revision=detail.summary.snapshot_revision,
+    )
+    previewed = preview_group_plan(
+        PreviewGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            expected_snapshot_revision=committed.snapshot_revision,
+            actor=_actor("teacher-preview-2"),
+        ),
+        workspace_root=root,
+    )
+    with pytest.raises(
+        ConcordWorkflowConflictError,
+        match="canonical digest",
+    ):
+        approve_group_plan(
+            ApproveGroupPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="signal-plan",
+                expected_snapshot_revision=previewed.summary.snapshot_revision,
+                actor=_actor("teacher-approve"),
+            ),
+            workspace_root=root,
+        )

--- a/tests/test_group_plan_missing_signal_menu_issue55.py
+++ b/tests/test_group_plan_missing_signal_menu_issue55.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+
+import concord.menu_group_plan as plan_menu
+import concord.menu_group_plan_missing_signal as missing_menu
+from concord.menu_context import MenuSessionContext
+from concord.models import PlannedGroup
+from concord.workflows import (
+    GroupPlanDetail,
+    MissingSignalPlanInspection,
+    WorkflowActor,
+)
+
+
+def _state() -> MenuSessionContext:
+    return MenuSessionContext(actor=WorkflowActor(actor_id="teacher-1"))
+
+
+def _detail(*, strategy: str = "mixed_signal") -> GroupPlanDetail:
+    plan = SimpleNamespace(
+        group_plan_id="signal-plan",
+        strategy=strategy,
+        status="draft",
+        roster_student_ids=("student-1", "student-2", "student-3", "student-4"),
+        proposed_groups=(
+            PlannedGroup(
+                planned_group_key="mixed-1",
+                label="Group 1",
+                student_ids=("student-1",),
+            ),
+            PlannedGroup(
+                planned_group_key="mixed-2",
+                label="Group 2",
+                student_ids=("student-2",),
+            ),
+        ),
+        unresolved_student_ids=("student-3", "student-4"),
+        missing_signal_disposition=None,
+        missing_signal_random_seed=None,
+    )
+    summary = SimpleNamespace(
+        class_id="class-1",
+        activity_id="activity-1",
+        group_plan_id="signal-plan",
+        snapshot_revision=7,
+        unresolved_student_count=2,
+    )
+    return cast(
+        GroupPlanDetail,
+        SimpleNamespace(plan=plan, summary=summary, record_revision=1),
+    )
+
+
+def _inspection() -> MissingSignalPlanInspection:
+    return MissingSignalPlanInspection(
+        detail=_detail(),
+        signal_set_id="signal-55",
+        signal_set_digest="d" * 64,
+        dimension_id="collaboration-context",
+        missing_student_ids=("student-3", "student-4"),
+        missing_assigned_student_ids=(),
+        missing_unresolved_student_ids=("student-3", "student-4"),
+    )
+
+
+def test_random_menu_previews_affected_placements_before_write(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    inspection = _inspection()
+    events: list[str] = []
+    captured: list[object] = []
+
+    monkeypatch.setattr(
+        missing_menu,
+        "inspect_group_plan_missing_signal",
+        lambda *a, **k: inspection,
+    )
+    monkeypatch.setattr(missing_menu, "_show_context", lambda _item: None)
+    monkeypatch.setattr(missing_menu, "select_one", lambda *a, **k: "random")
+    monkeypatch.setattr(
+        missing_menu,
+        "prompt_exact_text",
+        lambda *a, **k: "missing-seed",
+    )
+    monkeypatch.setattr(missing_menu, "clear_screen", lambda: None)
+    monkeypatch.setattr(missing_menu, "print_menu_header", lambda *a, **k: None)
+    monkeypatch.setattr(
+        missing_menu,
+        "pause_for_user",
+        lambda: events.append("preview"),
+    )
+    monkeypatch.setattr(
+        missing_menu,
+        "confirm_write",
+        lambda *a, **k: events.append("confirm") or True,
+    )
+    monkeypatch.setattr(missing_menu, "show_result", lambda *a, **k: None)
+
+    def fake_set(request: object) -> object:
+        captured.append(request)
+        assert events == ["preview", "confirm"]
+        return SimpleNamespace(
+            mutation=SimpleNamespace(
+                group_plan_id="signal-plan",
+                status="draft",
+                commit=SimpleNamespace(snapshot_revision=8),
+            ),
+            disposition="random",
+            missing_student_count=2,
+            assigned_student_count=4,
+            unresolved_student_count=0,
+            group_sizes=(2, 2),
+            random_seed="missing-seed",
+        )
+
+    monkeypatch.setattr(missing_menu, "set_missing_signal_disposition", fake_set)
+
+    missing_menu.resolve_missing_signal_from_menu(_detail(), _state())
+    output = capsys.readouterr().out
+    assert "Affected missing-signal students: 2" in output
+    assert "Seed: missing-seed" in output
+    assert "Result group sizes: 2,2" in output
+    assert "student-3 ->" in output
+    assert "student-4 ->" in output
+    assert "Students already represented" in output
+    request = captured[0]
+    assert getattr(request, "disposition") == "random"
+    assert getattr(request, "random_seed") == "missing-seed"
+    assert getattr(request, "expected_snapshot_revision") == 7
+
+
+def test_signal_plan_open_menu_exposes_missing_signal_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+    values = iter(["7", "b"])
+
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(values))
+    monkeypatch.setattr(plan_menu, "clear_screen", lambda: None)
+    monkeypatch.setattr(plan_menu, "print_menu_header", lambda *a, **k: None)
+    monkeypatch.setattr(plan_menu, "print_navigation", lambda *a, **k: None)
+    monkeypatch.setattr(plan_menu, "show_group_plan", lambda *a, **k: _detail())
+    monkeypatch.setattr(
+        plan_menu,
+        "resolve_missing_signal_from_menu",
+        lambda _detail, _state: calls.append("resolve"),
+    )
+
+    selected = SimpleNamespace(
+        class_id="class-1",
+        activity_id="activity-1",
+        group_plan_id="signal-plan",
+    )
+    activity = SimpleNamespace(class_id="class-1", activity_id="activity-1")
+    plan_menu._open_plan(activity, selected, _state())
+    assert calls == ["resolve"]

--- a/tests/test_group_plan_missing_signal_privacy_issue55.py
+++ b/tests/test_group_plan_missing_signal_privacy_issue55.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+
+from concord.models import GroupMembership
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PRIVATE_PLAN_FIELDS = frozenset(
+    {
+        "missing_signal_disposition",
+        "missing_signal_random_seed",
+        "missing_signal_disposition_provenance",
+        "source_signal_set_id",
+        "source_signal_set_digest",
+        "source_signal_dimension_id",
+    }
+)
+
+
+def test_group_membership_has_no_missing_signal_or_signal_history_fields() -> None:
+    membership_fields = {field.name for field in fields(GroupMembership)}
+    assert PRIVATE_PLAN_FIELDS.isdisjoint(membership_fields)
+    assert "band" not in membership_fields
+    assert "seed" not in membership_fields
+
+
+def test_nonplanning_publication_and_evidence_surfaces_do_not_reference_private_state(
+) -> None:
+    direct_files = (
+        ROOT / "concord" / "academic_result_manifest.py",
+        ROOT / "concord" / "academic_result_manifest_generation.py",
+        ROOT / "concord" / "academic_result_publication.py",
+        ROOT / "concord" / "pds_publication.py",
+        ROOT / "concord" / "models" / "artifacts.py",
+        ROOT / "concord" / "models" / "review.py",
+        ROOT / "concord" / "models" / "scoring.py",
+    )
+    routing_files = tuple(sorted((ROOT / "concord" / "routing").rglob("*.py")))
+    files_to_check = direct_files + routing_files
+
+    for path in files_to_check:
+        text = path.read_text(encoding="utf-8")
+        for field_name in PRIVATE_PLAN_FIELDS:
+            assert field_name not in text, (
+                f"{field_name} leaked into nonplanning surface "
+                f"{path.relative_to(ROOT)}"
+            )
+
+
+def test_group_plan_missing_signal_module_does_not_import_sibling_modules() -> None:
+    text = (
+        ROOT / "concord" / "workflows" / "group_plan_missing_signal.py"
+    ).read_text(encoding="utf-8")
+    for sibling in (
+        "meridian",
+        "scoreform",
+        "quillan",
+        "vitrine",
+        "portia",
+    ):
+        assert f"import {sibling}" not in text
+        assert f"from {sibling}" not in text

--- a/tests/test_group_plan_missing_signal_random_issue55.py
+++ b/tests/test_group_plan_missing_signal_random_issue55.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from concord.group_plan_missing_signal import (
+    MISSING_SIGNAL_RANDOM_DOMAIN,
+    MissingSignalRandomizationError,
+    distribute_missing_signal_students,
+)
+from concord.models import PlannedGroup
+
+
+def _group(
+    key: str,
+    *student_ids: str,
+) -> PlannedGroup:
+    return PlannedGroup(
+        planned_group_key=key,
+        label=key.upper(),
+        student_ids=student_ids,
+        description=f"metadata-{key}",
+    )
+
+
+def _mapping(result) -> dict[str, tuple[str, ...]]:
+    return {
+        group.planned_group_key: group.student_ids
+        for group in result.proposed_groups
+    }
+
+
+def test_random_contract_uses_exact_domain_rank_and_smallest_group() -> None:
+    groups = (
+        _group("g-b", "student-2"),
+        _group("g-c"),
+        _group("g-a", "student-1"),
+    )
+    result = distribute_missing_signal_students(
+        groups,
+        ("student-5", "student-3", "student-4"),
+        seed="seed-55",
+    )
+
+    expected_ranks = {
+        student_id: hashlib.sha256(
+            MISSING_SIGNAL_RANDOM_DOMAIN.encode("utf-8")
+            + b"\0"
+            + b"seed-55"
+            + b"\0"
+            + student_id.encode("utf-8")
+        ).hexdigest()
+        for student_id in ("student-3", "student-4", "student-5")
+    }
+    assert expected_ranks == {
+        "student-3": (
+            "84183d46166065b62507b19c20a63a6e276366e8e5b42019f750fa1d2d7bc3ee"
+        ),
+        "student-4": (
+            "09ba73e79dbb5627e43d5667b8ce112df53069949f1659f08ae75c540d34cae1"
+        ),
+        "student-5": (
+            "d5f958af9db780bb4a0f2f2a1ae89ce48e4380ef9820aaebba5732ff0e7de41c"
+        ),
+    }
+    assert result.placements == (
+        ("student-4", "g-c"),
+        ("student-3", "g-a"),
+        ("student-5", "g-b"),
+    )
+    assert _mapping(result) == {
+        "g-a": ("student-1", "student-3"),
+        "g-b": ("student-2", "student-5"),
+        "g-c": ("student-4",),
+    }
+
+
+def test_random_membership_is_independent_of_input_orders() -> None:
+    a = distribute_missing_signal_students(
+        (
+            _group("g-b", "student-2"),
+            _group("g-c"),
+            _group("g-a", "student-1"),
+        ),
+        ("student-5", "student-3", "student-4"),
+        seed="same-seed",
+    )
+    b = distribute_missing_signal_students(
+        (
+            _group("g-a", "student-1"),
+            _group("g-b", "student-2"),
+            _group("g-c"),
+        ),
+        ("student-4", "student-5", "student-3"),
+        seed="same-seed",
+    )
+    assert _mapping(a) == _mapping(b)
+    assert a.placements == b.placements
+
+
+def test_random_preserves_existing_memberships_and_group_metadata() -> None:
+    original = (
+        _group("g-1", "student-1", "student-2"),
+        _group("g-2"),
+    )
+    result = distribute_missing_signal_students(
+        original,
+        ("student-3",),
+        seed="seed",
+    )
+    mapping = _mapping(result)
+    assert mapping["g-1"] == ("student-1", "student-2")
+    assert mapping["g-2"] == ("student-3",)
+    for before, after in zip(original, result.proposed_groups, strict=True):
+        assert before.planned_group_key == after.planned_group_key
+        assert before.label == after.label
+        assert before.description == after.description
+
+
+@pytest.mark.parametrize("seed", ("", " ", " seed", "seed "))
+def test_random_rejects_invalid_seed(seed: str) -> None:
+    with pytest.raises(MissingSignalRandomizationError, match="seed"):
+        distribute_missing_signal_students(
+            (_group("g-1"),),
+            ("student-1",),
+            seed=seed,
+        )
+
+
+def test_random_rejects_missing_student_already_assigned() -> None:
+    with pytest.raises(MissingSignalRandomizationError, match="unresolved"):
+        distribute_missing_signal_students(
+            (_group("g-1", "student-1"),),
+            ("student-1",),
+            seed="seed",
+        )
+
+
+def test_random_rejects_no_groups_and_duplicate_missing_ids() -> None:
+    with pytest.raises(MissingSignalRandomizationError, match="PlannedGroup"):
+        distribute_missing_signal_students(
+            (),
+            ("student-1",),
+            seed="seed",
+        )
+    with pytest.raises(MissingSignalRandomizationError, match="duplicates"):
+        distribute_missing_signal_students(
+            (_group("g-1"),),
+            ("student-1", "student-1"),
+            seed="seed",
+        )

--- a/tests/test_group_plan_missing_signal_workflow_issue55.py
+++ b/tests/test_group_plan_missing_signal_workflow_issue55.py
@@ -1,0 +1,581 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.grouping_signal_storage import (
+    calculate_grouping_signal_digest,
+    write_grouping_signal,
+)
+from pds_core.grouping_signals import (
+    GroupingSignalDimension,
+    GroupingSignalSet,
+    GroupingSignalSource,
+    GroupingSignalStudentBand,
+)
+from pds_core.rosters import create_roster
+from pds_core.routing_models import ModuleWorkRef
+from pds_core.workspace import ensure_workspace_root
+
+from concord.storage import commit_record_batch, load_current_record_graph
+from concord.workflows import (
+    CreateActivityContextRequest,
+    CreateGroupPlanRequest,
+    CreateSignalGroupPlanRequest,
+    PlaceStudentInPlanRequest,
+    SetMissingSignalDispositionRequest,
+    UnassignStudentFromPlanRequest,
+    WorkflowActor,
+    create_activity_context,
+    create_group_plan,
+    create_signal_group_plan,
+    inspect_group_plan_missing_signal,
+    place_student_in_plan,
+    set_missing_signal_disposition,
+    unassign_student_from_plan,
+)
+from concord.workflows.errors import (
+    ConcordWorkflowConflictError,
+    ConcordWorkflowValidationError,
+)
+from concord.workflows.group_plan import show_group_plan
+
+
+def _clock(day: int) -> datetime:
+    return datetime(2026, 8, day, 19, 0, tzinfo=timezone.utc)
+
+
+def _actor(actor_id: str = "teacher-1") -> WorkflowActor:
+    return WorkflowActor(
+        actor_id=actor_id,
+        display_label="Synthetic Teacher",
+        role_label="teacher",
+    )
+
+
+def _roster(*student_ids: str):
+    return create_roster(
+        "class-1",
+        tuple(
+            {
+                "student_id": student_id,
+                "last_name": f"Last-{index}",
+                "first_name": f"First-{index}",
+                "period": "1",
+            }
+            for index, student_id in enumerate(student_ids, start=1)
+        ),
+    )
+
+
+def _workspace(
+    tmp_path: Path,
+    *student_ids: str,
+    name: str = "workspace",
+) -> tuple[Path, int]:
+    root = ensure_workspace_root(tmp_path / name)
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata(
+            "class-1",
+            "2026-2027",
+            created_at=_clock(1),
+        ),
+    )
+    write_class_roster(root, _roster(*student_ids))
+    created = create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            title="Synthetic Missing-Signal Activity",
+            activity_type="project",
+            scoring_orientation="evidence_only",
+            session_id="session-1",
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(2),
+    )
+    return root, created.commit.snapshot_revision
+
+
+def _signal(
+    bands: tuple[tuple[str, int], ...],
+    *,
+    signal_set_id: str = "signal-1",
+) -> GroupingSignalSet:
+    dimension_id = "collaboration-context"
+    return GroupingSignalSet(
+        schema_version="1",
+        record_type="grouping_signal_set",
+        signal_set_id=signal_set_id,
+        class_id="class-1",
+        created_at=_clock(2),
+        source=GroupingSignalSource(
+            kind="module_generated",
+            module_id="synthetic_module",
+            snapshot_id="snapshot-1",
+            snapshot_digest_algorithm="sha256",
+            snapshot_digest="b" * 64,
+        ),
+        dimensions=(
+            GroupingSignalDimension(
+                dimension_id=dimension_id,
+                band_count=4,
+            ),
+        ),
+        student_bands=tuple(
+            GroupingSignalStudentBand(
+                student_id=student_id,
+                dimension_id=dimension_id,
+                band=band,
+            )
+            for student_id, band in bands
+        ),
+    )
+
+
+def _partial_plan(
+    tmp_path: Path,
+    *,
+    name: str = "workspace",
+) -> tuple[Path, int, GroupingSignalSet]:
+    root, revision = _workspace(
+        tmp_path,
+        "student-1",
+        "student-2",
+        "student-3",
+        "student-4",
+        "student-5",
+        name=name,
+    )
+    signal = _signal((("student-1", 4), ("student-2", 1)))
+    write_grouping_signal(root, signal)
+    created = create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            strategy="mixed_signal",
+            signal_set_id=signal.signal_set_id,
+            dimension_id="collaboration-context",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            target_group_count=2,
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(3),
+    )
+    return root, created.mutation.commit.snapshot_revision, signal
+
+
+def _detail(root: Path):
+    return show_group_plan(
+        "class-1",
+        "activity-1",
+        "signal-plan",
+        workspace_root=root,
+    )
+
+
+def test_inspection_uses_exact_bound_signal_and_core_missing_findings(
+    tmp_path: Path,
+) -> None:
+    root, _, signal = _partial_plan(tmp_path)
+    inspection = inspect_group_plan_missing_signal(
+        "class-1",
+        "activity-1",
+        "signal-plan",
+        workspace_root=root,
+    )
+    assert inspection.signal_set_id == signal.signal_set_id
+    assert inspection.signal_set_digest == calculate_grouping_signal_digest(signal)
+    assert inspection.signal_set_digest != signal.source.snapshot_digest
+    assert inspection.dimension_id == "collaboration-context"
+    assert inspection.missing_student_ids == (
+        "student-3",
+        "student-4",
+        "student-5",
+    )
+    assert inspection.missing_assigned_student_ids == ()
+    assert inspection.missing_unresolved_student_ids == inspection.missing_student_ids
+
+
+def test_leave_unassigned_records_explicit_provenance_without_group_side_effects(
+    tmp_path: Path,
+) -> None:
+    root, revision, _ = _partial_plan(tmp_path)
+    result = set_missing_signal_disposition(
+        SetMissingSignalDispositionRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            disposition="leave_unassigned",
+            expected_snapshot_revision=revision,
+            actor=_actor("teacher-leave"),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(4),
+    )
+    detail = _detail(root)
+    assert result.disposition == "leave_unassigned"
+    assert result.missing_student_count == 3
+    assert result.unresolved_student_count == 3
+    assert detail.plan.status == "draft"
+    assert detail.plan.unresolved_student_ids == (
+        "student-3",
+        "student-4",
+        "student-5",
+    )
+    assert detail.plan.missing_signal_disposition == "leave_unassigned"
+    assert detail.plan.missing_signal_random_seed is None
+    provenance = detail.plan.missing_signal_disposition_provenance
+    assert provenance is not None
+    assert provenance.actor.actor_id == "teacher-leave"
+
+    graph = load_current_record_graph(
+        root,
+        ModuleWorkRef(
+            module_id="concord",
+            class_id="class-1",
+            work_id="activity-1",
+        ),
+    ).graph
+    assert graph.groups == ()
+    assert graph.memberships == ()
+
+
+def test_manual_disposition_requires_explicit_placement_then_confirmation(
+    tmp_path: Path,
+) -> None:
+    root, revision, _ = _partial_plan(tmp_path)
+    with pytest.raises(
+        ConcordWorkflowValidationError,
+        match="placed first",
+    ):
+        set_missing_signal_disposition(
+            SetMissingSignalDispositionRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="signal-plan",
+                disposition="manual",
+                expected_snapshot_revision=revision,
+                actor=_actor(),
+            ),
+            workspace_root=root,
+        )
+
+    for student_id, key in (
+        ("student-3", "mixed-1"),
+        ("student-4", "mixed-2"),
+        ("student-5", "mixed-1"),
+    ):
+        edited = place_student_in_plan(
+            PlaceStudentInPlanRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="signal-plan",
+                student_id=student_id,
+                planned_group_key=key,
+                expected_snapshot_revision=_detail(root).summary.snapshot_revision,
+                actor=_actor(),
+            ),
+            workspace_root=root,
+        )
+        assert edited.changed
+
+    before = _detail(root)
+    assert before.plan.unresolved_student_ids == ()
+    assert before.plan.missing_signal_disposition is None
+
+    set_missing_signal_disposition(
+        SetMissingSignalDispositionRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            disposition="manual",
+            expected_snapshot_revision=before.summary.snapshot_revision,
+            actor=_actor("teacher-manual"),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(5),
+    )
+    after = _detail(root)
+    assert after.plan.missing_signal_disposition == "manual"
+    assert after.plan.missing_signal_random_seed is None
+    assert after.plan.strategy == "mixed_signal"
+    assert after.plan.unresolved_student_ids == ()
+
+
+def test_random_disposition_is_deterministic_and_uses_separate_seed(
+    tmp_path: Path,
+) -> None:
+    root, revision, _ = _partial_plan(tmp_path)
+    result = set_missing_signal_disposition(
+        SetMissingSignalDispositionRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            disposition="random",
+            random_seed="missing-seed",
+            expected_snapshot_revision=revision,
+            actor=_actor("teacher-random"),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(4),
+    )
+    detail = _detail(root)
+    assert result.group_sizes == (3, 2)
+    assert result.unresolved_student_count == 0
+    assert detail.plan.strategy == "mixed_signal"
+    assert detail.plan.seed is None
+    assert detail.plan.missing_signal_disposition == "random"
+    assert detail.plan.missing_signal_random_seed == "missing-seed"
+    assert detail.plan.proposed_groups[0].student_ids == (
+        "student-1",
+        "student-3",
+        "student-5",
+    )
+    assert detail.plan.proposed_groups[1].student_ids == (
+        "student-2",
+        "student-4",
+    )
+
+
+def test_random_rejects_missing_student_that_teacher_already_placed(
+    tmp_path: Path,
+) -> None:
+    root, _, _ = _partial_plan(tmp_path)
+    detail = _detail(root)
+    place_student_in_plan(
+        PlaceStudentInPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            student_id="student-3",
+            planned_group_key="mixed-1",
+            expected_snapshot_revision=detail.summary.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+    detail = _detail(root)
+    with pytest.raises(
+        ConcordWorkflowValidationError,
+        match="unresolved first",
+    ):
+        set_missing_signal_disposition(
+            SetMissingSignalDispositionRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="signal-plan",
+                disposition="random",
+                random_seed="seed",
+                expected_snapshot_revision=detail.summary.snapshot_revision,
+                actor=_actor(),
+            ),
+            workspace_root=root,
+        )
+
+
+def test_random_places_only_missing_and_leaves_represented_unresolved(
+    tmp_path: Path,
+) -> None:
+    root, _, _ = _partial_plan(tmp_path)
+    detail = _detail(root)
+    unassign_student_from_plan(
+        UnassignStudentFromPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            student_id="student-1",
+            expected_snapshot_revision=detail.summary.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+    detail = _detail(root)
+    set_missing_signal_disposition(
+        SetMissingSignalDispositionRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            disposition="random",
+            random_seed="seed",
+            expected_snapshot_revision=detail.summary.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+    )
+    after = _detail(root)
+    assert after.plan.unresolved_student_ids == ("student-1",)
+    assigned = {
+        student_id
+        for group in after.plan.proposed_groups
+        for student_id in group.student_ids
+    }
+    assert {"student-3", "student-4", "student-5"} <= assigned
+    assert "student-1" not in assigned
+
+
+def test_disposition_rejects_stale_snapshot_and_zero_missing_population(
+    tmp_path: Path,
+) -> None:
+    root, revision, _ = _partial_plan(tmp_path)
+    with pytest.raises(ConcordWorkflowConflictError, match="expected snapshot"):
+        set_missing_signal_disposition(
+            SetMissingSignalDispositionRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="signal-plan",
+                disposition="leave_unassigned",
+                expected_snapshot_revision=revision - 1,
+                actor=_actor(),
+            ),
+            workspace_root=root,
+        )
+
+    full_root, initial = _workspace(
+        tmp_path,
+        "student-1",
+        "student-2",
+        name="complete",
+    )
+    full_signal = _signal(
+        (("student-1", 1), ("student-2", 2)),
+        signal_set_id="signal-complete",
+    )
+    write_grouping_signal(full_root, full_signal)
+    created = create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            strategy="similar_signal",
+            signal_set_id=full_signal.signal_set_id,
+            dimension_id="collaboration-context",
+            expected_snapshot_revision=initial,
+            actor=_actor(),
+            target_group_count=1,
+        ),
+        workspace_root=full_root,
+    )
+    with pytest.raises(ConcordWorkflowValidationError, match="no missing"):
+        set_missing_signal_disposition(
+            SetMissingSignalDispositionRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="signal-plan",
+                disposition="leave_unassigned",
+                expected_snapshot_revision=created.mutation.commit.snapshot_revision,
+                actor=_actor(),
+            ),
+            workspace_root=full_root,
+        )
+
+
+def test_exact_core_digest_mismatch_fails_closed(tmp_path: Path) -> None:
+    root, _, _ = _partial_plan(tmp_path)
+    detail = _detail(root)
+    corrupted = replace(
+        detail.plan,
+        source_signal_set_digest="c" * 64,
+    )
+    commit_record_batch(
+        root,
+        ModuleWorkRef(
+            module_id="concord",
+            class_id="class-1",
+            work_id="activity-1",
+        ),
+        (corrupted,),
+        expected_snapshot_revision=detail.summary.snapshot_revision,
+    )
+    with pytest.raises(
+        ConcordWorkflowConflictError,
+        match="canonical digest",
+    ):
+        inspect_group_plan_missing_signal(
+            "class-1",
+            "activity-1",
+            "signal-plan",
+            workspace_root=root,
+        )
+
+
+def test_core_diagnostic_error_fails_through_exact_selection(tmp_path: Path) -> None:
+    root, revision = _workspace(
+        tmp_path,
+        "student-1",
+        "student-2",
+    )
+    invalid_signal = _signal(
+        (("student-1", 1), ("student-999", 2)),
+        signal_set_id="signal-invalid",
+    )
+    write_grouping_signal(root, invalid_signal)
+    digest = calculate_grouping_signal_digest(invalid_signal)
+    created = create_group_plan(
+        CreateGroupPlanRequest(
+            class_id="class-1",
+            activity_id="activity-1",
+            group_plan_id="signal-plan",
+            strategy="similar_signal",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            target_group_count=1,
+            source_signal_set_id=invalid_signal.signal_set_id,
+            source_signal_set_digest=digest,
+            source_signal_dimension_id="collaboration-context",
+        ),
+        workspace_root=root,
+    )
+    assert created.status == "draft"
+    with pytest.raises(
+        ConcordWorkflowValidationError,
+        match="unknown_student",
+    ):
+        inspect_group_plan_missing_signal(
+            "class-1",
+            "activity-1",
+            "signal-plan",
+            workspace_root=root,
+        )
+
+
+@pytest.mark.parametrize(
+    ("disposition", "seed", "message"),
+    (
+        ("bogus", None, "disposition must be"),
+        ("manual", "seed", "allowed only"),
+        ("leave_unassigned", "seed", "allowed only"),
+        ("random", None, "explicit seed"),
+    ),
+)
+def test_disposition_input_contract(
+    tmp_path: Path,
+    disposition: str,
+    seed: str | None,
+    message: str,
+) -> None:
+    root, revision, _ = _partial_plan(tmp_path)
+    with pytest.raises(ConcordWorkflowValidationError, match=message):
+        set_missing_signal_disposition(
+            SetMissingSignalDispositionRequest(
+                class_id="class-1",
+                activity_id="activity-1",
+                group_plan_id="signal-plan",
+                disposition=disposition,
+                random_seed=seed,
+                expected_snapshot_revision=revision,
+                actor=_actor(),
+            ),
+            workspace_root=root,
+        )

--- a/tests/test_group_plan_signal_lifecycle_issue54.py
+++ b/tests/test_group_plan_signal_lifecycle_issue54.py
@@ -426,7 +426,7 @@ def test_unresolved_signal_plan_may_preview_but_cannot_be_approved(
 
     with pytest.raises(
         ConcordWorkflowValidationError,
-        match="every roster student to be resolved",
+        match="explicit missing-signal disposition",
     ):
         approve_group_plan(
             ApproveGroupPlanRequest(


### PR DESCRIPTION
## Summary

Completes issue #55 by requiring an explicit teacher decision whenever a signal-backed GroupPlan includes roster students who are missing from the plan's exact bound Core grouping-signal dimension.

This change preserves the #54 signal proposal as-is and adds a planning-only disposition workflow before approval. Missing-signal students may now be handled explicitly by:

- manual placement;
- deterministic seeded random distribution; or
- deliberate visible non-assignment.

No path silently omits roster students, synthesizes bands, selects a newer signal, reruns the #54 planner, or creates canonical `Group` / `GroupMembership` state.

## What this adds

### Structured missing-signal disposition state

Adds signal-plan-only `GroupPlan` fields for:

- `missing_signal_disposition`;
- `missing_signal_random_seed`;
- `missing_signal_disposition_provenance`.

Supported dispositions are exactly:

- `manual`;
- `random`;
- `leave_unassigned`.

The existing `GroupPlan.seed` remains reserved for the independent `random` planning strategy.

### Exact Core missing-set authority

Missing coverage is re-derived from the GroupPlan's frozen:

- signal-set ID;
- canonical signal digest;
- signal dimension.

Concord reuses the existing grouping-signal selector and Core diagnostics, accepting only matching `missing_student_signal` findings.

The workflow fails closed on:

- unavailable or corrupt signal data;
- missing dimensions;
- canonical-digest mismatch;
- diagnostics failure;
- roster drift.

Concord does not persist a duplicate missing-student set and does not implement a second diagnostics engine.

### Manual disposition

Teachers may use the existing GroupPlan editor to place missing-signal students and then explicitly confirm `manual`.

Confirmation requires every currently missing-signal student to have already been placed.

Manual placement alone does not silently establish the disposition.

### Deterministic missing-only random distribution

Adds seeded deterministic distribution for currently unresolved missing-signal students.

The ranking domain is:

```text
pds-concord:group-plan-missing-signal-random:v1
```

Each missing student is ranked from SHA-256 of the versioned domain, explicit seed, and student ID. Students are then assigned sequentially to the currently smallest existing `PlannedGroup`, with `planned_group_key` as the deterministic tie-breaker.

The operation:

- requires an explicit nonblank seed;
- affects only exact current missing-signal students;
- preserves represented-student placements;
- does not rerun the #54 similar/mixed planner;
- does not create new groups;
- uses no Python `random`, process hash, UUID, clock, or filesystem ordering.

### Deliberate leave-unassigned disposition

Teachers may explicitly choose `leave_unassigned`.

Those students:

- remain in the roster;
- remain visibly unresolved;
- receive no synthetic or inferred signal band;
- receive no placeholder membership.

### Lifecycle and approval integration

Ordinary GroupPlan edits preserve the current missing-signal disposition.

Explicit roster refresh invalidates the disposition and its seed/provenance because the missing population may have changed, while preserving the frozen signal binding and still-valid placements.

Any disposition mutation returns a previously previewed plan to `draft`, requiring a fresh preview.

Signal-backed approval now revalidates the exact Core signal binding and current missing set.

Approval rules are:

- no current missing students: no disposition required, but unresolved students are forbidden;
- `manual`: unresolved students are forbidden;
- `random`: unresolved students are forbidden and the separate random seed/provenance must be present;
- `leave_unassigned`: the unresolved set must exactly equal Core's current missing-signal set.

`leave_unassigned` is the only approved-plan exception that permits unresolved students.

Non-signal GroupPlan approval behavior is unchanged.

### CLI

Adds:

```text
concord group-plan confirm-missing-manual
concord group-plan distribute-missing-random
concord group-plan leave-missing-unassigned
```

These commands use the signal identity already frozen into the GroupPlan and do not accept signal-selection arguments.

The random command requires `--seed`.

Output remains planning-bounded and reports that canonical Groups were not created.

### Teacher menu

Signal-backed GroupPlans now expose:

```text
Resolve missing-signal students
```

The menu shows the exact signal binding, roster count, missing count/IDs, and unresolved count without displaying student bands.

The random path provides an in-memory preview before persistence showing:

- affected student count;
- seed;
- current and resulting group sizes;
- resulting affected student-to-group placements.

All disposition paths require explicit confirmation.

### Privacy and ownership boundaries

Adds regression coverage preventing #55 planning state from leaking into:

- `GroupMembership`;
- publication/academic-result surfaces;
- Artifact metadata;
- review/moderation/scoring surfaces;
- routing surfaces.

No Meridian runtime dependency is introduced.

Issue #55 stops at an approved `GroupPlan`. Canonical `Group` / `GroupMembership` application remains reserved for issue #56.

## Documentation

Adds:

- `docs/v0.3.0-missing-signal-disposition.md`

Updates:

- `README.md`;
- `docs/README.md`;
- `docs/cli-contract.md`;
- `docs/v0.3.0-group-plan-contract.md`;
- `docs/v0.3.0-grouping-signal-workflows.md`;
- `docs/v0.3.0-signal-group-planning.md`;
- `CHANGELOG.md`;
- documentation validation coverage.

## Validation

Qualified against `pds-core` v0.6.1.

Results:

- `816 passed, 9 skipped`;
- Ruff: clean;
- mypy: clean across 117 source files;
- documentation validation: clean;
- release compatibility validation: clean;
- package build and release-artifact checks: clean;
- installed-wheel smoke test: clean;
- installed producer acceptance: clean;
- `git diff --check`: clean.

The nine skips are expected platform-specific Windows/POSIX symlink and race-regression cases.

Closes #55