### PR TITLE
feat: define reusable Packet contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Public immutable reusable `PacketDefinition` / `PacketVersion` contracts with
+  deterministic ordered `PacketComponent` composition, exact Template
+  Definition/Version identity pairs, source-owned Core `ModuleRecordRef`
+  external components, positive `copies_per_target`, identity-free audience and
+  role intent, bounded non-executable conditions, and typed deterministic
+  packet-level rendering rules.
+- Shared `ROLE_KEYS` now backs both operational `RoleAssignment` validation and
+  reusable Packet role intent so the built-in role vocabulary cannot drift,
+  while namespaced role-key extensions remain supported.
+
 - Canonical workspace-level reusable Template storage under
   `shared/concord/templates/` using `concord_template_library_storage_v1`, with
   strict typed/canonical JSON, immutable Definition/Version record revisions,

--- a/README.md
+++ b/README.md
@@ -28,9 +28,14 @@ compatibility, and exact rendering-source SHA-256 binding. Issue #58 now adds th
 workspace-level reusable Template library under `shared/concord/templates/`,
 strict immutable history, exact rendering-byte storage, head/current Version
 selection, successor/activation/retirement workflows, a direct `concord template`
-CLI family, and a workspace-level teacher Template Library. The same typed service
-layer supports both fully noninteractive direct commands and the
-low-information-density menu.
+CLI family, and a workspace-level teacher Template Library. Issue #59 now also
+defines public immutable reusable Packet Definition/Version contracts with
+deterministic ordered components, exact Template Version references, source-owned
+external references, positive per-target copy counts, identity-free audience/role
+intent, bounded conditions, and typed packet-level rendering rules. Packet
+persistence/management remains #60 and Activity-specific generation remains #62.
+The same typed service layer supports both fully noninteractive direct commands and
+the low-information-density menu.
 Canonical state remains protected by immutable history, exact expected-snapshot
 concurrency, and guarded batch commits.
 
@@ -238,6 +243,10 @@ Issue #58's workspace-level authority, immutable Template history, rendering-byt
 integrity, head/current selection, authoring transport, direct CLI, and teacher
 menu are documented in the
 [Template storage and revision workflow guide](docs/v0.3.0-template-storage-revision-workflows.md).
+Issue #59's immutable Packet lineage/version/component contracts, exact Template
+references, copy/audience/role/condition semantics, external ownership, rendering
+rules, and #60/#62 handoffs are documented in the
+[Packet Definition contract](docs/v0.3.0-packet-definition-contract.md).
 The clean installed-wheel producer lifecycle and its Core verification,
 authorization, audit, and immutability boundaries are documented in the
 [installed acceptance guide](docs/implementation/installed-end-to-end-acceptance.md).

--- a/concord/models/__init__.py
+++ b/concord/models/__init__.py
@@ -34,6 +34,14 @@ from concord.models.common import (
 )
 from concord.models.corrections import CorrectionRecord
 from concord.models.group_planning import GroupPlan, PlannedGroup
