### PR TITLE
feat: define immutable Template contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Public immutable reusable `TemplateDefinition` / `TemplateVersion` contracts
+  with typed page manifests, rendering-input declarations, response regions,
+  identity-free privacy/authorship/Subject expectations and compatibility,
+  exact rendering-specification SHA-256 binding, and explicit separation from
+  Activity-native storage until #58.
+- Shared Activity/Artifact category, scoring-orientation, page-kind, return, and
+  authorship vocabularies now back both operational Artifact models and reusable
+  Template validation, preventing contract drift.
+
 - Exact approved-GroupPlan application preparation and atomic application,
   including deterministic application-bound Group/Membership IDs, semantic
   preview digests, exact snapshot/roster/signal revalidation, explicit fallback

--- a/README.md
+++ b/README.md
@@ -21,8 +21,13 @@ full-roster target semantics, explicit unresolved missing coverage, and no Merid
 runtime dependency. Issue #55 adds explicit manual/random/leave-unassigned missing-signal
 decisions with exact Core revalidation. Issue #56 now adds read-only exact
 application previews plus digest/snapshot-bound atomic application of approved
-plans to native Group/GroupMembership state. The same typed service layer supports a fully
-noninteractive direct CLI and a teacher-facing low-information-density menu.
+plans to native Group/GroupMembership state. Issue #57 now also defines public
+immutable reusable Template Definition/Version contracts with typed page
+manifests, rendering inputs, response regions, identity-free defaults and
+compatibility, and exact rendering-source SHA-256 binding. Templates are not yet
+a persisted/manageable library; canonical storage and revision workflows remain
+#58. The same typed service layer supports a fully noninteractive direct CLI and
+a teacher-facing low-information-density menu.
 Canonical state remains protected by immutable history, exact expected-snapshot
 concurrency, and guarded batch commits.
 

--- a/concord/models/__init__.py
+++ b/concord/models/__init__.py
@@ -43,6 +43,16 @@ from concord.models.scoring import (
     ScoringScale,
     ScoringScaleLevel,
 )