+from concord.models.packets import (
+    PacketAudienceIntent,
+    PacketComponent,
+    PacketCondition,
+    PacketDefinition,
+    PacketRenderingRules,
+    PacketVersion,
+)
 from concord.models.review import ArtifactReview, ModerationRecord
 from concord.models.scoring import (
     Criterion,
@@ -79,6 +87,12 @@ __all__ = [
     "GroupPlan",
     "ModerationRecord",
     "ParticipantReference",
+    "PacketAudienceIntent",
+    "PacketComponent",
+    "PacketCondition",
+    "PacketDefinition",
+    "PacketRenderingRules",
+    "PacketVersion",
     "PlannedGroup",
     "PrivacyPolicy",
     "Provenance",

--- a/concord/models/collaboration.py
+++ b/concord/models/collaboration.py
@@ -32,6 +32,17 @@ ACTIVITY_TYPES = frozenset({"socratic_seminar", "laboratory", "project"})
 SCORING_ORIENTATIONS = frozenset(
     {"evidence_only", "standards_based", "mixed", "local_criteria_only"}
 )
+ROLE_KEYS = frozenset(
+    {
+        "facilitator",
+        "recorder",
+        "observer",
+        "speaker",
+        "researcher",
+        "builder",
+        "presenter",
+    }
+)
 
 ASSIGNMENT_STATUSES = frozenset(
     {
@@ -292,17 +303,7 @@ class RoleAssignment:
         controlled_key(
             self.role_key,
             "role_key",
-            frozenset(
-                {
-                    "facilitator",
-                    "recorder",
-                    "observer",
-                    "speaker",
-                    "researcher",
-                    "builder",
-                    "presenter",
-                }
-            ),
+            ROLE_KEYS,
         )
         optional_text(self.role_label_snapshot, "role_label_snapshot")
         controlled(self.status, "status", ASSIGNMENT_STATUSES)

--- a/concord/models/packets.py
+++ b/concord/models/packets.py
@@ -1,0 +1,340 @@
+"""Typed reusable Packet Definition contracts for Concord v0.3."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from pds_core.routing_models import ModuleRecordRef
+
+from concord.models.collaboration import ROLE_KEYS
+from concord.models.common import (
+    ConcordModelError,
+    Provenance,
+    controlled,
+    controlled_key,
+    identifier,
+    optional_identifier,
+    optional_text,
+    positive_int,
+    require_bool,
+    require_text,
+    tuple_of_values,
+)
+
+PACKET_DEFINITION_STATUSES = frozenset({"draft", "active", "retired"})
+PACKET_VERSION_STATUSES = frozenset({"draft", "active", "retired", "superseded"})
+PACKET_COMPONENT_KINDS = frozenset({"concord_template", "external_component"})
+PACKET_AUDIENCE_KINDS = frozenset(
+    {"activity", "group", "participant", "teacher", "role"}
+)
+PACKET_REQUIREMENT_LEVELS = frozenset(
+    {"required", "recommended", "conditional"}
+)
+PACKET_CONDITION_KINDS = frozenset(
+    {
+        "teacher_choice",
+        "matching_role_present",
+        "group_context_present",
+        "participant_context_present",
+    }
+)
+PACKET_COPY_COLLATIONS = frozenset({"component_major"})
+PACKET_TARGET_ORDERS = frozenset({"stable_identity"})
+
+
+def _role_keys(value: Iterable[str], field_name: str) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)):
+        raise ConcordModelError(f"{field_name} must be an iterable.")
+    try:
+        values = tuple(value)
+    except TypeError as error:
+        raise ConcordModelError(f"{field_name} must be iterable.") from error
+    normalized = tuple(
+        controlled_key(item, f"{field_name}[{index}]", ROLE_KEYS)
+        for index, item in enumerate(values)
+    )
+    if len(set(normalized)) != len(normalized):
+        raise ConcordModelError(f"{field_name} must not contain duplicates.")
+    return tuple(sorted(normalized))
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PacketAudienceIntent:
+    """Identity-free declaration of the kind of target for one component."""
+
+    audience_kind: str
+    role_keys: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        kind = controlled(
+            self.audience_kind,
+            "audience_kind",
+            PACKET_AUDIENCE_KINDS,
+        )
+        roles = _role_keys(self.role_keys, "role_keys")
+        object.__setattr__(self, "role_keys", roles)
+        if kind == "role":
+            if not roles:
+                raise ConcordModelError(
+                    "role audience intent requires at least one role_key."
+                )
+        elif roles:
+            raise ConcordModelError(
+                "role_keys are permitted only for role audience intent."
+            )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PacketCondition:
+    """Bounded declarative generation condition; never executable code."""
+
+    condition_kind: str
+    role_keys: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        kind = controlled(
+            self.condition_kind,
+            "condition_kind",
+            PACKET_CONDITION_KINDS,
+        )
+        roles = _role_keys(self.role_keys, "role_keys")
+        object.__setattr__(self, "role_keys", roles)
+        if kind == "matching_role_present":
+            if not roles:
+                raise ConcordModelError(
+                    "matching_role_present requires at least one role_key."
+                )
+        elif roles:
+            raise ConcordModelError(
+                "role_keys are permitted only for matching_role_present."
+            )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PacketRenderingRules:
+    """Small deterministic packet-assembly contract above Template rendering."""
+
+    preserve_component_order: bool = True
+    start_each_component_on_new_page: bool = False
+    copy_collation: str = "component_major"
+    target_order: str = "stable_identity"
+
+    def __post_init__(self) -> None:
+        preserve = require_bool(
+            self.preserve_component_order,
+            "preserve_component_order",
+        )
+        require_bool(
+            self.start_each_component_on_new_page,
+            "start_each_component_on_new_page",
+        )
+        controlled(
+            self.copy_collation,
+            "copy_collation",
+            PACKET_COPY_COLLATIONS,
+        )
+        controlled(
+            self.target_order,
+            "target_order",
+            PACKET_TARGET_ORDERS,
+        )
+        if not preserve:
+            raise ConcordModelError(
+                "Packet rendering must preserve declared component order."
+            )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PacketComponent:
+    """One ordered immutable element of an exact Packet Version."""
+
+    packet_component_id: str
+    sequence: int
+    component_kind: str
+    copies_per_target: int
+    audience_intent: PacketAudienceIntent
+    requirement_level: str
+    template_id: str | None = None
+    template_version_id: str | None = None
+    external_reference: ModuleRecordRef | None = None
+    condition: PacketCondition | None = None
+    label: str | None = None
+
+    def __post_init__(self) -> None:
+        identifier(self.packet_component_id, "packet_component_id")
+        positive_int(self.sequence, "sequence")
+        kind = controlled(
+            self.component_kind,
+            "component_kind",
+            PACKET_COMPONENT_KINDS,
+        )
+        positive_int(self.copies_per_target, "copies_per_target")
+        if not isinstance(self.audience_intent, PacketAudienceIntent):
+            raise ConcordModelError(
+                "audience_intent must be a PacketAudienceIntent."
+            )
+        level = controlled(
+            self.requirement_level,
+            "requirement_level",
+            PACKET_REQUIREMENT_LEVELS,
+        )
+        template_id = optional_identifier(self.template_id, "template_id")
+        version_id = optional_identifier(
+            self.template_version_id,
+            "template_version_id",
+        )
+        if self.external_reference is not None and not isinstance(
+            self.external_reference,
+            ModuleRecordRef,
+        ):
+            raise ConcordModelError(
+                "external_reference must be a Core ModuleRecordRef."
+            )
+        if self.condition is not None and not isinstance(
+            self.condition,
+            PacketCondition,
+        ):
+            raise ConcordModelError("condition must be a PacketCondition.")
+        optional_text(self.label, "label")
+
+        if kind == "concord_template":
+            if template_id is None or version_id is None:
+                raise ConcordModelError(
+                    "concord_template components require template_id and "
+                    "template_version_id."
+                )
+            if self.external_reference is not None:
+                raise ConcordModelError(
+                    "concord_template components must not carry "
+                    "external_reference."
+                )
+        else:
+            if template_id is not None or version_id is not None:
+                raise ConcordModelError(
+                    "external_component must not carry Template identities."
+                )
+            if self.external_reference is None:
+                raise ConcordModelError(
+                    "external_component requires external_reference."
+                )
+            if self.external_reference.module_id == "concord":
+                raise ConcordModelError(
+                    "external_component must identify a source-owned record "
+                    "outside Concord."
+                )
+
+        if level == "conditional":
+            if self.condition is None:
+                raise ConcordModelError(
+                    "conditional components require an explicit condition."
+                )
+        elif self.condition is not None:
+            raise ConcordModelError(
+                "non-conditional components must not carry a condition."
+            )
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PacketDefinition:
+    """Stable reusable lineage identity for one Packet design."""
+
+    packet_definition_id: str
+    name: str
+    purpose: str
+    status: str
+    created_provenance: Provenance
+    description: str | None = None
+
+    def __post_init__(self) -> None:
+        identifier(self.packet_definition_id, "packet_definition_id")
+        require_text(self.name, "name")
+        require_text(self.purpose, "purpose")
+        controlled(
+            self.status,
+            "status",
+            PACKET_DEFINITION_STATUSES,
+        )
+        if not isinstance(self.created_provenance, Provenance):
+            raise ConcordModelError("created_provenance must be Provenance.")
+        optional_text(self.description, "description")
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PacketVersion:
+    """One exact immutable ordered composition of reusable components."""
+
+    packet_version_id: str
+    packet_definition_id: str
+    version_label: str
+    revision_sequence: int
+    components: tuple[PacketComponent, ...]
+    rendering_rules: PacketRenderingRules
+    created_provenance: Provenance
+    status: str
+    supersedes_packet_version_id: str | None = None
+
+    def __post_init__(self) -> None:
+        identifier(self.packet_version_id, "packet_version_id")
+        identifier(self.packet_definition_id, "packet_definition_id")
+        require_text(self.version_label, "version_label")
+        revision = positive_int(self.revision_sequence, "revision_sequence")
+        components = tuple_of_values(
+            self.components,
+            PacketComponent,
+            "components",
+            nonempty=True,
+        )
+        components = tuple(sorted(components, key=lambda item: item.sequence))
+        object.__setattr__(self, "components", components)
+        if not isinstance(self.rendering_rules, PacketRenderingRules):
+            raise ConcordModelError(
+                "rendering_rules must be PacketRenderingRules."
+            )
+        if not isinstance(self.created_provenance, Provenance):
+            raise ConcordModelError("created_provenance must be Provenance.")
+        controlled(self.status, "status", PACKET_VERSION_STATUSES)
+        predecessor = optional_identifier(
+            self.supersedes_packet_version_id,
+            "supersedes_packet_version_id",
+        )
+        if revision == 1 and predecessor is not None:
+            raise ConcordModelError(
+                "the first Packet Version must not supersede another version."
+            )
+        if revision > 1 and predecessor is None:
+            raise ConcordModelError(
+                "successor Packet Versions require "
+                "supersedes_packet_version_id."
+            )
+        if predecessor == self.packet_version_id:
+            raise ConcordModelError("a Packet Version cannot supersede itself.")
+
+        component_ids = tuple(
+            item.packet_component_id for item in components
+        )
+        if len(set(component_ids)) != len(component_ids):
+            raise ConcordModelError(
+                "components must not duplicate packet_component_id."
+            )
+        sequences = tuple(item.sequence for item in components)
+        if sequences != tuple(range(1, len(components) + 1)):
+            raise ConcordModelError(
+                "component sequences must form contiguous 1..N order."
+            )
+
+
+__all__ = [
+    "PACKET_AUDIENCE_KINDS",
+    "PACKET_COMPONENT_KINDS",
+    "PACKET_CONDITION_KINDS",
+    "PACKET_DEFINITION_STATUSES",
+    "PACKET_REQUIREMENT_LEVELS",
+    "PACKET_VERSION_STATUSES",
+    "PacketAudienceIntent",
+    "PacketComponent",
+    "PacketCondition",
+    "PacketDefinition",
+    "PacketRenderingRules",
+    "PacketVersion",
+]

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,10 @@ identity-free defaults/compatibility, and exact rendering-specification digest
 binding. Issue #58 now implements canonical workspace-level Template persistence,
 strict revision/snapshot history, rendering-specification storage, head/current
 selection, successor/activation/retirement workflows, and direct/menu management.
+Issue #59 now defines the public immutable reusable Packet Definition/Version
+contract with exact Template Version composition, source-owned external references,
+deterministic ordering/copy semantics, identity-free audience/role intent, bounded
+conditions, and typed packet-level rendering rules.
 
 The repository now contains:
 
@@ -89,6 +93,11 @@ The repository now contains:
   immutable record revisions, digest-linked snapshots, exact rendering bytes,
   explicit head/current Version state, guarded successor/activation/retirement
   workflows, and shared direct CLI/teacher-menu services;
+* public immutable reusable Packet Definition/Version/Component contracts with
+  exact Template identities, typed source-owned external references, contiguous
+  ordering, positive copies-per-target, identity-free audience/role intent,
+  bounded non-executable conditions, deterministic rendering rules, and no
+  Activity-native persistence;
 * contextual Membership, Role, and Responsibility workflow services;
 * a fully noninteractive direct CLI;
 * a teacher-facing H/B/M/Q menu with low-information-density screens;
@@ -255,15 +264,27 @@ head/current Version distinction, exact expected-snapshot concurrency,
 workspace-level Template Library menu, retirement semantics, and #59/#62
 handoffs.
 
+### 35. v0.3.0 reusable Packet Definition contract
+
+[`v0.3.0-packet-definition-contract.md`](v0.3.0-packet-definition-contract.md)
+
+Documents issue #59's stable Packet lineage, immutable Packet Versions, ordered
+Packet Components, exact Template Definition/Version references, producer-owned
+external `ModuleRecordRef` components, positive copies-per-target,
+identity-free audience/role intent, bounded conditional semantics, typed
+deterministic rendering rules, existing Artifact compatibility, GroupPlan/signal
+privacy exclusion, and the deliberate #60 storage / #62 generation handoffs.
+
 ### Future v0.3.0 Group Planning / Template / Packet plan
 
 [`pds-group-planning-interoperability-development-plan.md`](pds-group-planning-interoperability-development-plan.md)
 
 This remains the roadmap for future v0.3.0 issues beyond the implemented
-#48-#58 foundations. Issue #57 defines the reusable Template contract and #58 now
-implements its canonical storage/management layer. Packet workflows, starter
-libraries, Activity-specific instantiation/copying, reusable presets, guided
-Activity setup, and final integrated teacher UI behavior remain later work.
+#48-#59 foundations. Issue #57 defines the reusable Template contract, #58
+implements its canonical storage/management layer, and #59 defines the reusable
+Packet contract. Packet storage/management, starter libraries, Activity-specific
+instantiation/copying, reusable presets, guided Activity setup, and final
+integrated teacher UI behavior remain later work.
 
 ### 14. PDS2 Artifact Page integration
 

--- a/docs/v0.3.0-packet-definition-contract.md
+++ b/docs/v0.3.0-packet-definition-contract.md
@@ -1,0 +1,732 @@
+# Concord v0.3.0 reusable Packet Definition contract
+
+**Issue:** #59 — Define reusable Packet Definition contracts  
+**Umbrella:** #47 — v0.3.0 Group Planning, Templates, Packets, and Guided Setup  
+**Development version:** `pds-concord 0.3.0.dev0`  
+**Core requirement:** `pds-core>=0.6.1,<0.7`  
+**Status:** Contract implemented; canonical Packet storage/revision workflows remain #60
+
+## 1. Purpose
+
+Issue #59 defines Concord's reusable Packet contract boundary for v0.3.0.
+
+A Packet is an immutable reusable composition of exact Template Versions plus
+bounded generation intent. It describes what should be generated together and
+for what kind of target. It is not a generated classroom packet.
+
+The reusable-to-operational direction is:
+
+```text
+Packet Definition
+    -> exact immutable Packet Version
+        -> ordered Packet Components
+            -> exact Concord Template Version references
+            -> optional source-owned external references
+        -> later #62 target-context resolution
+            -> fresh Packet Instance
+                -> fresh Artifact Instance(s)
+                    -> fresh Artifact Page(s)
+                        -> fresh Core PDS2 route(s)
+```
+
+The reverse direction is prohibited:
+
+```text
+existing Activity / Packet Instance / Artifact / Page / route /
+Author / Subject / Score / GroupPlan / grouping-signal / publication history
+    -X-> reusable Packet state
+```
+
+This contract brings the older accepted conceptual Packet model forward to the
+stricter reusable/versioned semantics established by #57/#58.
+
+## 2. Current runtime boundary
+
+Before #59, Concord already had:
+
+- native Activity, Session, Group, GroupMembership, and GroupPlan records;
+- native ArtifactInstance and ArtifactPage records;
+- an optional opaque `ArtifactInstance.packet_instance_id`;
+- public reusable Template Definition/Version contracts from #57;
+- canonical workspace-level Template storage/revision workflows from #58;
+- generic Artifact/PDS2 preparation and rendering.
+
+Concord did not yet have public runtime Packet Definition, Packet Version, Packet
+Component, or Packet Instance models.
+
+The existing Artifact `packet_instance_id` therefore remains historical/opaque:
+
+```text
+ArtifactInstance.packet_instance_id present
+!=
+implemented Packet Instance subsystem
+```
+
+Issue #59 adds only immutable reusable Packet contracts. It does not add
+persistence, Packet authoring, Packet CLI/menu management, Packet Instances,
+Artifact generation, or route allocation.
+
+## 3. Ownership
+
+Concord owns:
+
+- Packet lineage semantics;
+- exact Packet Version semantics;
+- ordered Packet composition;
+- exact Template Definition/Version references inside components;
+- bounded copy-count semantics;
+- identity-free audience intent;
+- identity-free role intent;
+- bounded conditional generation intent;
+- packet-level deterministic rendering/assembly intent;
+- later Packet storage/revision workflows;
+- later Activity-specific Packet generation.
+
+Core remains authoritative for:
+
+- workspace/path safety;
+- identifiers;
+- class/student identity;
+- `ModuleRecordRef`;
+- PDS2 grammar and Route Registrations;
+- retained scans;
+- standards;
+- grouping-signal interchange;
+- academic registration/publication.
+
+Sibling modules remain authoritative for records referenced as external Packet
+components.
+
+## 4. Public contract surface
+
+Issue #59 exposes immutable types through `concord.models`:
+
+```text
+PacketDefinition
+PacketVersion
+PacketComponent
+PacketAudienceIntent
+PacketCondition
+PacketRenderingRules
+```
+
+The implementation module is:
+
+```text
+concord.models.packets
+```
+
+These are pure reusable-definition contracts.
+
+They are not registered in Activity-native `RECORD_DESCRIPTORS`.
+
+## 5. Packet Definition
+
+`PacketDefinition` is the stable reusable lineage of one Packet design.
+
+Fields:
+
+```text
+packet_definition_id
+name
+purpose
+status
+created_provenance
+description              optional
+```
+
+Definition statuses:
+
+```text
+draft
+active
+retired
+```
+
+### 5.1 Stable identity
+
+`packet_definition_id` identifies the reusable lineage.
+
+It is not:
+
+```text
+packet_version_id
+packet_instance_id
+activity_id
+artifact_instance_id
+artifact_page_id
+route_id
+```
+
+A display-name or description change does not create a different lineage.
+
+### 5.2 Composition is version-owned
+
+The Definition contains no component list.
+
+Composition belongs to exact immutable Packet Versions so a historical Packet
+Version can always identify the exact Template/external composition it meant.
+
+## 6. Packet Version
+
+`PacketVersion` is one exact immutable ordered composition of a Packet
+Definition.
+
+Fields:
+
+```text
+packet_version_id
+packet_definition_id
+version_label
+revision_sequence
+components
+rendering_rules
+created_provenance
+status
+supersedes_packet_version_id     optional
+```
+
+Version statuses:
+
+```text
+draft
+active
+retired
+superseded
+```
+
+### 6.1 Lineage
+
+First revision:
+
+```text
+revision_sequence = 1
+supersedes_packet_version_id = None
+```
+
+Successor revision:
+
+```text
+revision_sequence > 1
+supersedes_packet_version_id = <direct predecessor>
+```
+
+Self-supersession is invalid.
+
+Cross-record enforcement that the predecessor belongs to the same Packet
+lineage, is the unique head, and has the immediately previous sequence belongs to
+#60.
+
+### 6.2 Semantic immutability
+
+Packet Version semantic content is immutable regardless of whether it has already
+been instantiated.
+
+Changing any of the following requires a fresh Packet Version:
+
+- component membership;
+- component order;
+- exact Template identity/version;
+- external reference;
+- copies-per-target;
+- audience/role intent;
+- requirement/condition semantics;
+- component label;
+- packet rendering rules.
+
+This deliberately strengthens the older conceptual wording that required
+immutability only after generation.
+
+Lifecycle status changes are not permission to rewrite semantic content.
+
+## 7. Packet Component
+
+`PacketComponent` is one ordered immutable element of an exact Packet Version.
+
+Fields:
+
+```text
+packet_component_id
+sequence
+component_kind
+copies_per_target
+audience_intent
+requirement_level
+template_id                 optional/conditional
+template_version_id         optional/conditional
+external_reference          optional/conditional
+condition                   optional/conditional
+label                       optional
+```
+
+Built-in component kinds:
+
+```text
+concord_template
+external_component
+```
+
+A Packet Version contains at least one component.
+
+Component IDs are unique inside the Version and component sequences are
+canonicalized to contiguous:
+
+```text
+1..N
+```
+
+`packet_component_id` is a local identity in the Packet Version contract; it is
+not a separately mutable Activity-native record.
+
+## 8. Exact Concord Template references
+
+A `concord_template` component requires both:
+
+```text
+template_id
+template_version_id
+```
+
+and forbids an external reference.
+
+The dual identity explicitly binds the expected Template lineage and exact
+immutable Template Version.
+
+A Packet never references:
+
+```text
+latest
+current
+active-at-generation-time
+Template display name
+rendering path
+rendering asset alias
+```
+
+Packet state does not duplicate the referenced Template body, page manifest,
+rendering inputs, rendering specification, rendering digest, privacy default, or
+compatibility body.
+
+#60 owns strict resolution through the #58 Template library.
+
+Later Template supersession/retirement does not silently rewrite an existing
+Packet Version.
+
+## 9. External components
+
+An `external_component` requires one Core `ModuleRecordRef`.
+
+It forbids Template identities.
+
+The referenced record must be source-owned outside Concord. A `module_id` of
+`concord` is rejected for this component kind.
+
+This replaces the older conceptual `external_reference_id` assumption with a
+producer-neutral typed reference that does not require inventing an
+Activity-scoped reusable ExternalReference registry.
+
+An external component:
+
+- remains owned by its producer;
+- does not transfer record ownership to Concord;
+- does not authorize reading the source record;
+- does not import or duplicate the source body;
+- does not create a Quillan submission;
+- does not create ScoreForm OMR work;
+- does not add a Quillan, ScoreForm, Meridian, or other sibling runtime
+  dependency;
+- is not rendered or mutated by #59.
+
+## 10. Copies per target
+
+Every component declares:
+
+```text
+copies_per_target
+```
+
+as a positive integer.
+
+Examples:
+
+```text
+audience = group
+copies_per_target = 1
+
+audience = teacher
+copies_per_target = 2
+```
+
+The reusable contract does not resolve target cardinality.
+
+For example, one copy per Group does not persist concrete Group IDs. #62 resolves
+the target Activity context and expands copies into fresh generated instances.
+
+There is no free-form quantity expression or executable rule.
+
+## 11. Audience intent
+
+`PacketAudienceIntent` declares the kind of future generation target.
+
+Built-in audience kinds:
+
+```text
+activity
+group
+participant
+teacher
+role
+```
+
+For ordinary kinds, `role_keys` must be empty.
+
+For `role`, one or more role keys are required.
+
+Audience intent contains no concrete:
+
+```text
+activity_id
+session_id
+group_id
+membership_id
+participant_id
+student_id
+```
+
+Therefore:
+
+```text
+Packet audience intent != effective target identity
+```
+
+and:
+
+```text
+Packet audience intent != privacy authorization
+```
+
+## 12. Role intent
+
+Role intent uses the same built-in role-key vocabulary as operational
+`RoleAssignment` plus the existing namespaced-extension policy.
+
+The built-in role keys are centralized as:
+
+```text
+ROLE_KEYS
+```
+
+Current values:
+
+```text
+facilitator
+recorder
+observer
+speaker
+researcher
+builder
+presenter
+```
+
+A Packet may declare:
+
+```text
+audience_kind = role
+role_keys = observer, recorder
+```
+
+but may not persist RoleAssignment, participant, Membership, or Group identity.
+
+This preserves:
+
+```text
+Packet role intent != RoleAssignment
+```
+
+#64 may later add reusable Role presets. #59 does not invent or depend on those
+future preset identities.
+
+## 13. Requirement and condition semantics
+
+Built-in requirement levels:
+
+```text
+required
+recommended
+conditional
+```
+
+A `conditional` component requires `PacketCondition`.
+
+Non-conditional components must not carry a condition.
+
+Built-in condition kinds are deliberately bounded:
+
+```text
+teacher_choice
+matching_role_present
+group_context_present
+participant_context_present
+```
+
+`matching_role_present` requires at least one role key. Other condition kinds do
+not carry role keys.
+
+Conditions are declarations for later #62 generation eligibility.
+
+They do not execute:
+
+- Python;
+- shell;
+- JavaScript;
+- templates;
+- arbitrary expressions;
+- object traversal;
+- sibling-module queries.
+
+They must not inspect grouping-signal bands or infer ability, performance,
+proficiency, mastery, or Grade.
+
+## 14. Packet rendering rules
+
+`PacketRenderingRules` is a small deterministic orchestration contract above
+Template rendering.
+
+Fields:
+
+```text
+preserve_component_order
+start_each_component_on_new_page
+copy_collation
+target_order
+```
+
+For v0.3:
+
+```text
+preserve_component_order = true
+copy_collation = component_major
+target_order = stable_identity
+```
+
+`start_each_component_on_new_page` is the only current page-boundary choice.
+
+The current contract intentionally does not expose a generic print engine.
+
+Template-specific page layout, response geometry, wording, rendering inputs,
+return behavior, and QR slots remain properties of the exact Template Version.
+
+Packet rendering rules never contain:
+
+- executable code;
+- printer-driver commands;
+- absolute paths;
+- credentials/tokens;
+- concrete route values;
+- Artifact/Page identities;
+- concrete audience identities.
+
+Actual target expansion and rendering execution remain #62.
+
+## 15. Template compatibility boundary
+
+Packet composition does not nullify Template compatibility.
+
+Some contradictions can be reasoned about from contract semantics, but #59
+stores only exact Template IDs rather than duplicating Template bodies.
+
+Therefore:
+
+- structural Packet contradictions are rejected by #59 models;
+- exact Template identity/version existence and same-lineage verification belong
+  to #60;
+- reusable Packet-versus-Template compatibility checks requiring resolved
+  `TemplateVersion.compatibility` belong to #60;
+- Activity/Session/Group/participant/Role/Criteria/privacy checks belong to #62.
+
+A Packet never creates Criteria or Scores.
+
+## 16. Privacy
+
+Packet audience intent is generation intent, not authorization.
+
+Reusable Packet state contains no concrete privacy audience references.
+
+The exact Template Version remains the source of its reusable identity-free
+Artifact privacy default.
+
+#62 must resolve effective target-context privacy and must not silently broaden a
+more restrictive policy.
+
+Therefore:
+
+```text
+Packet audience intent
+!=
+effective privacy audience
+```
+
+## 17. Authorship and Subject boundaries
+
+Packet target declarations do not create attribution.
+
+The following distinctions are normative:
+
+```text
+Packet audience intent != ArtifactAuthor
+Packet role intent != ArtifactAuthor
+Packet audience intent != ArtifactSubject
+Packet role intent != ArtifactSubject
+GroupMembership != ArtifactAuthor
+RoleAssignment != ArtifactAuthor
+```
+
+Actual Author/Subject associations are fresh operational state.
+
+## 18. GroupPlan and grouping-signal privacy
+
+Reusable Packet state contains no:
+
+```text
+group_plan_id
+planning strategy
+planning seed
+target group size/count
+grouping signal set ID
+signal digest
+dimension ID
+student band
+missing-signal disposition
+```
+
+A later Packet Instance may target a canonical Group produced from an approved
+GroupPlan, but Packet metadata must not reveal the planning signal/history that
+produced the Group.
+
+The boundary remains:
+
+```text
+GroupPlan
+    -> explicit application
+    -> canonical Group / GroupMembership
+
+Packet Version
+    -> #62 resolves canonical Group context
+```
+
+There is no Packet -> GroupPlan dependency.
+
+## 19. Reusable versus generated identity
+
+The following distinctions are normative:
+
+```text
+PacketDefinition != PacketVersion
+PacketVersion != PacketInstance
+PacketComponent != ArtifactInstance
+PacketComponent != ArtifactPage
+Packet component sequence != Artifact page number
+Packet audience intent != concrete audience identity
+Packet role intent != RoleAssignment
+Packet condition != runtime execution history
+```
+
+Generated identities remain fresh.
+
+## 20. Existing Artifact compatibility
+
+The existing `ArtifactInstance.packet_instance_id` remains optional and opaque.
+
+Issue #59 does not:
+
+- require existing Artifacts to resolve Packet state;
+- invent Packet Instances for existing Artifacts;
+- alter Artifact/Page models;
+- alter Activity-native storage;
+- alter renderer behavior;
+- alter PDS2 route behavior.
+
+#62 may require exact Packet/Template resolution for newly generated
+Packet-backed Artifacts without retroactively invalidating historical Artifacts.
+
+## 21. Storage boundary and #60 handoff
+
+Reusable Packets are cross-Activity definitions.
+
+Issue #59 therefore does not register `PacketDefinition`, `PacketVersion`, or
+`PacketComponent` inside Activity-native `RECORD_DESCRIPTORS`.
+
+#60 owns:
+
+- canonical reusable Packet storage root;
+- strict Packet serialization;
+- immutable record revisions/snapshots;
+- current/head selection;
+- exact Template resolution;
+- authoring transport;
+- successor revision;
+- activation/retirement;
+- concurrency/conflict behavior;
+- direct CLI;
+- teacher menu.
+
+#60 should reuse the successful shared-workspace principles established by #58
+where appropriate without coupling Packet storage implementation to Template
+storage internals.
+
+## 22. #62 generation handoff
+
+#62 owns:
+
+- selecting an exact Packet Version;
+- resolving exact Template Versions;
+- resolving Activity/Session/Group/participant/role context;
+- expanding `copies_per_target`;
+- evaluating bounded Packet conditions;
+- applying Packet rendering rules;
+- creating fresh Packet Instance identity;
+- creating fresh Artifact Instances;
+- creating fresh Artifact Pages;
+- allocating fresh Core PDS2 routes;
+- binding Template rendering inputs;
+- resolving effective privacy;
+- preserving exact Packet/Template provenance.
+
+Grouping-signal and GroupPlan internals remain excluded.
+
+## 23. #64 preset handoff
+
+#64 may later create explicit reusable Role, Responsibility, Criterion Set, and
+Scoring Scale preset authorities.
+
+Packet role intent in #59 remains key-based and does not preempt those future
+identities.
+
+A future Packet contract revision may exact-reference a reusable preset only
+after such an authority exists.
+
+## 24. Qualification
+
+Issue #59 qualification covers:
+
+- valid Definition/Version lifecycle vocabulary;
+- positive/explicit version lineage;
+- frozen immutable models;
+- nonempty Packet Versions;
+- deterministic contiguous component order;
+- unique component IDs;
+- exact Template identity pair semantics;
+- source-owned `ModuleRecordRef` external components;
+- positive copy counts;
+- identity-free audience/role intent;
+- shared operational/reusable role-key vocabulary;
+- bounded non-executable conditions;
+- typed deterministic Packet rendering rules;
+- no Activity/student/Group/GroupPlan/signal/generated identities;
+- no Activity-native record registration;
+- existing Artifact packet-reference compatibility;
+- public `concord.models` exports;
+- complete existing test/static/documentation/package validation.
+
+Physical paper round-trip acceptance is intentionally deferred because #59
+creates no Packet Instance, Artifact, Page, route, or rendered output.

--- a/docs/v0.3.0-template-definition-contract.md
+++ b/docs/v0.3.0-template-definition-contract.md
@@ -735,10 +735,10 @@ Activity the authority for reusable Templates.
 
 ## 21. Packet and starter-library handoffs
 
-#59 defines reusable Packet Definition contracts that reference exact Template
-Versions.
+#59 now defines reusable Packet Definition/Version/Component contracts that
+reference exact Template Definition and Template Version identities.
 
-#60 implements Packet storage/revision workflows.
+#60 implements Packet storage/revision workflows and exact Template resolution.
 
 #61 builds the synthetic starter collaborative-learning Template library.
 

--- a/docs/v0.3.0-template-storage-revision-workflows.md
+++ b/docs/v0.3.0-template-storage-revision-workflows.md
@@ -346,10 +346,12 @@ invalidate older Artifacts.
 
 ## 19. Handoffs
 
-Issue #59 may define Packet contracts that exact-reference `template_id` and
-`template_version_id`.
+Issue #59 now defines Packet contracts that exact-reference both `template_id`
+and `template_version_id` without duplicating Template bodies. It also preserves
+source-owned external components through typed Core `ModuleRecordRef` values.
 
-Issue #60 should reuse accepted workspace-level shared-storage conventions where
+Issue #60 should resolve those exact Template pairs through the #58 authority and
+reuse accepted workspace-level shared-storage conventions where
 appropriate without coupling Packet state to Template storage internals.
 
 Issue #61's starter library must create Templates through #58 services.

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -57,6 +57,28 @@ TEMPLATE_DEFINITION_CONTRACT_DOC = (
 TEMPLATE_STORAGE_WORKFLOW_DOC = (
     ROOT / "docs" / "v0.3.0-template-storage-revision-workflows.md"
 )
+PACKET_DEFINITION_CONTRACT_DOC = (
+    ROOT / "docs" / "v0.3.0-packet-definition-contract.md"
+)
+REQUIRED_PACKET_DEFINITION_CONTRACT_PHRASES = (
+    "PacketDefinition",
+    "PacketVersion",
+    "PacketComponent",
+    "PacketAudienceIntent",
+    "PacketCondition",
+    "PacketRenderingRules",
+    "copies_per_target",
+    "ModuleRecordRef",
+    "concord_template",
+    "external_component",
+    "ROLE_KEYS",
+    "PacketDefinition != PacketVersion",
+    "PacketVersion != PacketInstance",
+    "grouping-signal",
+    "#60",
+    "#62",
+    "#64",
+)
 REQUIRED_TEMPLATE_STORAGE_WORKFLOW_PHRASES = (
     "concord_template_library_storage_v1",
     "shared/concord/templates/",
@@ -497,6 +519,25 @@ def check_documentation() -> None:
                 "Documentation index does not link the Template storage/revision "
                 "workflow document."
             )
+    if not PACKET_DEFINITION_CONTRACT_DOC.is_file():
+        failures.append(
+            "Current v0.3.0 Packet Definition contract document is missing."
+        )
+    else:
+        packet_contract_doc = PACKET_DEFINITION_CONTRACT_DOC.read_text(
+            encoding="utf-8"
+        )
+        for phrase in REQUIRED_PACKET_DEFINITION_CONTRACT_PHRASES:
+            if phrase not in packet_contract_doc:
+                failures.append(
+                    "Packet Definition contract document is missing required "
+                    f"boundary wording {phrase!r}."
+                )
+        if PACKET_DEFINITION_CONTRACT_DOC.name not in docs_index:
+            failures.append(
+                "Documentation index does not link the Packet Definition "
+                "contract document."
+            )
     for active_path in (
         ROOT / "README.md",
         ROOT / "docs" / "cli-contract.md",
@@ -533,6 +574,7 @@ def check_documentation() -> None:
         "#48-#55 foundations",
         "#48-#56 foundations",
         "#48-#57 foundations",
+        "#48-#58 foundations",
         "canonical plan application remains reserved for #56",
         "canonical Template storage and revision workflows remain #58",
         "Template Definition / Template Version remain wholly undefined",

--- a/tests/test_packet_definition_contract_issue59.py
+++ b/tests/test_packet_definition_contract_issue59.py
@@ -1,0 +1,394 @@
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import fields, replace
+
+import pytest
+from pds_core.routing_models import ModuleRecordRef
+
+from concord.model_conversion import record_to_dict
+from concord.models import (
+    ActorReference,
+    ArtifactInstance,
+    ConcordModelError,
+    PacketAudienceIntent,
+    PacketComponent,
+    PacketCondition,
+    PacketDefinition,
+    PacketRenderingRules,
+    PacketVersion,
+    PrivacyPolicy,
+    Provenance,
+)
+from concord.models.collaboration import ROLE_KEYS
+from concord.record_registry import RECORD_DESCRIPTORS
+
+
+def _provenance() -> Provenance:
+    return Provenance(
+        actor=ActorReference(
+            actor_kind="authorized_adult",
+            actor_id="teacher-1",
+            owning_system="concord",
+        ),
+        timestamp="2026-08-24T22:45:00-04:00",
+        source_kind="manual",
+        application_version="0.3.0.dev0",
+    )
+
+
+def _audience(
+    kind: str = "group",
+    *,
+    role_keys: tuple[str, ...] = (),
+) -> PacketAudienceIntent:
+    return PacketAudienceIntent(
+        audience_kind=kind,
+        role_keys=role_keys,
+    )
+
+
+def _component(
+    *,
+    component_id: str = "component-1",
+    sequence: int = 1,
+    copies: int = 1,
+    audience: PacketAudienceIntent | None = None,
+    requirement_level: str = "required",
+    condition: PacketCondition | None = None,
+) -> PacketComponent:
+    return PacketComponent(
+        packet_component_id=component_id,
+        sequence=sequence,
+        component_kind="concord_template",
+        template_id="template-1",
+        template_version_id="template-version-1",
+        copies_per_target=copies,
+        audience_intent=audience or _audience(),
+        requirement_level=requirement_level,
+        condition=condition,
+    )
+
+
+def _version(**changes: object) -> PacketVersion:
+    kwargs: dict[str, object] = {
+        "packet_version_id": "packet-version-1",
+        "packet_definition_id": "packet-1",
+        "version_label": "v1",
+        "revision_sequence": 1,
+        "components": (_component(),),
+        "rendering_rules": PacketRenderingRules(),
+        "created_provenance": _provenance(),
+        "status": "active",
+    }
+    kwargs.update(changes)
+    return PacketVersion(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("status", ("draft", "active", "retired"))
+def test_packet_definition_accepts_reusable_lifecycle(status: str) -> None:
+    definition = PacketDefinition(
+        packet_definition_id="packet-1",
+        name="Seminar Packet",
+        purpose="Collect seminar collaboration evidence.",
+        status=status,
+        created_provenance=_provenance(),
+        description="Reusable packet definition.",
+    )
+    assert definition.status == status
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    (
+        ("packet_definition_id", "../bad"),
+        ("name", " "),
+        ("purpose", "  padded"),
+        ("status", "distributed"),
+    ),
+)
+def test_packet_definition_rejects_invalid_fields(
+    field_name: str,
+    value: object,
+) -> None:
+    kwargs: dict[str, object] = {
+        "packet_definition_id": "packet-1",
+        "name": "Name",
+        "purpose": "Purpose",
+        "status": "draft",
+        "created_provenance": _provenance(),
+    }
+    kwargs[field_name] = value
+    with pytest.raises(ConcordModelError):
+        PacketDefinition(**kwargs)  # type: ignore[arg-type]
+
+
+def test_packet_models_contain_no_instance_or_signal_fields() -> None:
+    forbidden = {
+        "class_id",
+        "class_reference",
+        "activity_id",
+        "session_id",
+        "group_id",
+        "group_plan_id",
+        "membership_id",
+        "student_id",
+        "participant_id",
+        "participant_reference",
+        "role_assignment_id",
+        "source_signal_set_id",
+        "source_signal_set_digest",
+        "source_signal_dimension_id",
+        "band",
+        "packet_instance_id",
+        "artifact_instance_id",
+        "artifact_page_id",
+        "route_id",
+        "scan_reference_id",
+        "score_record_id",
+        "publication_id",
+    }
+    for model in (
+        PacketDefinition,
+        PacketVersion,
+        PacketComponent,
+        PacketAudienceIntent,
+        PacketCondition,
+        PacketRenderingRules,
+    ):
+        assert forbidden.isdisjoint(field.name for field in fields(model))
+
+
+def test_packet_version_canonicalizes_component_order() -> None:
+    component_2 = _component(
+        component_id="component-2",
+        sequence=2,
+    )
+    version = _version(components=(component_2, _component()))
+    assert tuple(item.sequence for item in version.components) == (1, 2)
+
+
+def test_packet_version_requires_unique_contiguous_components() -> None:
+    with pytest.raises(ConcordModelError, match="packet_component_id"):
+        _version(
+            components=(
+                _component(),
+                _component(sequence=2),
+            )
+        )
+    with pytest.raises(ConcordModelError, match="contiguous"):
+        _version(
+            components=(
+                _component(),
+                _component(
+                    component_id="component-3",
+                    sequence=3,
+                ),
+            )
+        )
+
+
+def test_packet_version_requires_at_least_one_component() -> None:
+    with pytest.raises(ConcordModelError, match="must not be empty"):
+        _version(components=())
+
+
+def test_first_version_and_successor_lineage_rules() -> None:
+    with pytest.raises(ConcordModelError, match="first Packet Version"):
+        _version(supersedes_packet_version_id="packet-version-0")
+    successor = _version(
+        packet_version_id="packet-version-2",
+        revision_sequence=2,
+        supersedes_packet_version_id="packet-version-1",
+        status="draft",
+    )
+    assert successor.supersedes_packet_version_id == "packet-version-1"
+    with pytest.raises(ConcordModelError, match="successor Packet Versions"):
+        _version(
+            packet_version_id="packet-version-2",
+            revision_sequence=2,
+        )
+    with pytest.raises(ConcordModelError, match="cannot supersede itself"):
+        _version(
+            packet_version_id="packet-version-2",
+            revision_sequence=2,
+            supersedes_packet_version_id="packet-version-2",
+        )
+
+
+def test_packet_component_requires_exact_template_pair() -> None:
+    with pytest.raises(ConcordModelError, match="template_id"):
+        replace(_component(), template_id=None)
+    with pytest.raises(ConcordModelError, match="template_version_id"):
+        replace(_component(), template_version_id=None)
+    with pytest.raises(ConcordModelError, match="external_reference"):
+        replace(
+            _component(),
+            external_reference=ModuleRecordRef(
+                module_id="quillan",
+                record_kind="submission",
+                record_id="submission-1",
+            ),
+        )
+
+
+def test_external_component_uses_source_owned_module_record_ref() -> None:
+    component = PacketComponent(
+        packet_component_id="component-external",
+        sequence=1,
+        component_kind="external_component",
+        copies_per_target=1,
+        audience_intent=_audience("participant"),
+        requirement_level="recommended",
+        external_reference=ModuleRecordRef(
+            module_id="quillan",
+            record_kind="submission",
+            record_id="submission-1",
+            contract_version="1",
+        ),
+    )
+    assert component.external_reference is not None
+    assert component.external_reference.module_id == "quillan"
+    with pytest.raises(ConcordModelError, match="Template identities"):
+        replace(
+            component,
+            template_id="template-1",
+            template_version_id="template-version-1",
+        )
+    with pytest.raises(ConcordModelError, match="requires external_reference"):
+        replace(component, external_reference=None)
+    with pytest.raises(ConcordModelError, match="outside Concord"):
+        replace(
+            component,
+            external_reference=ModuleRecordRef(
+                module_id="concord",
+                record_kind="artifact_instance",
+                record_id="artifact-1",
+            ),
+        )
+
+
+@pytest.mark.parametrize("copies", (0, -1, True))
+def test_copy_count_must_be_positive(copies: object) -> None:
+    with pytest.raises(ConcordModelError, match="positive integer"):
+        _component(copies=copies)  # type: ignore[arg-type]
+
+
+def test_audience_intent_is_identity_free_and_role_keys_are_bounded() -> None:
+    role = _audience("role", role_keys=("observer", "recorder"))
+    assert role.role_keys == ("observer", "recorder")
+    assert set(role.role_keys).issubset(ROLE_KEYS)
+
+    extension = _audience(
+        "role",
+        role_keys=("school:discussion_leader",),
+    )
+    assert extension.role_keys == ("school:discussion_leader",)
+
+    with pytest.raises(ConcordModelError, match="at least one role_key"):
+        _audience("role")
+    with pytest.raises(ConcordModelError, match="only for role"):
+        _audience("group", role_keys=("observer",))
+    with pytest.raises(ConcordModelError):
+        _audience("role", role_keys=("not valid",))
+
+
+def test_conditions_are_bounded_and_requirement_level_is_explicit() -> None:
+    choice = PacketCondition(condition_kind="teacher_choice")
+    conditional = _component(
+        requirement_level="conditional",
+        condition=choice,
+    )
+    assert conditional.condition == choice
+
+    with pytest.raises(ConcordModelError, match="explicit condition"):
+        _component(requirement_level="conditional")
+    with pytest.raises(ConcordModelError, match="non-conditional"):
+        _component(condition=choice)
+    with pytest.raises(ConcordModelError, match="at least one role_key"):
+        PacketCondition(condition_kind="matching_role_present")
+    with pytest.raises(ConcordModelError, match="only for matching_role_present"):
+        PacketCondition(
+            condition_kind="teacher_choice",
+            role_keys=("observer",),
+        )
+    with pytest.raises(ConcordModelError):
+        PacketCondition(condition_kind="python_expression")
+
+
+def test_packet_rendering_rules_are_small_and_deterministic() -> None:
+    rules = PacketRenderingRules(
+        start_each_component_on_new_page=True,
+    )
+    assert rules.preserve_component_order is True
+    assert rules.copy_collation == "component_major"
+    assert rules.target_order == "stable_identity"
+
+    with pytest.raises(ConcordModelError, match="preserve"):
+        PacketRenderingRules(preserve_component_order=False)
+    with pytest.raises(ConcordModelError):
+        PacketRenderingRules(copy_collation="random")
+    with pytest.raises(ConcordModelError):
+        PacketRenderingRules(target_order="display_name")
+
+
+def test_packet_contract_models_are_frozen() -> None:
+    definition = PacketDefinition(
+        packet_definition_id="packet-1",
+        name="Name",
+        purpose="Purpose",
+        status="draft",
+        created_provenance=_provenance(),
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        definition.name = "Changed"  # type: ignore[misc]
+
+
+def test_packet_contract_is_not_activity_native_persistence() -> None:
+    registered_types = {descriptor.model_type for descriptor in RECORD_DESCRIPTORS}
+    assert PacketDefinition not in registered_types
+    assert PacketVersion not in registered_types
+    assert PacketComponent not in registered_types
+    with pytest.raises(ConcordModelError, match="registered Concord record"):
+        record_to_dict(  # type: ignore[arg-type]
+            PacketDefinition(
+                packet_definition_id="packet-1",
+                name="Name",
+                purpose="Purpose",
+                status="draft",
+                created_provenance=_provenance(),
+            )
+        )
+
+
+def test_existing_artifact_packet_reference_remains_opaque() -> None:
+    artifact = ArtifactInstance(
+        artifact_instance_id="artifact-1",
+        template_version_id="legacy-template-version",
+        packet_instance_id="legacy-packet-instance",
+        activity_id="activity-1",
+        artifact_category="discussion_record",
+        generation_status="planned",
+        expected_return_status="returned_expected",
+        artifact_status="planned",
+        privacy_policy=PrivacyPolicy(classification="teacher_restricted"),
+        page_ids=("page-1",),
+        created_provenance=_provenance(),
+    )
+    assert artifact.packet_instance_id == "legacy-packet-instance"
+
+
+def test_packet_contracts_are_public_model_exports() -> None:
+    from concord import models
+
+    required = (
+        "PacketAudienceIntent",
+        "PacketComponent",
+        "PacketCondition",
+        "PacketDefinition",
+        "PacketRenderingRules",
+        "PacketVersion",
+    )
+    for name in required:
+        assert hasattr(models, name), name
+        assert name in models.__all__


### PR DESCRIPTION
## Summary

Implements reusable Packet Definition contracts for Concord v0.3.0.

This completes issue #59 by defining the immutable, cross-Activity Packet contract layer that will sit between reusable Template Versions and later Activity-specific Packet generation.

The core relationship is now:

```text
Packet Definition
    -> exact immutable Packet Version
        -> ordered Packet Components
            -> exact Concord Template Version references
            -> optional source-owned external references
        -> later #62 target-context resolution
            -> fresh Packet Instance
                -> fresh Artifact Instance(s)
                    -> fresh Artifact Page(s)
                        -> fresh Core PDS2 route(s)
```

This PR deliberately stops at reusable contracts. Packet persistence/revision workflows remain #60, while Packet instantiation, Artifact/Page creation, and PDS2 routing remain #62.

## What this adds

### Public immutable Packet contracts

Adds the following public models through `concord.models`:

```text
PacketDefinition
PacketVersion
PacketComponent
PacketAudienceIntent
PacketCondition
PacketRenderingRules
```

The implementation lives in:

```text
concord/models/packets.py
```

All Packet contract models are frozen immutable value objects and remain outside Concord's Activity-native `RECORD_DESCRIPTORS`.

### Packet Definition lineage

`PacketDefinition` provides the stable reusable lineage identity for a Packet design.

It contains reusable metadata only:

```text
packet_definition_id
name
purpose
status
created_provenance
description
```

Supported lifecycle values are:

```text
draft
active
retired
```

Composition does not live on the Definition; it belongs to exact immutable Packet Versions.

### Immutable Packet Versions

`PacketVersion` defines one exact ordered reusable composition.

It includes:

```text
packet_version_id
packet_definition_id
version_label
revision_sequence
components
rendering_rules
created_provenance
status
supersedes_packet_version_id
```

Supported Version lifecycle values are:

```text
draft
active
retired
superseded
```

The contract enforces structural lineage rules:

```text
revision 1 -> no predecessor
revision >1 -> exact predecessor required
self-supersession -> rejected
```

Cross-record lineage-head, exact predecessor, activation, current selection, and lifecycle enforcement remain #60 responsibilities.

Packet Version semantics are immutable: changing component composition, order, Template references, audience behavior, copy rules, conditions, labels, external references, or rendering rules requires a fresh Packet Version.

### Deterministic ordered components

`PacketComponent` defines one ordered element of an exact Packet Version.

Components have explicit:

```text
packet_component_id
sequence
component_kind
copies_per_target
audience_intent
requirement_level
```

plus conditional Template/external reference, condition, and label fields.

Packet Versions require:

- at least one component;
- unique component IDs;
- deterministic component ordering;
- contiguous sequences:

```text
1..N
```

### Exact Template Version references

The normal Packet component kind is:

```text
concord_template
```

A Template-backed component must contain both:

```text
template_id
template_version_id
```

and cannot carry an external reference.

Packets therefore refer to an exact reusable Template lineage and exact immutable Template Version rather than:

```text
latest
current
active-at-generation-time
display name
filesystem path
mutable rendering alias
```

Template bodies, manifests, rendering specifications, digests, privacy defaults, and compatibility metadata are not duplicated into Packet state.

Exact resolution through the #58 Template authority remains #60.

### Source-owned external components

Adds the optional component kind:

```text
external_component
```

External components use Core's producer-neutral:

```python
ModuleRecordRef
```

rather than introducing an Activity-scoped Concord external-reference registry.

The referenced record remains owned by its originating module.

This does not:

- import or duplicate sibling-module records;
- authorize reading those records;
- turn external work into Concord-native Artifacts;
- add runtime dependencies on Quillan, ScoreForm, Meridian, or other sibling modules.

A Concord-owned `ModuleRecordRef` is rejected as an `external_component`, preserving the distinction between Concord Template composition and truly source-owned external material.

### Explicit copy semantics

Every component uses:

```text
copies_per_target
```

as a positive integer.

This replaces vague or executable quantity-rule concepts with a bounded reusable declaration.

Examples include:

```text
1 copy per Group
1 copy per participant
2 copies for the teacher
```

Concrete target cardinality is not resolved in reusable Packet state. #62 will expand the declaration against the selected Activity context.

### Identity-free audience and role intent

`PacketAudienceIntent` supports:

```text
activity
group
participant
teacher
role
```

Audience declarations contain no concrete Activity, Session, Group, Membership, participant, or student identity.

Role-targeted components use reusable role keys rather than Role Assignment IDs.

The built-in role vocabulary is now centralized as:

```text
ROLE_KEYS
```

and shared between operational `RoleAssignment` validation and reusable Packet role intent.

Current built-ins include:

```text
facilitator
recorder
observer
speaker
researcher
builder
presenter
```

Namespace-qualified role-key extensions remain supported.

This preserves:

```text
Packet role intent != RoleAssignment
```

and does not preempt #64's later reusable Role-preset authority.

### Bounded conditional behavior

Packet components support:

```text
required
recommended
conditional
```

A `conditional` component requires a typed `PacketCondition`.

Initial bounded condition kinds are:

```text
teacher_choice
matching_role_present
group_context_present
participant_context_present
```

`matching_role_present` requires explicit reusable role keys.

Packet conditions are declarative only. They cannot contain or execute:

- Python;
- shell;
- JavaScript;
- arbitrary expression syntax;
- generic object traversal;
- sibling-module queries;
- grouping-signal or grading logic.

Actual condition evaluation remains #62.

### Typed deterministic Packet rendering rules

Adds `PacketRenderingRules` for bounded orchestration above individual Template rendering.

The initial contract includes:

```text
preserve_component_order
start_each_component_on_new_page
copy_collation
target_order
```

For v0.3, declared component order must be preserved.

The initial deterministic policies are:

```text
copy_collation = component_major
target_order = stable_identity
```

Template-specific page layout, response geometry, wording, rendering inputs, return behavior, and QR requirements remain owned by the referenced Template Version.

This PR does not implement a generic print/layout engine.

## Boundaries preserved

Reusable Packet state contains no concrete:

- class;
- Activity;
- Session;
- Group;
- Membership;
- participant/student;
- Role Assignment;
- GroupPlan;
- grouping-signal set/digest/dimension/band;
- Packet Instance;
- Artifact Instance;
- Artifact Page;
- PDS2 route;
- Scan Reference;
- Author;
- Subject;
- Review;
- Moderation;
- Criterion;
- Score;
- Publication identity.

The following distinctions are explicit:

```text
PacketDefinition != PacketVersion
PacketVersion != PacketInstance
PacketComponent != ArtifactInstance
PacketComponent != ArtifactPage
Packet audience intent != concrete audience identity
Packet role intent != RoleAssignment
Packet condition != runtime execution history
```

## Existing Artifact compatibility

The existing optional:

```text
ArtifactInstance.packet_instance_id
```

remains opaque.

This PR does not:

- require historical Artifacts to resolve Packet state;
- create Packet Instances for existing Artifacts;
- alter Artifact/Page storage;
- alter renderer behavior;
- alter PDS2 routing.

#62 may require exact Packet/Template resolution for newly generated Packet-backed Artifacts without retroactively invalidating historical Artifact records.

## Storage boundary

Packet Definition, Version, and Component contracts are intentionally **not** added to Activity-native `RECORD_DESCRIPTORS`.

Reusable Packets are cross-Activity definitions.

Issue #60 owns:

- reusable Packet persistence;
- strict serialization;
- immutable record/snapshot history;
- head/current Version selection;
- exact Template resolution;
- successor revisions;
- activation/retirement;
- concurrency;
- authoring transport;
- direct CLI;
- teacher-menu management.

## Documentation

Adds:

```text
docs/v0.3.0-packet-definition-contract.md
```

and updates:

- `README.md`;
- `docs/README.md`;
- `docs/v0.3.0-template-definition-contract.md`;
- `docs/v0.3.0-template-storage-revision-workflows.md`;
- `CHANGELOG.md`;
- `scripts/check_documentation.py`.

The documentation now records #59 as the reusable Packet-contract authority while keeping #60 persistence and #62 generation explicitly deferred.

## Qualification

Full repository validation completed against the exact released Core 0.6.1 wheel:

```text
pds_core-0.6.1-py3-none-any.whl
```

Results:

- `950 passed, 9 skipped`
  - skips are expected Windows/POSIX filesystem-capability cases;
- Ruff: passed;
- Mypy: passed across 130 source files;
- documentation checker: passed;
- release compatibility: passed;
- sdist/wheel build: passed;
- package validation: passed;
- installed-wheel producer acceptance: passed;
- `git diff --check`: passed.

The built distributions include the new `concord.models.packets` module.

Closes #59