+from concord.models.templates import (
+    TemplateAuthorshipExpectation,
+    TemplateCompatibility,
+    TemplateDefinition,
+    TemplatePageDefinition,
+    TemplateRenderingInput,
+    TemplateResponseRegion,
+    TemplateSubjectExpectation,
+    TemplateVersion,
+)
 
 __all__ = [
     "Activity",
@@ -82,4 +92,12 @@ __all__ = [
     "Session",
     "StatusReason",
     "SubjectReference",
+    "TemplateAuthorshipExpectation",
+    "TemplateCompatibility",
+    "TemplateDefinition",
+    "TemplatePageDefinition",
+    "TemplateRenderingInput",
+    "TemplateResponseRegion",
+    "TemplateSubjectExpectation",
+    "TemplateVersion",
 ]

--- a/concord/models/artifacts.py
+++ b/concord/models/artifacts.py
@@ -27,6 +27,43 @@ from concord.models.common import (
     tuple_of_identifiers,
 )
 
+ARTIFACT_CATEGORIES = frozenset(
+    {
+        "student_work",
+        "observation",
+        "discussion_record",
+        "laboratory_record",
+        "project_record",
+    }
+)
+ARTIFACT_EXPECTED_RETURN_STATUSES = frozenset(
+    {"returned_expected", "returned_optional", "return_not_expected"}
+)
+ARTIFACT_PAGE_KINDS = frozenset(
+    {
+        "primary",
+        "continuation",
+        "rubric",
+        "cover",
+        "instructional",
+        "observation",
+        "attachment_label",
+    }
+)
+AUTHORSHIP_MODES = frozenset(
+    {
+        "individual_author",
+        "co_author",
+        "observer",
+        "recorder",
+        "recorder_for_group",
+        "collective_group_author",
+        "teacher_author",
+        "authorized_adult_author",
+        "unknown",
+    }
+)
+
 
 @dataclass(frozen=True, slots=True, kw_only=True)
 class ArtifactInstance:
@@ -58,15 +95,7 @@ class ArtifactInstance:
         controlled_key(
             self.artifact_category,
             "artifact_category",
-            frozenset(
-                {
-                    "student_work",
-                    "observation",
-                    "discussion_record",
-                    "laboratory_record",
-                    "project_record",
-                }
-            ),
+            ARTIFACT_CATEGORIES,
         )
         controlled(
             self.generation_status,
@@ -76,9 +105,7 @@ class ArtifactInstance:
         controlled(
             self.expected_return_status,
             "expected_return_status",
-            frozenset(
-                {"returned_expected", "returned_optional", "return_not_expected"}
-            ),
+            ARTIFACT_EXPECTED_RETURN_STATUSES,
         )
         controlled(
             self.artifact_status,
@@ -133,17 +160,7 @@ class ArtifactPage:
         controlled_key(
             self.page_kind,
             "page_kind",
-            frozenset(
-                {
-                    "primary",
-                    "continuation",
-                    "rubric",
-                    "cover",
-                    "instructional",
-                    "observation",
-                    "attachment_label",
-                }
-            ),
+            ARTIFACT_PAGE_KINDS,
         )
         require_bool(self.return_expected, "return_expected")
         require_bool(self.route_required, "route_required")
@@ -276,19 +293,7 @@ class ArtifactAuthor:
         controlled(
             self.authorship_mode,
             "authorship_mode",
-            frozenset(
-                {
-                    "individual_author",
-                    "co_author",
-                    "observer",
-                    "recorder",
-                    "recorder_for_group",
-                    "collective_group_author",
-                    "teacher_author",
-                    "authorized_adult_author",
-                    "unknown",
-                }
-            ),
+            AUTHORSHIP_MODES,
         )
         controlled(
             self.attribution_status,

--- a/concord/models/collaboration.py
+++ b/concord/models/collaboration.py
@@ -28,6 +28,11 @@ from concord.models.common import (
     tuple_of_identifiers,
 )
 
+ACTIVITY_TYPES = frozenset({"socratic_seminar", "laboratory", "project"})
+SCORING_ORIENTATIONS = frozenset(
+    {"evidence_only", "standards_based", "mixed", "local_criteria_only"}
+)
+
 ASSIGNMENT_STATUSES = frozenset(
     {
         "planned",
@@ -71,14 +76,12 @@ class Activity:
         controlled_key(
             self.activity_type,
             "activity_type",
-            frozenset({"socratic_seminar", "laboratory", "project"}),
+            ACTIVITY_TYPES,
         )
         orientation = controlled(
             self.scoring_orientation,
             "scoring_orientation",
-            frozenset(
-                {"evidence_only", "standards_based", "mixed", "local_criteria_only"}
-            ),
+            SCORING_ORIENTATIONS,
         )
         controlled(
             self.status,

--- a/concord/models/templates.py
+++ b/concord/models/templates.py
@@ -1,0 +1,550 @@
+"""Typed reusable Template Definition contracts for Concord v0.3."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from concord.models.artifacts import (
+    ARTIFACT_CATEGORIES,
+    ARTIFACT_EXPECTED_RETURN_STATUSES,
+    ARTIFACT_PAGE_KINDS,
+    AUTHORSHIP_MODES,
+)
+from concord.models.collaboration import ACTIVITY_TYPES, SCORING_ORIENTATIONS
+from concord.models.common import (
+    ActorReference,
+    ConcordModelError,
+    PrivacyPolicy,
+    Provenance,
+    controlled,
+    controlled_key,
+    identifier,
+    optional_identifier,
+    optional_positive_int,
+    optional_text,
+    positive_int,
+    require_bool,
+    require_text,
+    tuple_of_identifiers,
+    tuple_of_values,
+)
+
+TEMPLATE_DEFINITION_STATUSES = frozenset({"draft", "active", "retired"})
+TEMPLATE_VERSION_STATUSES = frozenset({"draft", "active", "retired", "superseded"})
+TEMPLATE_RENDERING_INPUT_SOURCES = frozenset(
+    {
+        "teacher_text",
+        "activity_title",
+        "session_label",
+        "group_label",
+        "participant_display_label",
+        "current_date",
+        "criterion_label",
+        "pds2_route_payload",
+        "human_fallback",
+    }
+)
+TEMPLATE_RENDERING_VALUE_KINDS = frozenset(
+    {"text", "multiline_text", "integer", "boolean", "date"}
+)
+TEMPLATE_RESPONSE_REGION_KINDS = frozenset(
+    {
+        "free_response",
+        "structured_entry",
+        "selection",
+        "table",
+        "drawing",
+        "annotation",
+        "teacher_observation",
+    }
+)
+TEMPLATE_AUDIENCE_KINDS = frozenset({"activity", "group", "participant", "teacher"})
+TEMPLATE_CRITERION_KINDS = frozenset({"standard_backed", "local"})
+TEMPLATE_SUBJECT_KINDS = frozenset(
+    {
+        "core_student",
+        "concord_group",
+        "concord_session",
+        "concord_activity",
+        "external_record",
+    }
+)
+TEMPLATE_DIRECT_PRIVACY_CLASSIFICATIONS = frozenset(
+    {
+        "teacher_restricted",
+        "teacher_and_subjects",
+        "group_and_teacher",
+        "classroom_shared",
+    }
+)
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _controlled_tuple(
+    value: Iterable[str],
+    field_name: str,
+    allowed: frozenset[str],
+    *,
+    allow_extensions: bool = False,
+) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)):
+        raise ConcordModelError(f"{field_name} must be an iterable.")
+    try:
+        values = tuple(value)
+    except TypeError as error:
+        raise ConcordModelError(f"{field_name} must be iterable.") from error
+    normalized = tuple(
+        (
+            controlled_key(item, f"{field_name}[{index}]", allowed)
+            if allow_extensions
+            else controlled(item, f"{field_name}[{index}]", allowed)
+        )
+        for index, item in enumerate(values)
+    )
+    if len(set(normalized)) != len(normalized):
+        raise ConcordModelError(f"{field_name} must not contain duplicates.")
+    return tuple(sorted(normalized))
+
+
+def _sha256(value: object, field_name: str) -> str:
+    if not isinstance(value, str) or _SHA256.fullmatch(value) is None:
+        raise ConcordModelError(
+            f"{field_name} must be a lowercase 64-character SHA-256 digest."
+        )
+    return value
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TemplateRenderingInput:
+    """One reusable declaration for a value bound only during generation."""
+
+    input_key: str
+    label: str
+    source_kind: str
+    value_kind: str
+    required: bool
+    description: str | None = None
+    max_length: int | None = None
+
+    def __post_init__(self) -> None:
+        identifier(self.input_key, "input_key")
+        require_text(self.label, "label")
+        controlled_key(
+            self.source_kind,
+            "source_kind",
+            TEMPLATE_RENDERING_INPUT_SOURCES,
+        )
+        controlled(
+            self.value_kind,
+            "value_kind",
+            TEMPLATE_RENDERING_VALUE_KINDS,
+        )
+        require_bool(self.required, "required")
+        optional_text(self.description, "description")
+        maximum = optional_positive_int(self.max_length, "max_length")
+        if maximum is not None and self.value_kind not in {"text", "multiline_text"}:
+            raise ConcordModelError(
+                "max_length is permitted only for text rendering inputs."
+            )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TemplateResponseRegion:
+    """One semantic printable evidence-capture region."""
+
+    region_key: str
+    label: str
+    region_kind: str
+    required: bool
+    description: str | None = None
+
+    def __post_init__(self) -> None:
+        identifier(self.region_key, "region_key")
+        require_text(self.label, "label")
+        controlled_key(
+            self.region_kind,
+            "region_kind",
+            TEMPLATE_RESPONSE_REGION_KINDS,
+        )
+        require_bool(self.required, "required")
+        optional_text(self.description, "description")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TemplatePageDefinition:
+    """One reusable page declaration; never a generated ArtifactPage."""
+
+    page_key: str
+    sequence: int
+    page_kind: str
+    return_expected: bool
+    route_required: bool
+    rendering_input_keys: tuple[str, ...] = ()
+    response_regions: tuple[TemplateResponseRegion, ...] = ()
+    label: str | None = None
+    route_payload_input_key: str | None = None
+    human_fallback_input_key: str | None = None
+
+    def __post_init__(self) -> None:
+        identifier(self.page_key, "page_key")
+        positive_int(self.sequence, "sequence")
+        controlled_key(self.page_kind, "page_kind", ARTIFACT_PAGE_KINDS)
+        require_bool(self.return_expected, "return_expected")
+        require_bool(self.route_required, "route_required")
+        object.__setattr__(
+            self,
+            "rendering_input_keys",
+            tuple_of_identifiers(
+                self.rendering_input_keys,
+                "rendering_input_keys",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "response_regions",
+            tuple_of_values(
+                self.response_regions,
+                TemplateResponseRegion,
+                "response_regions",
+            ),
+        )
+        optional_text(self.label, "label")
+        optional_identifier(self.route_payload_input_key, "route_payload_input_key")
+        optional_identifier(self.human_fallback_input_key, "human_fallback_input_key")
+
+        region_keys = tuple(item.region_key for item in self.response_regions)
+        if len(set(region_keys)) != len(region_keys):
+            raise ConcordModelError(
+                "response_regions must not duplicate region_key within one page."
+            )
+
+        if self.route_required:
+            if not self.return_expected:
+                raise ConcordModelError(
+                    "route-required Template pages must be expected to return."
+                )
+            if (
+                self.route_payload_input_key is None
+                or self.human_fallback_input_key is None
+            ):
+                raise ConcordModelError(
+                    "route-required Template pages require route payload and "
+                    "human-fallback rendering input keys."
+                )
+            for key in (
+                self.route_payload_input_key,
+                self.human_fallback_input_key,
+            ):
+                if key not in self.rendering_input_keys:
+                    raise ConcordModelError(
+                        "route rendering input keys must appear in "
+                        "rendering_input_keys."
+                    )
+        elif (
+            self.route_payload_input_key is not None
+            or self.human_fallback_input_key is not None
+        ):
+            raise ConcordModelError(
+                "non-route Template pages must not declare route rendering slots."
+            )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TemplateAuthorshipExpectation:
+    """Reusable authorship expectation, never an ArtifactAuthor association."""
+
+    authorship_mode: str
+    required: bool = True
+    multiple_allowed: bool = False
+
+    def __post_init__(self) -> None:
+        controlled(self.authorship_mode, "authorship_mode", AUTHORSHIP_MODES)
+        require_bool(self.required, "required")
+        require_bool(self.multiple_allowed, "multiple_allowed")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TemplateSubjectExpectation:
+    """Reusable Subject-kind expectation without a concrete Subject identity."""
+
+    subject_kind: str
+    required: bool = True
+    multiple_allowed: bool = False
+
+    def __post_init__(self) -> None:
+        controlled(self.subject_kind, "subject_kind", TEMPLATE_SUBJECT_KINDS)
+        require_bool(self.required, "required")
+        require_bool(self.multiple_allowed, "multiple_allowed")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TemplateCompatibility:
+    """Identity-free compatibility guidance for later Template selection."""
+
+    audience_kinds: tuple[str, ...] = ()
+    activity_type_keys: tuple[str, ...] = ()
+    scoring_orientations: tuple[str, ...] = ()
+    criterion_kinds: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "audience_kinds",
+            _controlled_tuple(
+                self.audience_kinds,
+                "audience_kinds",
+                TEMPLATE_AUDIENCE_KINDS,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "activity_type_keys",
+            _controlled_tuple(
+                self.activity_type_keys,
+                "activity_type_keys",
+                ACTIVITY_TYPES,
+                allow_extensions=True,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "scoring_orientations",
+            _controlled_tuple(
+                self.scoring_orientations,
+                "scoring_orientations",
+                SCORING_ORIENTATIONS,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "criterion_kinds",
+            _controlled_tuple(
+                self.criterion_kinds,
+                "criterion_kinds",
+                TEMPLATE_CRITERION_KINDS,
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TemplateDefinition:
+    """Stable reusable lineage identity for one printable design."""
+
+    template_id: str
+    name: str
+    purpose: str
+    artifact_category: str
+    status: str
+    created_provenance: Provenance
+    description: str | None = None
+    owner_reference: ActorReference | None = None
+
+    def __post_init__(self) -> None:
+        identifier(self.template_id, "template_id")
+        require_text(self.name, "name")
+        require_text(self.purpose, "purpose")
+        controlled_key(
+            self.artifact_category,
+            "artifact_category",
+            ARTIFACT_CATEGORIES,
+        )
+        controlled(self.status, "status", TEMPLATE_DEFINITION_STATUSES)
+        if not isinstance(self.created_provenance, Provenance):
+            raise ConcordModelError("created_provenance must be Provenance.")
+        optional_text(self.description, "description")
+        if self.owner_reference is not None:
+            if not isinstance(self.owner_reference, ActorReference):
+                raise ConcordModelError("owner_reference must be an ActorReference.")
+            if self.owner_reference.actor_kind == "core_student":
+                raise ConcordModelError(
+                    "reusable Template ownership must not embed a Core student."
+                )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class TemplateVersion:
+    """One exact immutable printable revision of a Template Definition."""
+
+    template_version_id: str
+    template_id: str
+    version_label: str
+    revision_sequence: int
+    rendering_contract_version: str
+    rendering_specification_reference: str
+    rendering_specification_sha256: str
+    artifact_category: str
+    page_manifest: tuple[TemplatePageDefinition, ...]
+    rendering_inputs: tuple[TemplateRenderingInput, ...]
+    default_expected_return_status: str
+    default_privacy_policy: PrivacyPolicy
+    compatibility: TemplateCompatibility
+    created_provenance: Provenance
+    status: str
+    supersedes_template_version_id: str | None = None
+    default_authorship_expectation: TemplateAuthorshipExpectation | None = None
+    default_subject_expectation: TemplateSubjectExpectation | None = None
+
+    def __post_init__(self) -> None:
+        identifier(self.template_version_id, "template_version_id")
+        identifier(self.template_id, "template_id")
+        require_text(self.version_label, "version_label")
+        revision = positive_int(self.revision_sequence, "revision_sequence")
+        identifier(self.rendering_contract_version, "rendering_contract_version")
+        identifier(
+            self.rendering_specification_reference,
+            "rendering_specification_reference",
+        )
+        _sha256(
+            self.rendering_specification_sha256,
+            "rendering_specification_sha256",
+        )
+        controlled_key(
+            self.artifact_category,
+            "artifact_category",
+            ARTIFACT_CATEGORIES,
+        )
+        pages = tuple_of_values(
+            self.page_manifest,
+            TemplatePageDefinition,
+            "page_manifest",
+            nonempty=True,
+        )
+        pages = tuple(sorted(pages, key=lambda item: item.sequence))
+        object.__setattr__(self, "page_manifest", pages)
+        inputs = tuple_of_values(
+            self.rendering_inputs,
+            TemplateRenderingInput,
+            "rendering_inputs",
+        )
+        inputs = tuple(sorted(inputs, key=lambda item: item.input_key))
+        object.__setattr__(self, "rendering_inputs", inputs)
+        expected_return = controlled(
+            self.default_expected_return_status,
+            "default_expected_return_status",
+            ARTIFACT_EXPECTED_RETURN_STATUSES,
+        )
+        if not isinstance(self.default_privacy_policy, PrivacyPolicy):
+            raise ConcordModelError(
+                "default_privacy_policy must be a PrivacyPolicy."
+            )
+        if (
+            self.default_privacy_policy.classification
+            not in TEMPLATE_DIRECT_PRIVACY_CLASSIFICATIONS
+            or self.default_privacy_policy.audience_references
+            or self.default_privacy_policy.policy_reference is not None
+            or self.default_privacy_policy.inherited_from is not None
+        ):
+            raise ConcordModelError(
+                "Template privacy defaults must be identity-free direct "
+                "classifications."
+            )
+        if not isinstance(self.compatibility, TemplateCompatibility):
+            raise ConcordModelError(
+                "compatibility must be a TemplateCompatibility."
+            )
+        if not isinstance(self.created_provenance, Provenance):
+            raise ConcordModelError("created_provenance must be Provenance.")
+        controlled(self.status, "status", TEMPLATE_VERSION_STATUSES)
+        predecessor = optional_identifier(
+            self.supersedes_template_version_id,
+            "supersedes_template_version_id",
+        )
+        if revision == 1 and predecessor is not None:
+            raise ConcordModelError(
+                "the first Template Version must not supersede another version."
+            )
+        if revision > 1 and predecessor is None:
+            raise ConcordModelError(
+                "successor Template Versions require "
+                "supersedes_template_version_id."
+            )
+        if predecessor == self.template_version_id:
+            raise ConcordModelError("a Template Version cannot supersede itself.")
+        if (
+            self.default_authorship_expectation is not None
+            and not isinstance(
+                self.default_authorship_expectation,
+                TemplateAuthorshipExpectation,
+            )
+        ):
+            raise ConcordModelError(
+                "default_authorship_expectation is invalid."
+            )
+        if (
+            self.default_subject_expectation is not None
+            and not isinstance(
+                self.default_subject_expectation,
+                TemplateSubjectExpectation,
+            )
+        ):
+            raise ConcordModelError("default_subject_expectation is invalid.")
+
+        page_keys = tuple(item.page_key for item in pages)
+        if len(set(page_keys)) != len(page_keys):
+            raise ConcordModelError("page_manifest must not duplicate page_key.")
+        sequences = tuple(item.sequence for item in pages)
+        if sequences != tuple(range(1, len(pages) + 1)):
+            raise ConcordModelError(
+                "page_manifest sequences must form contiguous 1..N order."
+            )
+
+        input_by_key = {item.input_key: item for item in inputs}
+        if len(input_by_key) != len(inputs):
+            raise ConcordModelError(
+                "rendering_inputs must not duplicate input_key."
+            )
+        region_keys: list[str] = []
+        for page in pages:
+            unknown = sorted(set(page.rendering_input_keys) - set(input_by_key))
+            if unknown:
+                raise ConcordModelError(
+                    "Template page references undeclared rendering input(s): "
+                    + ", ".join(unknown)
+                    + "."
+                )
+            region_keys.extend(item.region_key for item in page.response_regions)
+            if page.route_required:
+                assert page.route_payload_input_key is not None
+                assert page.human_fallback_input_key is not None
+                route_input = input_by_key[page.route_payload_input_key]
+                fallback_input = input_by_key[page.human_fallback_input_key]
+                if route_input.source_kind != "pds2_route_payload":
+                    raise ConcordModelError(
+                        "route_payload_input_key must reference a "
+                        "pds2_route_payload input."
+                    )
+                if fallback_input.source_kind != "human_fallback":
+                    raise ConcordModelError(
+                        "human_fallback_input_key must reference a "
+                        "human_fallback input."
+                    )
+        if len(set(region_keys)) != len(region_keys):
+            raise ConcordModelError(
+                "response region keys must be unique within one Template Version."
+            )
+
+        any_return = any(page.return_expected for page in pages)
+        if expected_return == "return_not_expected" and any_return:
+            raise ConcordModelError(
+                "return_not_expected Template Versions cannot contain "
+                "return-expected pages."
+            )
+        if expected_return != "return_not_expected" and not any_return:
+            raise ConcordModelError(
+                "returnable Template Versions require at least one "
+                "return-expected page."
+            )
+
+
+__all__ = [
+    "TemplateAuthorshipExpectation",
+    "TemplateCompatibility",
+    "TemplateDefinition",
+    "TemplatePageDefinition",
+    "TemplateRenderingInput",
+    "TemplateResponseRegion",
+    "TemplateSubjectExpectation",
+    "TemplateVersion",
+]

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,7 +37,11 @@ Issue #55 implements explicit manual/random/leave-unassigned missing-signal
 decisions and approval revalidation. Issue #56 now implements exact read-only
 application preparation, deterministic canonical identity derivation, digest- and
 snapshot-bound atomic Group/GroupMembership application, and the terminal
-`approved -> applied` GroupPlan transition.
+`approved -> applied` GroupPlan transition. Issue #57 now defines the public,
+immutable, cross-Activity reusable Template Definition/Version contract,
+including typed page manifests, rendering-input declarations, response regions,
+identity-free defaults/compatibility, and exact rendering-specification digest
+binding; canonical Template storage and revision workflows remain #58.
 
 The repository now contains:
 
@@ -75,6 +79,10 @@ The repository now contains:
   of canonical Groups/Memberships and the terminal applied GroupPlan revision,
   with deterministic IDs, explicit fallback context, stale/digest rejection, and
   no signal-band leakage into operational records;
+* public immutable reusable Template Definition/Version contracts with typed
+  page manifests, rendering inputs, response regions, privacy/authorship/subject
+  defaults, compatibility metadata, exact rendering-source integrity binding,
+  and no Activity-native persistence before #58;
 * contextual Membership, Role, and Responsibility workflow services;
 * a fully noninteractive direct CLI;
 * a teacher-facing H/B/M/Q menu with low-information-density screens;
@@ -219,14 +227,24 @@ revalidation, explicit Membership fallback context, empty-group and
 leave-unassigned behavior, one-batch application, terminal applied metadata,
 privacy exclusions, direct CLI commands, and teacher `APPLY` confirmation.
 
+### 33. v0.3.0 immutable Template Definition contract
+
+[`v0.3.0-template-definition-contract.md`](v0.3.0-template-definition-contract.md)
+
+Documents issue #57's stable Template lineage, exact immutable Template Version,
+typed page/rendering-input/response-region contracts, identity-free privacy and
+authorship/Subject expectations, compatibility metadata, rendering-source
+SHA-256 binding, existing Artifact compatibility, grouping-signal exclusions,
+and the deliberate #58 storage/revision handoff.
+
 ### Future v0.3.0 Group Planning / Template / Packet plan
 
 [`pds-group-planning-interoperability-development-plan.md`](pds-group-planning-interoperability-development-plan.md)
 
 This remains the roadmap for future v0.3.0 issues beyond the implemented
-#48-#56 foundations. It does not make later Template, Packet, guided Activity setup,
-or final integrated teacher UI behavior implemented merely because their contracts
-are documented.
+#48-#57 foundations. Issue #57 now implements the reusable Template contract
+itself, but it does not make #58 Template storage/management, Packet workflows,
+guided Activity setup, or final integrated teacher UI behavior implemented.
 
 ### 14. PDS2 Artifact Page integration
 

--- a/docs/v0.3.0-template-definition-contract.md
+++ b/docs/v0.3.0-template-definition-contract.md
@@ -1,0 +1,881 @@
+# Concord v0.3.0 immutable Template Definition contract
+
+**Issue:** #57 — Define immutable Template Definition contracts
+**Umbrella:** #47 — v0.3.0 Group Planning, Templates, Packets, and Guided Setup
+**Development version:** `pds-concord 0.3.0.dev0`
+**Core requirement:** `pds-core>=0.6.1,<0.7`
+**Status:** Contract implemented; canonical storage and revision workflows remain #58
+
+## 1. Purpose
+
+This document defines Concord's reusable Template contract boundary for v0.3.0.
+
+The reusable-to-operational direction is:
+
+```text
+Template Definition
+    -> exact immutable Template Version
+        -> later Activity-specific generation
+            -> fresh Artifact Instance
+                -> fresh Artifact Page(s)
+                    -> fresh Core PDS2 route(s)
+```
+
+The reverse direction is prohibited:
+
+```text
+existing Activity / Artifact / Page / route / Score history
+    -X-> reusable Template state
+```
+
+A Template describes a reusable printable design. It does not describe one
+specific classroom use of that design.
+
+## 2. Current runtime boundary
+
+Before #57, Concord already had:
+
+- native Activity, Session, Group, GroupMembership, and GroupPlan records;
+- native ArtifactInstance and ArtifactPage records;
+- a required opaque `ArtifactInstance.template_version_id` field;
+- generic PDS2 Artifact Page preparation and rendering;
+- immutable Activity-work record history and exact work snapshots.
+
+That existing `template_version_id` field did not resolve through a Template
+registry, and the generic renderer did not load a reusable Template Version.
+
+Issue #57 adds public immutable typed Template contracts. It deliberately does
+not add Template Definition or Template Version to the Activity-scoped native
+record registry.
+
+The canonical Template storage and revision workflows remain #58. Current
+selection, activation, retirement, and reusable rendering-asset storage are also
+deferred to #58.
+
+Therefore:
+
+```text
+Template contract implemented
+!=
+Template library/storage workflow implemented
+```
+
+## 3. Ownership
+
+Concord owns:
+
+- Template lineage semantics;
+- exact Template Version semantics;
+- reusable page manifests;
+- rendering-input declarations;
+- response-region declarations;
+- reusable privacy defaults;
+- authorship and Subject expectations;
+- identity-free compatibility metadata;
+- exact rendering-specification integrity binding;
+- later Template storage and revision workflows;
+- later Packet composition and Activity-specific generation.
+
+Core remains authoritative for:
+
+- workspace and safe-path behavior;
+- identifiers;
+- class and student identity;
+- PDS2 grammar;
+- Route Registrations;
+- retained scan ownership;
+- standards;
+- Academic Work Registration;
+- Publication Records;
+- `grouping_signal_set_v1`.
+
+Templates do not duplicate those authorities.
+
+## 4. Public contract surface
+
+Issue #57 exposes immutable value types through `concord.models`:
+
+```text
+TemplateDefinition
+TemplateVersion
+TemplatePageDefinition
+TemplateRenderingInput
+TemplateResponseRegion
+TemplateCompatibility
+TemplateAuthorshipExpectation
+TemplateSubjectExpectation
+```
+
+These types are pure reusable-definition contracts.
+
+They are not registered Activity-native records in #57.
+
+## 5. Template Definition
+
+A `TemplateDefinition` is the stable lineage of one reusable printable design.
+
+Its contract contains:
+
+```text
+template_id
+name
+purpose
+artifact_category
+status
+created_provenance
+description             optional
+owner_reference         optional
+```
+
+### 5.1 Stable lineage identity
+
+`template_id` remains stable while printable revisions change.
+
+It is not:
+
+```text
+template_version_id
+artifact_instance_id
+artifact_page_id
+route_id
+activity_id
+```
+
+A display name may change without changing lineage identity.
+
+### 5.2 Artifact category
+
+Template definitions reuse the same controlled Artifact-category vocabulary as
+`ArtifactInstance`.
+
+The built-in categories currently include:
+
+```text
+student_work
+observation
+discussion_record
+laboratory_record
+project_record
+```
+
+Namespace-qualified extension behavior follows Concord's existing controlled-key
+policy.
+
+The Template subsystem must not create a second incompatible category vocabulary.
+
+### 5.3 Definition lifecycle
+
+The contract supports:
+
+```text
+draft
+active
+retired
+```
+
+These states describe availability of a reusable lineage.
+
+They do not describe generated Artifact state.
+
+### 5.4 Owner/source metadata
+
+`owner_reference`, when present, is reusable creator/source metadata.
+
+A Core student cannot be embedded as reusable Template ownership.
+
+Creation provenance remains separate.
+
+## 6. Template Version
+
+A `TemplateVersion` is one exact printable revision of one Template Definition.
+
+Its contract contains:
+
+```text
+template_version_id
+template_id
+version_label
+revision_sequence
+rendering_contract_version
+rendering_specification_reference
+rendering_specification_sha256
+artifact_category
+page_manifest
+rendering_inputs
+default_expected_return_status
+default_privacy_policy
+compatibility
+created_provenance
+status
+supersedes_template_version_id      optional
+default_authorship_expectation      optional
+default_subject_expectation         optional
+```
+
+### 6.1 Version identity
+
+`template_version_id` identifies one exact immutable revision.
+
+`template_id` identifies the parent lineage.
+
+`version_label` is display text only.
+
+`revision_sequence` is the explicit positive lineage order.
+
+A first revision has:
+
+```text
+revision_sequence = 1
+supersedes_template_version_id = None
+```
+
+A successor has:
+
+```text
+revision_sequence > 1
+supersedes_template_version_id = <exact predecessor>
+```
+
+Cross-record enforcement that the predecessor belongs to the same lineage and is
+the unique current head belongs to #58.
+
+### 6.2 Version lifecycle
+
+The contract supports:
+
+```text
+draft
+active
+retired
+superseded
+```
+
+Retirement or supersession does not invalidate historical Artifact Instances that
+already reference the exact version.
+
+## 7. Semantic immutability
+
+Printable meaning is versioned state.
+
+Changing any of the following requires a new Template Version after the version
+is in use:
+
+- rendering specification;
+- rendering-source digest;
+- static wording/content represented by that specification;
+- page structure or order;
+- rendering-input declarations;
+- response-region declarations;
+- page kinds;
+- return behavior;
+- route requirements;
+- Artifact category;
+- privacy default;
+- authorship expectation;
+- Subject expectation;
+- compatibility metadata.
+
+A lifecycle transition is not permission to rewrite printable meaning.
+
+#58 owns persisted transition enforcement.
+
+## 8. Rendering specification integrity
+
+A Template Version binds its rendering source through:
+
+```text
+rendering_contract_version
+rendering_specification_reference
+rendering_specification_sha256
+```
+
+The digest is exact lowercase SHA-256.
+
+The reference is an opaque identifier for a reusable rendering asset, not an
+absolute machine path and not a mutable alias such as `latest`.
+
+The Template contract does not execute arbitrary code.
+
+#58 owns safe reusable rendering-asset storage/resolution.
+
+Later rendering work owns actual interpretation of the bounded rendering
+contract.
+
+## 9. Rendering inputs
+
+`TemplateRenderingInput` declares a value that will be bound only during later
+generation.
+
+Fields are:
+
+```text
+input_key
+label
+source_kind
+value_kind
+required
+description          optional
+max_length           optional
+```
+
+Built-in source kinds are:
+
+```text
+teacher_text
+activity_title
+session_label
+group_label
+participant_display_label
+current_date
+criterion_label
+pds2_route_payload
+human_fallback
+```
+
+Built-in value kinds are:
+
+```text
+text
+multiline_text
+integer
+boolean
+date
+```
+
+Namespace-qualified input-source extensions may use Concord's controlled-key
+extension policy.
+
+There is no generic expression, Python, shell, JavaScript, object traversal, or
+callable input source.
+
+### 9.1 Declaration versus bound value
+
+A reusable Template may declare:
+
+```text
+group_label
+```
+
+as a required source kind.
+
+It must not persist:
+
+```text
+Group 3
+```
+
+as reusable target context.
+
+Likewise, `pds2_route_payload` declares that generation must supply a route
+payload. It is not a persisted route ID or serialized locator.
+
+## 10. Page manifest
+
+`TemplatePageDefinition` declares one reusable logical page.
+
+Fields are:
+
+```text
+page_key
+sequence
+page_kind
+return_expected
+route_required
+rendering_input_keys
+response_regions
+label                         optional
+route_payload_input_key       optional/conditional
+human_fallback_input_key      optional/conditional
+```
+
+### 10.1 Page-local identity
+
+`page_key` is local to the reusable Template Version.
+
+It is not an `artifact_page_id`.
+
+Later generation creates a fresh Artifact Page identity.
+
+### 10.2 Deterministic order
+
+Page sequences are positive, unique, and canonicalized to contiguous:
+
+```text
+1..N
+```
+
+Tuple insertion order is not the sole durable ordering rule.
+
+### 10.3 Page-kind vocabulary
+
+Template pages reuse the native Artifact Page vocabulary:
+
+```text
+primary
+continuation
+rubric
+cover
+instructional
+observation
+attachment_label
+```
+
+plus namespace-qualified controlled extensions.
+
+### 10.4 Return and route behavior
+
+For v0.3:
+
+```text
+route_required -> return_expected
+```
+
+A route-required page must identify declared rendering inputs for:
+
+```text
+pds2_route_payload
+human_fallback
+```
+
+A non-route page must not declare route-specific binding slots.
+
+The Template stores route requirements, not concrete route state.
+
+## 11. PDS2 boundary
+
+The later generation sequence remains:
+
+```text
+exact Template Version
+    -> fresh Artifact Instance
+    -> fresh Artifact Page
+    -> fresh Core Route Registration
+    -> bind PDS2 payload + human fallback
+    -> render
+```
+
+A Template never stores:
+
+```text
+route_id
+RouteRegistration
+PDS2|m=concord|...
+```
+
+The Core route continues to target:
+
+```text
+record_kind = artifact_page
+```
+
+not a Template Definition or Template Version.
+
+## 12. Response regions
+
+`TemplateResponseRegion` identifies a semantic printable evidence-capture area.
+
+Fields are:
+
+```text
+region_key
+label
+region_kind
+required
+description          optional
+```
+
+Built-in region kinds are:
+
+```text
+free_response
+structured_entry
+selection
+table
+drawing
+annotation
+teacher_observation
+```
+
+Response-region keys are unique across one Template Version.
+
+A response region may later help provide a stable human/evidence locator.
+
+It does not itself create:
+
+- an EvidenceReference;
+- an Artifact Author;
+- an Artifact Subject;
+- a Score target;
+- a Score.
+
+`selection` does not imply OMR.
+
+`free_response` does not create a Quillan submission.
+
+#57 adds no OCR, OMR, or handwriting recognition.
+
+Physical geometry remains part of the exact rendering specification rather than
+being duplicated in this semantic contract.
+
+## 13. Artifact-level expected return
+
+Template Version reuses the existing Artifact expected-return vocabulary:
+
+```text
+returned_expected
+returned_optional
+return_not_expected
+```
+
+The page manifest independently declares which pages return.
+
+The contract rejects obvious contradictions:
+
+- `return_not_expected` cannot contain a return-expected page;
+- a returnable Artifact default requires at least one return-expected page.
+
+The eventual generated `ArtifactInstance` owns the effective operational return
+state.
+
+## 14. Privacy defaults
+
+A Template Version may carry an identity-free reusable default `PrivacyPolicy`.
+
+Allowed direct classifications are:
+
+```text
+teacher_restricted
+teacher_and_subjects
+group_and_teacher
+classroom_shared
+```
+
+Reusable Template privacy cannot contain concrete audience references,
+`inherited_from`, or an instance-bound external policy.
+
+This preserves:
+
+```text
+privacy default
+!=
+effective target-context privacy
+```
+
+#62 must resolve the effective Artifact privacy state and must not silently
+broaden a more restrictive target policy.
+
+## 15. Authorship expectation
+
+`TemplateAuthorshipExpectation` uses the native Concord authorship-mode vocabulary.
+
+Examples include:
+
+```text
+individual_author
+co_author
+recorder
+recorder_for_group
+collective_group_author
+teacher_author
+authorized_adult_author
+unknown
+```
+
+This says what kind of attribution is expected.
+
+It does not create or confirm an `ArtifactAuthor`.
+
+In particular:
+
+```text
+Template authorship expectation != ArtifactAuthor
+```
+
+## 16. Subject expectation
+
+`TemplateSubjectExpectation` declares reusable Subject kinds:
+
+```text
+core_student
+concord_group
+concord_session
+concord_activity
+external_record
+```
+
+It may declare whether a Subject is required and whether multiple Subjects are
+permitted.
+
+It stores no concrete Subject identity.
+
+Therefore:
+
+```text
+Template Subject expectation != ArtifactSubject
+```
+
+## 17. Compatibility
+
+`TemplateCompatibility` is identity-free selection guidance and validation input.
+
+It can constrain:
+
+```text
+audience_kinds
+activity_type_keys
+scoring_orientations
+criterion_kinds
+```
+
+### 17.1 Audience kinds
+
+Built-in audience kinds are:
+
+```text
+activity
+group
+participant
+teacher
+```
+
+They express generation intent, not a target identity.
+
+### 17.2 Activity types
+
+Template compatibility reuses Activity's controlled type vocabulary and extension
+policy.
+
+### 17.3 Scoring orientations
+
+Template compatibility reuses:
+
+```text
+evidence_only
+standards_based
+mixed
+local_criteria_only
+```
+
+Compatibility does not create Criteria or Scores.
+
+### 17.4 Criterion compatibility reconciliation
+
+The older conceptual contract mentioned:
+
+```text
+supported_criterion_ids
+```
+
+The #48 reusable-versus-instance audit established that current Criterion IDs are
+Activity-work scoped and cannot be blindly treated as global reusable identities.
+
+Therefore #57 deliberately narrows reusable Template compatibility to criterion
+kinds:
+
+```text
+standard_backed
+local
+```
+
+It does not persist current Activity-scoped `criterion_id` values.
+
+If #64 later introduces an explicit reusable Criterion authority, a future
+Template contract revision may add an exact reference to that authority.
+
+## 18. Reusable versus generated identity
+
+The following distinctions are normative:
+
+```text
+TemplateDefinition != TemplateVersion
+TemplateVersion != ArtifactInstance
+TemplatePageDefinition != ArtifactPage
+TemplateResponseRegion != Score
+Template audience intent != ArtifactAuthor
+Template Subject expectation != ArtifactSubject
+Template route requirement != RouteRegistration
+Template rendering input declaration != bound Activity value
+```
+
+Generated identities remain fresh.
+
+## 19. Existing Artifact compatibility
+
+The existing native `ArtifactInstance.template_version_id` remains an opaque
+identifier for historical/current non-Template-driven Artifact workflows until
+#58/#62 provide the canonical Template authority and new generation path.
+
+#57 does not retroactively require existing Artifacts to resolve their
+`template_version_id`.
+
+Existing Artifact/Page storage, rendering, routing, assembly, review, scoring,
+and publication remain unchanged.
+
+## 20. Storage boundary and #58 handoff
+
+Reusable Templates are cross-Activity definitions.
+
+Issue #57 therefore does not register Template Definition or Template Version
+inside the Activity-scoped native `RECORD_DESCRIPTORS` graph merely to obtain
+persistence.
+
+The following are explicitly deferred to #58:
+
+- canonical reusable Template storage root;
+- safe rendering-asset storage;
+- exact mapping serialization for persisted Templates;
+- create/list/show workflows;
+- current-version selection;
+- activation;
+- successor revision;
+- unique lineage-head validation;
+- retirement;
+- CLI/menu management;
+- conflict/concurrency behavior.
+
+#58 must use Core-safe workspace/path conventions and must not make an arbitrary
+Activity the authority for reusable Templates.
+
+## 21. Packet and starter-library handoffs
+
+#59 defines reusable Packet Definition contracts that reference exact Template
+Versions.
+
+#60 implements Packet storage/revision workflows.
+
+#61 builds the synthetic starter collaborative-learning Template library.
+
+A starter Template is still a normal reusable Template Definition/Version. It
+must not receive special operational identity semantics.
+
+## 22. Activity-specific generation handoff
+
+#62 binds exact reusable Template/Packet versions to one target Activity context.
+
+It creates fresh:
+
+- Packet Instance identities;
+- Artifact Instance identities;
+- Artifact Page identities;
+- Core route identities;
+- effective privacy state;
+- actual Author/Subject associations only through their proper workflows.
+
+#62 must never copy prior generated state out of a reusable Template.
+
+## 23. Grouping-signal privacy boundary
+
+Reusable Templates contain no:
+
+```text
+grouping_signal_set_v1 identity
+source_signal_set_id
+source_signal_set_digest
+source_signal_dimension_id
+band
+student band
+missing_signal_disposition
+GroupPlan strategy
+GroupPlan seed
+Meridian producer identity
+```
+
+A generated Artifact may be for a Group that happened to originate from a
+signal-backed GroupPlan.
+
+That planning history does not become Template, Packet, Artifact, route, or Score
+metadata.
+
+## 24. Forbidden reusable state
+
+Template contracts must not contain concrete:
+
+```text
+class_id
+activity_id
+session_id
+group_id
+group_plan_id
+membership_id
+student_id
+participant_reference
+packet_instance_id
+artifact_instance_id
+artifact_page_id
+route_id
+scan_reference_id
+ArtifactAuthor association
+ArtifactSubject association
+Review
+Moderation
+Score
+manifest
+Publication Record
+retained scan path/digest
+```
+
+Operational timestamps/provenance from an earlier Activity or Artifact are also
+not reusable Template state.
+
+The Template's own creation provenance is definition history and is legitimate.
+
+## 25. General-purpose editor boundary
+
+The v0.3 contract is intentionally bounded.
+
+It does not define:
+
+- arbitrary HTML/JavaScript execution;
+- arbitrary CSS execution;
+- arbitrary Markdown execution;
+- a Python/Jinja scripting engine;
+- a general word processor;
+- a generic office-document format;
+- a universal page-layout language.
+
+It defines enough reusable semantic structure for Concord's paper-first classroom
+forms while keeping rendering deterministic and reviewable.
+
+## 26. Non-goals for #57
+
+Issue #57 does not implement:
+
+```text
+Template persistence                         #58
+Template create/revise/retire workflows      #58
+Template CLI/menu management                 #58
+Packet contracts                             #59
+Packet storage/workflows                     #60
+starter Template library                     #61
+Activity-specific Template instantiation     #62
+fresh Artifact/Page/PDS2 allocation          #62
+Activity copying                             #63
+reusable Criterion/Scale authority           #64
+OCR
+OMR
+handwriting recognition
+automatic scoring
+automatic authorship inference
+automatic Subject inference
+Meridian integration
+```
+
+No sibling PDS runtime dependency is added.
+
+## 27. Qualification boundary
+
+#57 qualification must demonstrate:
+
+- pure typed Template contracts;
+- exact validation;
+- shared category/page/authorship/Activity vocabularies rather than drift;
+- no Template registration in Activity-native storage;
+- no Template write workflow;
+- existing Artifact compatibility;
+- no new PDS2 route creation;
+- no Group/GroupMembership/Score/publication side effects;
+- documentation consistency;
+- full repository compatibility against Core 0.6.1.
+
+Physical paper round-trip acceptance belongs to later Template/Packet
+instantiation work.

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -51,6 +51,26 @@ MISSING_SIGNAL_DISPOSITION_DOC = (
 GROUP_PLAN_APPLICATION_DOC = (
     ROOT / "docs" / "v0.3.0-group-plan-application.md"
 )
+TEMPLATE_DEFINITION_CONTRACT_DOC = (
+    ROOT / "docs" / "v0.3.0-template-definition-contract.md"
+)
+REQUIRED_TEMPLATE_DEFINITION_CONTRACT_PHRASES = (
+    "TemplateDefinition",
+    "TemplateVersion",
+    "TemplatePageDefinition",
+    "TemplateRenderingInput",
+    "TemplateResponseRegion",
+    "TemplateCompatibility",
+    "rendering_specification_sha256",
+    "pds2_route_payload",
+    "human_fallback",
+    "supported_criterion_ids",
+    "grouping_signal_set_v1",
+    "TemplateVersion != ArtifactInstance",
+    "TemplatePageDefinition != ArtifactPage",
+    "canonical Template storage and revision workflows remain #58",
+    "Issue #57 does not implement",
+)
 REQUIRED_GROUP_PLAN_APPLICATION_DOC_PHRASES = (
     "group_plan_application_preview_v1",
     "pds-concord:group-plan-application-preview:v1",
@@ -419,6 +439,25 @@ def check_documentation() -> None:
             failures.append(
                 "Documentation index does not link the GroupPlan application document."
             )
+    if not TEMPLATE_DEFINITION_CONTRACT_DOC.is_file():
+        failures.append(
+            "Current v0.3.0 Template Definition contract document is missing."
+        )
+    else:
+        template_contract_doc = TEMPLATE_DEFINITION_CONTRACT_DOC.read_text(
+            encoding="utf-8"
+        )
+        for phrase in REQUIRED_TEMPLATE_DEFINITION_CONTRACT_PHRASES:
+            if phrase not in template_contract_doc:
+                failures.append(
+                    "Template Definition contract document is missing required "
+                    f"boundary wording {phrase!r}."
+                )
+        if TEMPLATE_DEFINITION_CONTRACT_DOC.name not in docs_index:
+            failures.append(
+                "Documentation index does not link the Template Definition "
+                "contract document."
+            )
     for active_path in (
         ROOT / "README.md",
         ROOT / "docs" / "cli-contract.md",
@@ -449,7 +488,9 @@ def check_documentation() -> None:
         "Missing-signal disposition remains reserved for #55",
         "#48-#54 foundations",
         "#48-#55 foundations",
+        "#48-#56 foundations",
         "canonical plan application remains reserved for #56",
+        "Template Definition / Template Version remain wholly undefined",
         "there is no `group-plan\napply` command",
     ):
         if stale_phrase in docs_index:

--- a/tests/test_template_definition_contract_issue57.py
+++ b/tests/test_template_definition_contract_issue57.py
@@ -1,0 +1,487 @@
+from __future__ import annotations
+
+from dataclasses import fields, replace
+
+import pytest
+
+from concord.model_conversion import record_to_dict
+from concord.models import (
+    ActorReference,
+    ArtifactInstance,
+    ConcordModelError,
+    ConcordRecordReference,
+    PrivacyPolicy,
+    Provenance,
+    TemplateAuthorshipExpectation,
+    TemplateCompatibility,
+    TemplateDefinition,
+    TemplatePageDefinition,
+    TemplateRenderingInput,
+    TemplateResponseRegion,
+    TemplateSubjectExpectation,
+    TemplateVersion,
+)
+from concord.record_registry import RECORD_DESCRIPTORS
+
+
+def _provenance() -> Provenance:
+    return Provenance(
+        actor=ActorReference(
+            actor_kind="authorized_adult",
+            actor_id="teacher-1",
+            owning_system="concord",
+        ),
+        timestamp="2026-08-24T17:00:00-04:00",
+        source_kind="manual",
+        application_version="0.3.0.dev0",
+    )
+
+
+def _privacy() -> PrivacyPolicy:
+    return PrivacyPolicy(classification="teacher_restricted")
+
+
+def _inputs() -> tuple[TemplateRenderingInput, ...]:
+    return (
+        TemplateRenderingInput(
+            input_key="route-payload",
+            label="PDS2 route payload",
+            source_kind="pds2_route_payload",
+            value_kind="text",
+            required=True,
+        ),
+        TemplateRenderingInput(
+            input_key="human-fallback",
+            label="Human fallback",
+            source_kind="human_fallback",
+            value_kind="text",
+            required=True,
+        ),
+        TemplateRenderingInput(
+            input_key="group-label",
+            label="Group label",
+            source_kind="group_label",
+            value_kind="text",
+            required=True,
+            max_length=80,
+        ),
+    )
+
+
+def _page(
+    *,
+    page_key: str = "page-1",
+    sequence: int = 1,
+    route_required: bool = True,
+    return_expected: bool = True,
+) -> TemplatePageDefinition:
+    if route_required:
+        keys = ("route-payload", "human-fallback", "group-label")
+        route_key = "route-payload"
+        fallback_key = "human-fallback"
+    else:
+        keys = ("group-label",)
+        route_key = None
+        fallback_key = None
+    return TemplatePageDefinition(
+        page_key=page_key,
+        sequence=sequence,
+        page_kind="primary",
+        return_expected=return_expected,
+        route_required=route_required,
+        rendering_input_keys=keys,
+        response_regions=(
+            TemplateResponseRegion(
+                region_key=f"response-{sequence}",
+                label="Student notes",
+                region_kind="free_response",
+                required=False,
+            ),
+        ),
+        route_payload_input_key=route_key,
+        human_fallback_input_key=fallback_key,
+    )
+
+
+def _version(**changes: object) -> TemplateVersion:
+    kwargs: dict[str, object] = {
+        "template_version_id": "template-version-1",
+        "template_id": "template-1",
+        "version_label": "v1",
+        "revision_sequence": 1,
+        "rendering_contract_version": "concord-template-rendering-v1",
+        "rendering_specification_reference": "rendering-spec-seminar-v1",
+        "rendering_specification_sha256": "a" * 64,
+        "artifact_category": "discussion_record",
+        "page_manifest": (_page(),),
+        "rendering_inputs": _inputs(),
+        "default_expected_return_status": "returned_expected",
+        "default_privacy_policy": _privacy(),
+        "compatibility": TemplateCompatibility(
+            audience_kinds=("group",),
+            activity_type_keys=("socratic_seminar",),
+            scoring_orientations=("evidence_only", "mixed"),
+            criterion_kinds=("local", "standard_backed"),
+        ),
+        "created_provenance": _provenance(),
+        "status": "active",
+        "default_authorship_expectation": TemplateAuthorshipExpectation(
+            authorship_mode="recorder_for_group",
+        ),
+        "default_subject_expectation": TemplateSubjectExpectation(
+            subject_kind="concord_group",
+        ),
+    }
+    kwargs.update(changes)
+    return TemplateVersion(**kwargs)  # type: ignore[arg-type]
+
+
+def test_template_definition_validates_reusable_identity_and_owner() -> None:
+    definition = TemplateDefinition(
+        template_id="template-1",
+        name="Seminar Discussion Map",
+        purpose="Capture collaborative seminar evidence.",
+        artifact_category="discussion_record",
+        status="active",
+        created_provenance=_provenance(),
+        description="Reusable synthetic starter.",
+        owner_reference=ActorReference(
+            actor_kind="authorized_adult",
+            actor_id="teacher-1",
+            owning_system="concord",
+        ),
+    )
+    assert definition.template_id == "template-1"
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    (
+        ("template_id", "../bad"),
+        ("name", "  bad"),
+        ("purpose", ""),
+        ("artifact_category", "not valid"),
+        ("status", "distributed"),
+    ),
+)
+def test_template_definition_rejects_invalid_fields(
+    field_name: str,
+    value: object,
+) -> None:
+    kwargs: dict[str, object] = {
+        "template_id": "template-1",
+        "name": "Name",
+        "purpose": "Purpose",
+        "artifact_category": "discussion_record",
+        "status": "draft",
+        "created_provenance": _provenance(),
+    }
+    kwargs[field_name] = value
+    with pytest.raises(ConcordModelError):
+        TemplateDefinition(**kwargs)  # type: ignore[arg-type]
+
+
+def test_template_definition_rejects_core_student_owner() -> None:
+    with pytest.raises(ConcordModelError, match="Core student"):
+        TemplateDefinition(
+            template_id="template-1",
+            name="Name",
+            purpose="Purpose",
+            artifact_category="discussion_record",
+            status="draft",
+            created_provenance=_provenance(),
+            owner_reference=ActorReference(
+                actor_kind="core_student",
+                actor_id="student-1",
+                owning_system="core",
+            ),
+        )
+
+
+def test_template_models_contain_no_instance_or_signal_fields() -> None:
+    forbidden = {
+        "class_id",
+        "class_reference",
+        "activity_id",
+        "session_id",
+        "group_id",
+        "group_plan_id",
+        "planned_group_key",
+        "membership_id",
+        "student_id",
+        "participant_reference",
+        "source_signal_set_id",
+        "source_signal_set_digest",
+        "source_signal_dimension_id",
+        "band",
+        "packet_instance_id",
+        "artifact_instance_id",
+        "artifact_page_id",
+        "route_id",
+        "scan_reference_id",
+        "score_record_id",
+        "publication_id",
+    }
+    for model in (
+        TemplateDefinition,
+        TemplateVersion,
+        TemplatePageDefinition,
+        TemplateRenderingInput,
+        TemplateResponseRegion,
+        TemplateCompatibility,
+    ):
+        assert forbidden.isdisjoint(field.name for field in fields(model))
+
+
+def test_template_version_canonicalizes_order_and_preserves_exact_digest() -> None:
+    page_2 = TemplatePageDefinition(
+        page_key="page-2",
+        sequence=2,
+        page_kind="instructional",
+        return_expected=False,
+        route_required=False,
+        rendering_input_keys=("group-label",),
+    )
+    version = _version(page_manifest=(page_2, _page()))
+    assert tuple(page.sequence for page in version.page_manifest) == (1, 2)
+    assert tuple(item.input_key for item in version.rendering_inputs) == (
+        "group-label",
+        "human-fallback",
+        "route-payload",
+    )
+    assert version.rendering_specification_sha256 == "a" * 64
+
+
+def test_template_version_requires_lowercase_sha256() -> None:
+    with pytest.raises(ConcordModelError, match="SHA-256"):
+        _version(rendering_specification_sha256="A" * 64)
+
+
+@pytest.mark.parametrize("revision", (0, -1, True))
+def test_template_version_requires_positive_revision_sequence(
+    revision: object,
+) -> None:
+    with pytest.raises(ConcordModelError, match="positive integer"):
+        _version(revision_sequence=revision)
+
+
+def test_first_version_forbids_predecessor_and_successor_requires_one() -> None:
+    with pytest.raises(ConcordModelError, match="first Template Version"):
+        _version(supersedes_template_version_id="template-version-0")
+    successor = _version(
+        template_version_id="template-version-2",
+        revision_sequence=2,
+        supersedes_template_version_id="template-version-1",
+    )
+    assert successor.supersedes_template_version_id == "template-version-1"
+    with pytest.raises(ConcordModelError, match="successor Template Versions"):
+        _version(template_version_id="template-version-2", revision_sequence=2)
+
+
+def test_template_version_rejects_duplicate_or_noncontiguous_pages() -> None:
+    with pytest.raises(ConcordModelError, match="duplicate page_key"):
+        _version(page_manifest=(_page(), replace(_page(), sequence=2)))
+    with pytest.raises(ConcordModelError, match="contiguous"):
+        _version(
+            page_manifest=(
+                _page(),
+                TemplatePageDefinition(
+                    page_key="page-3",
+                    sequence=3,
+                    page_kind="instructional",
+                    return_expected=False,
+                    route_required=False,
+                    rendering_input_keys=("group-label",),
+                ),
+            )
+        )
+
+
+def test_route_required_page_needs_return_and_both_binding_slots() -> None:
+    with pytest.raises(ConcordModelError, match="expected to return"):
+        _page(return_expected=False)
+    with pytest.raises(ConcordModelError, match="route payload"):
+        TemplatePageDefinition(
+            page_key="page-1",
+            sequence=1,
+            page_kind="primary",
+            return_expected=True,
+            route_required=True,
+            rendering_input_keys=("group-label",),
+        )
+
+
+def test_nonroute_page_forbids_route_binding_slots() -> None:
+    with pytest.raises(ConcordModelError, match="non-route"):
+        TemplatePageDefinition(
+            page_key="page-1",
+            sequence=1,
+            page_kind="instructional",
+            return_expected=False,
+            route_required=False,
+            rendering_input_keys=("route-payload",),
+            route_payload_input_key="route-payload",
+        )
+
+
+def test_template_version_requires_declared_inputs_and_correct_sources() -> None:
+    with pytest.raises(ConcordModelError, match="undeclared"):
+        _version(
+            page_manifest=(
+                replace(
+                    _page(),
+                    rendering_input_keys=(
+                        "route-payload",
+                        "human-fallback",
+                        "missing-input",
+                    ),
+                ),
+            )
+        )
+    wrong = tuple(
+        replace(item, source_kind="teacher_text")
+        if item.input_key == "route-payload"
+        else item
+        for item in _inputs()
+    )
+    with pytest.raises(ConcordModelError, match="pds2_route_payload"):
+        _version(rendering_inputs=wrong)
+
+
+def test_response_region_keys_are_unique_across_template_version() -> None:
+    duplicate_region = TemplateResponseRegion(
+        region_key="response-1",
+        label="Second region",
+        region_kind="annotation",
+        required=False,
+    )
+    page_2 = TemplatePageDefinition(
+        page_key="page-2",
+        sequence=2,
+        page_kind="instructional",
+        return_expected=False,
+        route_required=False,
+        rendering_input_keys=("group-label",),
+        response_regions=(duplicate_region,),
+    )
+    with pytest.raises(ConcordModelError, match="region keys"):
+        _version(page_manifest=(_page(), page_2))
+
+
+def test_rendering_input_vocab_is_bounded_and_nonexecutable() -> None:
+    with pytest.raises(ConcordModelError):
+        TemplateRenderingInput(
+            input_key="unsafe",
+            label="Unsafe",
+            source_kind="python_expression",
+            value_kind="text",
+            required=True,
+        )
+    with pytest.raises(ConcordModelError):
+        TemplateRenderingInput(
+            input_key="unsafe",
+            label="Unsafe",
+            source_kind="teacher_text",
+            value_kind="object",
+            required=True,
+        )
+    with pytest.raises(ConcordModelError, match="max_length"):
+        TemplateRenderingInput(
+            input_key="number",
+            label="Number",
+            source_kind="teacher_text",
+            value_kind="integer",
+            required=True,
+            max_length=10,
+        )
+
+
+def test_identity_free_template_privacy_only() -> None:
+    version = _version(
+        default_privacy_policy=PrivacyPolicy(
+            classification="group_and_teacher",
+        )
+    )
+    assert version.default_privacy_policy.classification == "group_and_teacher"
+    with pytest.raises(ConcordModelError, match="identity-free"):
+        _version(
+            default_privacy_policy=PrivacyPolicy(
+                classification="inherited",
+                inherited_from=ConcordRecordReference(
+                    record_kind="activity",
+                    record_id="activity-1",
+                ),
+            )
+        )
+
+
+def test_expectations_are_kinds_not_concrete_associations() -> None:
+    authorship = TemplateAuthorshipExpectation(
+        authorship_mode="collective_group_author",
+    )
+    subject = TemplateSubjectExpectation(subject_kind="concord_group")
+    assert not hasattr(authorship, "author_reference")
+    assert not hasattr(subject, "subject_id")
+
+
+def test_template_compatibility_is_identity_free_and_deterministic() -> None:
+    compatibility = TemplateCompatibility(
+        audience_kinds=("teacher", "group"),
+        activity_type_keys=("project", "socratic_seminar"),
+        scoring_orientations=("mixed", "evidence_only"),
+        criterion_kinds=("standard_backed", "local"),
+    )
+    assert compatibility.audience_kinds == ("group", "teacher")
+    assert compatibility.scoring_orientations == ("evidence_only", "mixed")
+    assert not hasattr(compatibility, "criterion_ids")
+    with pytest.raises(ConcordModelError, match="duplicates"):
+        TemplateCompatibility(audience_kinds=("group", "group"))
+
+
+def test_expected_return_status_and_page_manifest_must_agree() -> None:
+    nonreturn_page = _page(route_required=False, return_expected=False)
+    version = _version(
+        page_manifest=(nonreturn_page,),
+        default_expected_return_status="return_not_expected",
+    )
+    assert version.default_expected_return_status == "return_not_expected"
+    with pytest.raises(ConcordModelError, match="cannot contain"):
+        _version(default_expected_return_status="return_not_expected")
+    with pytest.raises(ConcordModelError, match="at least one"):
+        _version(
+            page_manifest=(nonreturn_page,),
+            default_expected_return_status="returned_optional",
+        )
+
+
+def test_template_contract_is_not_activity_native_persistence_yet() -> None:
+    registered_types = {descriptor.model_type for descriptor in RECORD_DESCRIPTORS}
+    assert TemplateDefinition not in registered_types
+    assert TemplateVersion not in registered_types
+    with pytest.raises(ConcordModelError, match="registered Concord record"):
+        record_to_dict(  # type: ignore[arg-type]
+            TemplateDefinition(
+                template_id="template-1",
+                name="Name",
+                purpose="Purpose",
+                artifact_category="discussion_record",
+                status="draft",
+                created_provenance=_provenance(),
+            )
+        )
+
+
+def test_existing_artifact_instance_contract_remains_opaque_and_unchanged() -> None:
+    artifact = ArtifactInstance(
+        artifact_instance_id="artifact-1",
+        template_version_id="legacy-template-version",
+        activity_id="activity-1",
+        artifact_category="discussion_record",
+        generation_status="planned",
+        expected_return_status="returned_expected",
+        artifact_status="planned",
+        privacy_policy=_privacy(),
+        page_ids=("page-1",),
+        created_provenance=_provenance(),
+    )
+    assert artifact.template_version_id == "legacy-template-version"


### PR DESCRIPTION
## Summary

Defines Concord's v0.3.0 reusable immutable Template Definition and Template Version contracts for issue #57.

This establishes the typed reusable-definition layer required by later Template persistence, Packet composition, starter-template, and Activity-specific generation work without prematurely introducing cross-Activity Template storage or operational workflows.

## What this adds

- public immutable `TemplateDefinition` and `TemplateVersion` models;
- typed `TemplatePageDefinition` page manifests;
- typed reusable `TemplateRenderingInput` declarations;
- typed `TemplateResponseRegion` evidence-capture declarations;
- identity-free `TemplateCompatibility`;
- reusable authorship and Subject expectations;
- exact lowercase SHA-256 binding for rendering specifications;
- deterministic page ordering and version-lineage validation;
- explicit return/PDS2-route requirement semantics;
- identity-free reusable privacy defaults;
- shared Activity/Artifact vocabularies so reusable and operational contracts cannot drift;
- normative `docs/v0.3.0-template-definition-contract.md`;
- documentation-index, status, changelog, and checker integration;
- focused issue #57 contract and regression tests.

## Architectural boundaries

The implementation preserves:

```text
Template Definition
    -> exact immutable Template Version
        -> later fresh Artifact Instance
            -> later fresh Artifact Page
                -> later fresh Core PDS2 route
```

It explicitly does **not** make Templates Activity-native persisted records.

Canonical reusable Template storage, revision workflows, current-version selection, rendering-asset storage, and CLI/menu management remain issue #58.

The contract also preserves these distinctions:

```text
TemplateDefinition != TemplateVersion
TemplateVersion != ArtifactInstance
TemplatePageDefinition != ArtifactPage
TemplateResponseRegion != Score
Template authorship expectation != ArtifactAuthor
Template Subject expectation != ArtifactSubject
Template route requirement != RouteRegistration
rendering input declaration != bound Activity/student/Group value
```

Reusable Template state contains no Activity, Session, Group, GroupPlan, Membership, student, grouping-signal band, generated Artifact/Page/route, scan, Review, Moderation, Score, manifest, or publication history.

Current Activity-scoped Criterion IDs are not treated as globally reusable Template compatibility; #57 uses identity-free criterion kinds pending the reusable Criterion/Scale work in #64.

## Backward compatibility

Existing `ArtifactInstance.template_version_id` values remain opaque and readable.

Issue #57 does not require historical/current Artifacts to resolve through a Template registry and does not change existing Artifact/Page generation, routing, assembly, review, scoring, or publication workflows.

No sibling PDS runtime dependency is added.

## Qualification

Qualified locally against the exact released:

```text
pds_core-0.6.1-py3-none-any.whl
```

Results:

- 882 tests passed;
- 9 expected Windows/POSIX filesystem-capability skips;
- Ruff passed;
- strict mypy passed across 121 source files;
- documentation validation passed;
- release compatibility passed;
- package build and artifact validation passed;
- installed Concord producer acceptance passed through publication, supersession, historical Artifact access, withdrawal, registry audit, and immutability;
- `git diff --check` passed.

Closes #57