### PR TITLE
feat: implement Activity copying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
           $coreWheel = Join-Path `
             $coreDirectory `
-            "pds_core-0.6.1-py3-none-any.whl"
+            "pds_core-0.6.3-py3-none-any.whl"
 
           $coreGroupingFixtures = Join-Path `
             $coreDirectory `
@@ -63,7 +63,7 @@ jobs:
         shell: pwsh
         run: |
           Invoke-WebRequest `
-            -Uri "https://github.com/Paper-Data-Suite/pds-core/releases/download/v0.6.1/pds_core-0.6.1-py3-none-any.whl" `
+            -Uri "https://github.com/Paper-Data-Suite/pds-core/releases/download/v0.6.3/pds_core-0.6.3-py3-none-any.whl" `
             -OutFile $env:PDS_CORE_WHEEL `
             -ErrorAction Stop
 
@@ -152,6 +152,10 @@ jobs:
           python scripts/check_package.py "$concordWheel"
           python scripts/verify_release_artifacts.py "$dist"
           python scripts/smoke_test_wheel.py `
+            "$concordWheel" `
+            "$env:PDS_CORE_WHEEL"
+
+          python scripts/smoke_test_activity_copying_wheel.py `
             "$concordWheel" `
             "$env:PDS_CORE_WHEEL"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Safe Activity copying now reuses only an explicit positive allowlist of
+  configuration, creates a fresh draft Activity plus one fresh planned Session,
+  tightens context-bound privacy, and excludes operational/history state.
+- `concord activity copy-preview|copy` and Activity Management `Copy an Activity`
+  share deterministic review-digest preparation and create-only persistence.
+- Issue #63 qualification adds isolated installed-wheel Activity-copy coverage
+  against the authenticated released Core v0.6.3 wheel.
+
 - Activity-specific reusable Packet instantiation now resolves exact Packet and
   Template Versions against one explicit Activity Session, previews concrete
   targets/copies/pages/routes without mutation, freezes teacher rendering
@@ -158,7 +166,10 @@ All notable changes to this project will be documented in this file.
   (`GroupPlan`/`PlannedGroup`) from operational Group/Membership management;
   GroupPlan approval still creates no canonical Groups, while issue #56 now
   implements the sole explicit canonical application boundary.
-- Began the v0.3 development line as `0.3.0.dev0` and raised the Core runtime minimum to `pds-core>=0.6.1,<0.7`; active CI/package/installed acceptance qualifies against the exact released Core v0.6.1 wheel while historical v0.2.0 release evidence remains bound to Core v0.6.0.
+- Current v0.3 development now targets the latest released PDS dependency baseline,
+  `pds-core>=0.6.3,<0.7`; active CI/package/installed acceptance authenticates
+  the exact released Core v0.6.3 wheel while historical release/fixture evidence
+  remains bound to the versions under which it was originally qualified.
 
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 Concord is the Paper Data Suite module for paper-first, human-reviewed evidence
 created during collaborative classroom Activities. The released v0.2.0 artifact
 remains historically qualified against `pds-core` v0.6.0. Current source is the
-v0.3.0 development line (`0.3.0.dev0`) and requires `pds-core>=0.6.1,<0.7`
-because v0.3 consumes Core's neutral `grouping_signal_set_v1` contract. Official
+v0.3.0 development line (`0.3.0.dev0`) and requires `pds-core>=0.6.3,<0.7`
+under the suite policy of developing against the latest released PDS
+dependencies. The neutral `grouping_signal_set_v1` contract introduced in
+Core 0.6.1 remains the grouping-signal boundary consumed by Concord. Official
 release artifacts are distributed through GitHub Releases only after independent
 review, hosted CI, merge, and exact-main requalification.
 
@@ -52,6 +54,9 @@ PDS2 identities, deterministic starter-layout PDFs, explicit recovery/reprint,
 direct runtime Packet commands, and the opened-Activity `Prepare / Generate
 Packet` teacher workflow. The same typed service layer supports both fully
 noninteractive direct commands and the low-information-density menu.
+Issue #63 now adds safe Activity copying: exact source selection, a positive
+configuration allowlist, target-specific privacy resolution, one fresh first
+Session, zero-write review digests, and create-only commit semantics.
 Canonical state remains protected by immutable history, exact expected-snapshot
 concurrency, and guarded batch commits.
 
@@ -77,28 +82,30 @@ authoritative release qualification.
 ## Requirements and installation
 
 Current Concord development requires Python 3.11 or newer and
-`pds-core>=0.6.1,<0.7`. Core is distributed as authenticated GitHub Release
+`pds-core>=0.6.3,<0.7`. Core is distributed as authenticated GitHub Release
 artifacts rather than through PyPI. For v0.3 development, download the released
-`pds_core-0.6.1-py3-none-any.whl` and, when qualifying the external fixture
-asset, `pds-core-0.6.1-grouping-signal-fixtures.zip` from the
-[pds-core v0.6.1 release](https://github.com/Paper-Data-Suite/pds-core/releases/tag/v0.6.1),
-then verify/install the wheel before installing Concord from source:
+`pds_core-0.6.3-py3-none-any.whl` from the
+[pds-core v0.6.3 release](https://github.com/Paper-Data-Suite/pds-core/releases/tag/v0.6.3).
+When qualifying the immutable grouping-signal fixture asset, continue to use
+`pds-core-0.6.1-grouping-signal-fixtures.zip` from the historical
+[pds-core v0.6.1 release](https://github.com/Paper-Data-Suite/pds-core/releases/tag/v0.6.1).
+Then verify/install the Core 0.6.3 wheel before installing Concord from source:
 
 ```powershell
-python scripts/verify_core_wheel.py path\to\pds_core-0.6.1-py3-none-any.whl
+python scripts/verify_core_wheel.py path\to\pds_core-0.6.3-py3-none-any.whl
 python scripts/verify_core_grouping_fixtures.py path\to\pds-core-0.6.1-grouping-signal-fixtures.zip
-python -m pip install path\to\pds_core-0.6.1-py3-none-any.whl
+python -m pip install path\to\pds_core-0.6.3-py3-none-any.whl
 python -m pip install -e ".[dev]"
 ```
 
 Historical v0.2.0 release installation remains documented by the `v0.2.0`
 tag and its release checklist. That tagged source uses Core 0.6.0 and its own
 version of `scripts/verify_core_wheel.py`; the current v0.3 development verifier
-intentionally authenticates only the Core 0.6.1 wheel.
+intentionally authenticates only the Core 0.6.3 wheel.
 
 The Concord v0.2.0 wheel and checksum file remain available through that
 historical GitHub Release and must be authenticated against its published
-`SHA256SUMS.txt`. For current source development, use the Core 0.6.1 procedure
+`SHA256SUMS.txt`. For current source development, use the Core 0.6.3 procedure
 above.
 
 ## Teacher menu
@@ -126,7 +133,7 @@ Q. Quit
 ```
 
 Every menu write shows a focused review screen and requires the operation word
-`CREATE`, `RENDER`, `ASSEMBLE`, `ROUTE`, `RESOLVE`, `CONFIRM`,
+`CREATE`, `COPY`, `RENDER`, `ASSEMBLE`, `ROUTE`, `RESOLVE`, `CONFIRM`,
 `DISTRIBUTE`, `LEAVE`, `APPLY`, `UPDATE`, `ADD`, `CORRECT`, `REVIEW`,
 `MODERATE`, `SCORE`, `REVISE`, `ACTIVATE`, `RETIRE`, `END`, `REASSIGN`,
 `REGISTER`, `GENERATE`, `PUBLISH`, `WITHDRAW`, or `REBUILD`.
@@ -142,6 +149,7 @@ the screen, pause, or call `input()`.
 ```text
 concord workspace show|set|validate|reset
 concord activity create|list|show|update|set-status
+concord activity copy-preview|copy
 concord session add|list|show|update|set-status
 concord group create|list|show|update|set-status
 concord group member add|list|end|reassign
@@ -181,9 +189,10 @@ concord publication publish|supersede|withdraw|series-show
 concord publication catalog-list|catalog-rebuild
 ```
 
-Mutating direct commands require explicit actor context. Every write after the
-initial Activity-plus-first-Session creation also requires the exact current
-snapshot revision. Template mutations after initial Template creation likewise
+Mutating direct commands require explicit actor context. Mutations of existing
+Activity state require the exact current snapshot revision. Activity copy is a
+separate create-only exception: `copy-preview` performs zero-write review and
+`copy` requires its exact digest before creating a fresh target Activity/Session. Template mutations after initial Template creation likewise
 require `--expected-snapshot`, but that value is the exact reusable Template
 library snapshot rather than an Activity snapshot. Packet mutations after
 initial Packet creation use the same flag for the exact reusable Packet-library
@@ -243,7 +252,7 @@ catalog reconciliation are documented in the
 Consumer-neutral manifest interpretation and authorization-gated bounded Artifact
 access are documented in the
 [consumer reader guide](docs/implementation/academic-result-reader.md). The v0.3
-Core 0.6.1 dependency and neutral grouping-signal boundary are documented in the
+Core 0.6.3 dependency and neutral grouping-signal boundary are documented in the
 [grouping-signal integration guide](docs/v0.3.0-core-grouping-signal-integration.md).
 The planning-only record/lifecycle foundation is documented in the
 [GroupPlan contract](docs/v0.3.0-group-plan-contract.md), and issue #51's manual
@@ -301,7 +310,7 @@ Run focused checks with `python -m pytest`, `python -m ruff check .`, and
 `python -m mypy`. Run the complete repository validation on Windows with:
 
 ```powershell
-.\run_tests.ps1 -CoreWheel path\to\pds_core-0.6.1-py3-none-any.whl
+.\run_tests.ps1 -CoreWheel path\to\pds_core-0.6.3-py3-none-any.whl
 ```
 
 The cross-platform equivalent is:
@@ -310,7 +319,7 @@ The cross-platform equivalent is:
 python scripts/validate_repository.py --core-wheel <wheel>
 ```
 
-The validator authenticates the exact Core v0.6.1 wheel, runs pytest, Ruff,
+The validator authenticates the exact Core v0.6.3 wheel, runs pytest, Ruff,
 strict Mypy, documentation checks, package builds, Twine validation, package
 inspection, isolated installed-wheel workflow/menu/public-reader smoke tests, and
 the full installed Activity-to-publication producer acceptance before

--- a/concord/cli_app/handlers/activity.py
+++ b/concord/cli_app/handlers/activity.py
@@ -10,18 +10,24 @@ from concord.cli_app.common import (
     workspace_arg,
 )
 from concord.cli_app.output import (
+    print_activity_copy_preview,
     print_activity_detail,
     print_activity_summary,
     print_commit,
 )
 from concord.workflows import (
+    CopyActivityRequest,
     CreateActivityContextRequest,
+    PrepareActivityCopyRequest,
     UpdateActivityRequest,
+    copy_activity,
     create_activity_context,
     list_activities,
+    prepare_activity_copy,
     show_activity,
     update_activity,
 )
+from concord.workflows.models import UNSET, OptionalTextUpdate, TextUpdate
 
 
 def handle_create(args: argparse.Namespace) -> int:
@@ -52,6 +58,64 @@ def handle_create(args: argparse.Namespace) -> int:
     )
     print_commit(result.commit)
     print(f"First Session: {result.first_session_id}")
+    return 0
+
+
+def _prepare_copy_request(args: argparse.Namespace) -> PrepareActivityCopyRequest:
+    title: TextUpdate = UNSET if args.title is None else args.title
+    description: OptionalTextUpdate
+    if args.clear_description:
+        description = None
+    elif args.description is not None:
+        description = args.description
+    else:
+        description = UNSET
+    return PrepareActivityCopyRequest(
+        source_class_id=args.source_class_id,
+        source_activity_id=args.source_activity_id,
+        target_class_id=args.target_class_id,
+        target_activity_id=args.target_activity_id,
+        first_session_id=args.session_id,
+        first_session_label=args.session_label,
+        title=title,
+        description=description,
+    )
+
+
+def handle_copy_preview(args: argparse.Namespace) -> int:
+    # Actor context is required and structurally validated for parity with the
+    # eventual write, but is intentionally absent from the semantic review digest.
+    workflow_actor(args)
+    prepared = prepare_activity_copy(
+        _prepare_copy_request(args),
+        workspace_root=workspace_arg(args),
+        standards_library=load_command_standards_library(args),
+    )
+    print_activity_copy_preview(prepared)
+    return 0
+
+
+def handle_copy(args: argparse.Namespace) -> int:
+    prepared_request = _prepare_copy_request(args)
+    result = copy_activity(
+        CopyActivityRequest(
+            source_class_id=prepared_request.source_class_id,
+            source_activity_id=prepared_request.source_activity_id,
+            target_class_id=prepared_request.target_class_id,
+            target_activity_id=prepared_request.target_activity_id,
+            first_session_id=prepared_request.first_session_id,
+            actor=workflow_actor(args),
+            review_digest=args.review_digest,
+            title=prepared_request.title,
+            description=prepared_request.description,
+            first_session_label=prepared_request.first_session_label,
+        ),
+        workspace_root=workspace_arg(args),
+        standards_library=load_command_standards_library(args),
+    )
+    print_commit(result.commit)
+    print(f"First Session: {result.first_session_id}")
+    print(f"Review digest: {result.review_digest}")
     return 0
 
 

--- a/concord/cli_app/output.py
+++ b/concord/cli_app/output.py
@@ -9,6 +9,7 @@ from concord.workflows import (
     GroupDetail,
     GroupSummary,
     MembershipSummary,
+    PreparedActivityCopy,
     ResponsibilitySummary,
     RoleSummary,
     SessionSummary,
@@ -31,6 +32,44 @@ def print_commit(result: WorkflowCommitResult) -> None:
             for item in result.changed_records
         )
         print(f"Changed: {changed}")
+
+
+def print_activity_copy_preview(item: PreparedActivityCopy) -> None:
+    print(
+        f"Source Activity: {item.source_class_id}/{item.source_activity_id}"
+    )
+    print(f"Source status: {item.source_status}")
+    print(
+        f"Target Activity: {item.target_class_id}/{item.target_activity_id}"
+    )
+    print("Target status: draft")
+    print(f"Title: {item.title}")
+    print(f"Description: {item.description if item.description is not None else '-'}")
+    print(f"Activity type: {item.activity_type}")
+    print(f"Scoring orientation: {item.scoring_orientation}")
+    print(f"Standards profile: {item.standards_profile_id or '-'}")
+    print(
+        "Focus standards: "
+        + (", ".join(item.focus_standard_ids) if item.focus_standard_ids else "-")
+    )
+    classification = (
+        item.privacy_policy.classification
+        if item.privacy_policy is not None
+        else "none"
+    )
+    print(f"Target privacy: {classification}")
+    print(
+        f"First Session: {item.first_session_id}"
+        + (f" ({item.first_session_label})" if item.first_session_label else "")
+    )
+    if item.diagnostics:
+        print("Diagnostics:")
+        for diagnostic in item.diagnostics:
+            print(f"- {diagnostic.code}: {diagnostic.message}")
+    print("Will not copy:")
+    for excluded in item.excluded_state:
+        print(f"- {excluded}")
+    print(f"Review digest: {item.review_digest}")
 
 
 def print_activity_summary(item: ActivitySummary) -> None:

--- a/concord/cli_app/parser.py
+++ b/concord/cli_app/parser.py
@@ -539,6 +539,40 @@ def _activity_commands(
     create.add_argument("--session-notes")
     create.set_defaults(handler=activity.handle_create)
 
+    def copy_options(command: argparse.ArgumentParser) -> None:
+        _workspace_option(command)
+        _actor_options(command)
+        _standards_option(command)
+        command.add_argument("--source-class-id", required=True)
+        command.add_argument("--source-activity-id", required=True)
+        command.add_argument("--target-class-id", required=True)
+        command.add_argument("--target-activity-id", required=True)
+        command.add_argument("--title")
+        description = command.add_mutually_exclusive_group()
+        description.add_argument("--description")
+        description.add_argument("--clear-description", action="store_true")
+        command.add_argument("--session-id", required=True)
+        command.add_argument("--session-label")
+
+    copy_preview = actions.add_parser(
+        "copy-preview",
+        help="Prepare an exact zero-write Activity copy and review digest.",
+    )
+    copy_options(copy_preview)
+    copy_preview.set_defaults(handler=activity.handle_copy_preview)
+
+    copy_command = actions.add_parser(
+        "copy",
+        help="Create one fresh Activity from an exact reviewed copy preview.",
+    )
+    copy_options(copy_command)
+    copy_command.add_argument(
+        "--review-digest",
+        required=True,
+        help="Exact review digest printed by activity copy-preview.",
+    )
+    copy_command.set_defaults(handler=activity.handle_copy)
+
     list_command = actions.add_parser("list", help="List current Activities.")
     _workspace_option(list_command)
     list_command.add_argument("--class-id")

--- a/concord/menu_activity.py
+++ b/concord/menu_activity.py
@@ -46,8 +46,12 @@ from concord.workflows import (
     ActivitySummary,
     ClassSummary,
     ConcordWorkflowError,
+    CopyActivityRequest,
     CreateActivityContextRequest,
+    PrepareActivityCopyRequest,
+    PreparedActivityCopy,
     UpdateActivityRequest,
+    copy_activity,
     create_activity_context,
     list_activities,
     list_available_classes,
@@ -56,10 +60,12 @@ from concord.workflows import (
     list_responsibilities,
     list_roles,
     list_sessions,
+    prepare_activity_copy,
     resolve_read_workspace_root,
     show_activity,
     update_activity,
 )
+from concord.workflows.models import UNSET, OptionalTextUpdate, TextUpdate
 
 _ACTIVITY_TYPES = ("socratic_seminar", "laboratory", "project")
 _SCORING_ORIENTATIONS = (
@@ -330,6 +336,256 @@ def _create_activity(state: MenuSessionContext) -> None:
         show_partial_success(error)
     except Exception as error:
         show_result("Activity Error", (str(error),))
+
+
+def _copy_title(source_title: str) -> TextUpdate:
+    while True:
+        clear_screen()
+        print_menu_header("Copy Activity Title")
+        print(f"Source: {source_title}")
+        print()
+        print("1. Keep source title")
+        print("2. Replace title")
+        print_navigation()
+        print()
+        raw = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(raw)
+        if navigation is ConcordMenuChoice.HELP:
+            clear_screen()
+            print_menu_header("Copy Activity Title Help")
+            print("Keep the source title as a reviewed copied value, or replace it.")
+            print("Either choice affects only the new Activity.")
+            print()
+            pause_for_user()
+            continue
+        if navigation is NavigationChoice.BACK:
+            raise CancelMenuAction
+        if raw == "1":
+            return UNSET
+        if raw == "2":
+            replacement = prompt_text(
+                "Copy Activity Title",
+                "New title",
+                help_text=(
+                    "Enter the starting teacher-facing title for the new Activity."
+                ),
+            )
+            assert replacement is not None
+            return replacement
+        print(navigation_hint_with_help())
+        pause_for_user()
+
+
+def _copy_description(source_description: str | None) -> OptionalTextUpdate:
+    while True:
+        clear_screen()
+        print_menu_header("Copy Activity Description")
+        source_label = source_description if source_description is not None else "-"
+        print(f"Source: {source_label}")
+        print()
+        print("1. Keep source description")
+        print("2. Replace description")
+        print("3. Clear description")
+        print_navigation()
+        print()
+        raw = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(raw)
+        if navigation is ConcordMenuChoice.HELP:
+            clear_screen()
+            print_menu_header("Copy Activity Description Help")
+            print("Choose whether the new Activity starts with the source description,")
+            print("a replacement, or no description. The source is never changed.")
+            print()
+            pause_for_user()
+            continue
+        if navigation is NavigationChoice.BACK:
+            raise CancelMenuAction
+        if raw == "1":
+            return UNSET
+        if raw == "2":
+            replacement = prompt_text(
+                "Copy Activity Description",
+                "New description",
+                help_text="Enter the starting description for the new Activity.",
+            )
+            assert replacement is not None
+            return replacement
+        if raw == "3":
+            return None
+        print(navigation_hint_with_help())
+        pause_for_user()
+
+
+def _copy_review_lines(prepared: PreparedActivityCopy) -> tuple[str, ...]:
+    privacy = (
+        prepared.privacy_policy.classification
+        if prepared.privacy_policy is not None
+        else "none"
+    )
+    description = prepared.description if prepared.description is not None else "-"
+    lines = [
+        f"Source: {prepared.source_class_id}/{prepared.source_activity_id}",
+        f"Source status (not copied): {prepared.source_status}",
+        f"Target: {prepared.target_class_id}/{prepared.target_activity_id}",
+        f"Title: {prepared.title}",
+        f"Description: {description}",
+        f"Type / scoring: {prepared.activity_type} / {prepared.scoring_orientation}",
+        f"Target privacy: {privacy}",
+        f"First Session: {prepared.first_session_label or prepared.first_session_id}",
+    ]
+    if prepared.standards_profile_id is not None:
+        lines.append(f"Standards profile: {prepared.standards_profile_id}")
+        lines.append("Focus Standards (ordered):")
+        lines.extend(
+            f"  {index}. {standard_id}"
+            for index, standard_id in enumerate(prepared.focus_standard_ids, start=1)
+        )
+    for diagnostic in prepared.diagnostics:
+        lines.append(f"Notice: {diagnostic.message}")
+    lines.extend(
+        (
+            "NOT COPIED: source Sessions/Groups/Memberships/GroupPlans/signals/roles",
+            "NOT COPIED: Packets/Artifacts/routes/scans/evidence/reviews/moderation",
+            "NOT COPIED: Criterion Sets/Scales/Scores/publications/history/provenance",
+            f"Review digest: {prepared.review_digest}",
+        )
+    )
+    return tuple(lines)
+
+
+def _confirm_copy(lines: tuple[str, ...]) -> bool:
+    while True:
+        clear_screen()
+        print_menu_header("Copy an Activity")
+        for line in lines:
+            print(line)
+        print()
+        print(
+            "Type COPY exactly to create the independent Activity, "
+            "or Enter to cancel."
+        )
+        print_navigation()
+        print()
+        raw = input("Confirmation: ").strip()
+        navigation = parse_menu_navigation(raw)
+        if navigation is ConcordMenuChoice.HELP:
+            clear_screen()
+            print_menu_header("Copy an Activity Help")
+            print("COPY creates a new draft Activity and one fresh planned Session.")
+            print("It does not clone prior classroom state or history.")
+            print()
+            pause_for_user()
+            continue
+        if navigation is NavigationChoice.BACK or not raw:
+            return False
+        if raw == "COPY":
+            return True
+        print("Type uppercase COPY exactly, or use H, B, M, or Q.")
+        pause_for_user()
+
+
+def _copy_activity(state: MenuSessionContext) -> None:
+    try:
+        root = resolve_read_workspace_root()
+        if root is None:
+            show_result(
+                "Copy an Activity",
+                ("The Paper Data Suite workspace does not exist yet.",),
+            )
+            return
+        classes = list_available_classes(root)
+        activities = list_activities(workspace_root=root)
+        if not classes or not activities:
+            show_result(
+                "Copy an Activity",
+                ("An existing Core class and source Concord Activity are required.",),
+            )
+            return
+        source = select_one(
+            "Copy Source Activity",
+            activities,
+            tuple(
+                f"{item.title} ({item.class_id} / {item.activity_id}) - {item.status}"
+                for item in activities
+            ),
+            help_text=(
+                "Choose the exact canonical Activity whose configuration "
+                "starts the copy."
+            ),
+        )
+        detail = show_activity(source.class_id, source.activity_id, workspace_root=root)
+        target_class = choose_class(classes)
+        target_id = prompt_text(
+            "Copy an Activity",
+            "New Activity ID",
+            help_text="Choose a fresh class-qualified Activity ID for the target.",
+            default=slug_identifier(f"{source.activity_id}-copy", "activity-copy"),
+        )
+        assert target_id is not None
+        title = _copy_title(detail.summary.title)
+        description = _copy_description(detail.description)
+        session_id = prompt_text(
+            "Copy an Activity",
+            "First Session ID",
+            help_text="The copied Activity receives one fresh planned Session.",
+            default=slug_identifier(f"{target_id}-session-1", "session-1"),
+        )
+        assert session_id is not None
+        session_label = prompt_text(
+            "Copy an Activity",
+            "First Session label",
+            help_text="Optional target-only label; no source Session label is copied.",
+            optional=True,
+        )
+        library = load_menu_standards_library()
+        prepare_request = PrepareActivityCopyRequest(
+            source_class_id=source.class_id,
+            source_activity_id=source.activity_id,
+            target_class_id=target_class.class_id,
+            target_activity_id=target_id,
+            first_session_id=session_id,
+            title=title,
+            description=description,
+            first_session_label=session_label,
+        )
+        prepared = prepare_activity_copy(
+            prepare_request,
+            workspace_root=root,
+            standards_library=library,
+        )
+        if not _confirm_copy(_copy_review_lines(prepared)):
+            return
+        result = copy_activity(
+            CopyActivityRequest(
+                source_class_id=prepare_request.source_class_id,
+                source_activity_id=prepare_request.source_activity_id,
+                target_class_id=prepare_request.target_class_id,
+                target_activity_id=prepare_request.target_activity_id,
+                first_session_id=prepare_request.first_session_id,
+                actor=state.require_actor(),
+                review_digest=prepared.review_digest,
+                title=prepare_request.title,
+                description=prepare_request.description,
+                first_session_label=prepare_request.first_session_label,
+            ),
+            workspace_root=root,
+            standards_library=library,
+        )
+        show_result(
+            "Activity Copy Result",
+            (
+                "Independent draft Activity created.",
+                f"Activity: {result.activity_id}",
+                f"First Session: {result.first_session_id}",
+                f"Snapshot: {result.commit.snapshot_revision}",
+            ),
+        )
+    except CancelMenuAction:
+        return
+    except ConcordStoragePartialSuccessError as error:
+        show_partial_success(error)
+    except Exception as error:
+        show_result("Activity Copy Error", (str(error),))
 
 
 def _update_activity_field(
@@ -606,8 +862,9 @@ def launch_activity_management_menu(
         clear_screen()
         print_menu_header("Activity Management")
         print("1. Create an Activity")
-        print("2. List Activities")
-        print("3. Open an Activity")
+        print("2. Copy an Activity")
+        print("3. List Activities")
+        print("4. Open an Activity")
         print_navigation()
         print()
         choice = input("Select an option: ").strip()
@@ -619,10 +876,12 @@ def launch_activity_management_menu(
         elif choice == "1":
             _create_activity(session_state)
         elif choice == "2":
+            _copy_activity(session_state)
+        elif choice == "3":
             activity = select_activity()
             if activity is not None:
                 _print_summary(activity)
-        elif choice == "3":
+        elif choice == "4":
             activity = select_activity()
             if activity is not None:
                 launch_activity_context_menu(activity, session_state)

--- a/concord/workflows/__init__.py
+++ b/concord/workflows/__init__.py
@@ -6,6 +6,15 @@ from concord.workflows.activity import (
     show_activity,
     update_activity,
 )
+from concord.workflows.activity_copy import (
+    ActivityCopyDiagnostic,
+    ActivityCopyResult,
+    CopyActivityRequest,
+    PrepareActivityCopyRequest,
+    PreparedActivityCopy,
+    copy_activity,
+    prepare_activity_copy,
+)
 from concord.workflows.artifact import (
     ArtifactDetail,
     ArtifactScanOccurrenceSummary,
@@ -413,6 +422,13 @@ from concord.workflows.template import (
 )
 
 __all__ = [
+    "ActivityCopyDiagnostic",
+    "ActivityCopyResult",
+    "CopyActivityRequest",
+    "PrepareActivityCopyRequest",
+    "PreparedActivityCopy",
+    "copy_activity",
+    "prepare_activity_copy",
     "PacketDetail",
     "PacketMutationResult",
     "PacketSummary",

--- a/concord/workflows/activity_copy.py
+++ b/concord/workflows/activity_copy.py
@@ -1,0 +1,573 @@
+"""Safe, zero-write preparation and create-only commit for Activity copying."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef
+from pds_core.standards import StandardsLibrary
+
+from concord.model_validation import (
+    ConcordRecordGraph,
+    validate_core_standards,
+    validate_record_graph,
+)
+from concord.models import (
+    Activity,
+    ActorReference,
+    ConcordRecordReference,
+    PrivacyPolicy,
+    Provenance,
+    Session,
+    SubjectReference,
+)
+from concord.storage import (
+    commit_record_batch,
+    list_activity_work_refs,
+    load_current_record,
+)
+from concord.storage_errors import (
+    ConcordStorageConflictError,
+    ConcordStorageNotFoundError,
+)
+from concord.validation_diagnostics import ConcordRecordGraphError
+from concord.workflows.context import (
+    Clock,
+    provenance,
+    require_core_class,
+    resolve_read_workspace_root,
+)
+from concord.workflows.errors import (
+    ConcordWorkflowConflictError,
+    ConcordWorkflowNotFoundError,
+    ConcordWorkflowValidationError,
+)
+from concord.workflows.models import (
+    UNSET,
+    OptionalTextUpdate,
+    TextUpdate,
+    WorkflowActor,
+    WorkflowCommitResult,
+)
+
+_COPY_REVIEW_SCHEMA = "concord_activity_copy_review_v1"
+_EXCLUDED_STATE = (
+    "source lifecycle status and provenance/history",
+    "source Sessions beyond the required fresh first target Session",
+    "Groups, Memberships, GroupPlans, grouping signals, Roles, and Responsibilities",
+    "PacketInstances/generations, Artifacts/Pages/routes, scans, and evidence",
+    "Authors, Subjects, Reviews, Moderation, CriterionSets, ScoringScales, and Scores",
+    "manifests, Academic Work Registration, publications, catalog history, "
+    "and snapshots",
+    "source external_reference_ids",
+)
+
+_PREVIEW_PROVENANCE = Provenance(
+    actor=ActorReference(
+        actor_kind="system",
+        actor_id="activity-copy-preview",
+        owning_system="concord",
+    ),
+    timestamp="1970-01-01T00:00:00+00:00",
+    source_kind="system",
+    application_version="preview",
+)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ActivityCopyDiagnostic:
+    """One visible, deterministic preparation diagnostic."""
+
+    code: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PrepareActivityCopyRequest:
+    """Explicit source/target inputs for zero-write Activity-copy preparation."""
+
+    source_class_id: str
+    source_activity_id: str
+    target_class_id: str
+    target_activity_id: str
+    first_session_id: str
+    title: TextUpdate = UNSET
+    description: OptionalTextUpdate = UNSET
+    first_session_label: str | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PreparedActivityCopy:
+    """Exact teacher-review surface for one proposed independent Activity."""
+
+    source_class_id: str
+    source_activity_id: str
+    source_status: str
+    target_class_id: str
+    target_activity_id: str
+    title: str
+    description: str | None
+    activity_type: str
+    scoring_orientation: str
+    standards_profile_id: str | None
+    focus_standard_ids: tuple[str, ...]
+    privacy_policy: PrivacyPolicy | None
+    first_session_id: str
+    first_session_label: str | None
+    diagnostics: tuple[ActivityCopyDiagnostic, ...]
+    excluded_state: tuple[str, ...]
+    review_digest: str
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class CopyActivityRequest:
+    """Commit request that must reproduce one exact reviewed preparation."""
+
+    source_class_id: str
+    source_activity_id: str
+    target_class_id: str
+    target_activity_id: str
+    first_session_id: str
+    actor: WorkflowActor
+    review_digest: str
+    title: TextUpdate = UNSET
+    description: OptionalTextUpdate = UNSET
+    first_session_label: str | None = None
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ActivityCopyResult:
+    """Committed identity for a fresh copied Activity work graph."""
+
+    commit: WorkflowCommitResult
+    activity_id: str
+    first_session_id: str
+    review_digest: str
+
+
+def _work(class_id: str, activity_id: str) -> ModuleWorkRef:
+    return ModuleWorkRef(module_id="concord", class_id=class_id, work_id=activity_id)
+
+
+def _resolve_title(source: Activity, value: TextUpdate) -> str:
+    if isinstance(value, str):
+        return value
+    return source.title
+
+
+def _resolve_description(source: Activity, value: OptionalTextUpdate) -> str | None:
+    if isinstance(value, str) or value is None:
+        return value
+    return source.description
+
+
+def _subject_reference_payload(reference: SubjectReference) -> dict[str, Any]:
+    return {
+        "subject_kind": reference.subject_kind,
+        "subject_id": reference.subject_id,
+        "owning_system": reference.owning_system,
+        "contract_version": reference.contract_version,
+    }
+
+
+def _module_reference_payload(
+    reference: ModuleRecordRef | None,
+) -> dict[str, Any] | None:
+    if reference is None:
+        return None
+    return {
+        "module_id": reference.module_id,
+        "record_kind": reference.record_kind,
+        "record_id": reference.record_id,
+        "contract_version": reference.contract_version,
+    }
+
+
+def _concord_reference_payload(
+    reference: ConcordRecordReference | None,
+) -> dict[str, Any] | None:
+    if reference is None:
+        return None
+    return {
+        "record_kind": reference.record_kind,
+        "record_id": reference.record_id,
+        "contract_version": reference.contract_version,
+    }
+
+
+def _privacy_payload(policy: PrivacyPolicy | None) -> dict[str, Any] | None:
+    if policy is None:
+        return None
+    return {
+        "classification": policy.classification,
+        "audience_references": [
+            _subject_reference_payload(item) for item in policy.audience_references
+        ],
+        "policy_reference": _module_reference_payload(policy.policy_reference),
+        "reason": policy.reason,
+        "inherited_from": _concord_reference_payload(policy.inherited_from),
+    }
+
+
+def _resolve_privacy(
+    policy: PrivacyPolicy | None,
+) -> tuple[PrivacyPolicy | None, tuple[ActivityCopyDiagnostic, ...]]:
+    if policy is None:
+        return None, ()
+    context_free = (
+        not policy.audience_references
+        and policy.policy_reference is None
+        and policy.inherited_from is None
+    )
+    if context_free and policy.classification in {
+        "teacher_restricted",
+        "classroom_shared",
+    }:
+        return (
+            PrivacyPolicy(classification=policy.classification),
+            (),
+        )
+    return (
+        PrivacyPolicy(classification="teacher_restricted"),
+        (
+            ActivityCopyDiagnostic(
+                code="privacy_context_not_copied",
+                message=(
+                    "Source privacy depends on source-context audience or policy "
+                    "references. The target is restricted to teacher_restricted; "
+                    "source audience/reference state will not be copied."
+                ),
+            ),
+        ),
+    )
+
+
+def _source_activity(
+    root: Path,
+    request: PrepareActivityCopyRequest,
+) -> Activity:
+    require_core_class(root, request.source_class_id)
+    work = _work(request.source_class_id, request.source_activity_id)
+    try:
+        record, _ = load_current_record(
+            root,
+            work,
+            "activity",
+            request.source_activity_id,
+        )
+    except ConcordStorageNotFoundError as error:
+        raise ConcordWorkflowNotFoundError(
+            "Source Activity is not available: "
+            f"{request.source_class_id}/{request.source_activity_id}"
+        ) from error
+    if not isinstance(record, Activity):
+        raise ConcordWorkflowNotFoundError(
+            "Source Activity is not available: "
+            f"{request.source_class_id}/{request.source_activity_id}"
+        )
+    if record.activity_id != request.source_activity_id:
+        raise ConcordWorkflowValidationError(
+            "Source Activity identity disagrees with its canonical work path."
+        )
+    return record
+
+
+def _target_is_available(root: Path, request: PrepareActivityCopyRequest) -> None:
+    if (
+        request.source_class_id == request.target_class_id
+        and request.source_activity_id == request.target_activity_id
+    ):
+        raise ConcordWorkflowValidationError(
+            "The exact source Activity work cannot be its own copy destination."
+        )
+    require_core_class(root, request.target_class_id)
+    target = _work(request.target_class_id, request.target_activity_id)
+    if target in list_activity_work_refs(root, request.target_class_id):
+        raise ConcordWorkflowConflictError(
+            "Target Activity already exists: "
+            f"{request.target_class_id}/{request.target_activity_id}"
+        )
+
+
+def _validate_prepared_graph(
+    activity: Activity,
+    session: Session,
+    standards_library: StandardsLibrary | None,
+) -> None:
+    graph = ConcordRecordGraph(activities=(activity,), sessions=(session,))
+    try:
+        validate_record_graph(graph)
+    except (ConcordRecordGraphError, ValueError) as error:
+        raise ConcordWorkflowValidationError(
+            f"Prepared target Activity is invalid: {error}"
+        ) from error
+
+    has_standards = (
+        activity.standards_profile_id is not None or bool(activity.focus_standard_ids)
+    )
+    if not has_standards:
+        return
+    if activity.standards_profile_id is None:
+        raise ConcordWorkflowValidationError(
+            "Source Focus Standards cannot be copied without a standards profile."
+        )
+    if standards_library is None:
+        raise ConcordWorkflowValidationError(
+            "A current Core standards library is required to copy this Activity."
+        )
+    try:
+        validate_core_standards(graph, standards_library)
+    except (ConcordRecordGraphError, ValueError) as error:
+        raise ConcordWorkflowValidationError(
+            "Source Activity standards configuration is no longer valid in the "
+            f"current Core standards library: {error}"
+        ) from error
+
+
+def _review_payload(
+    source: Activity,
+    request: PrepareActivityCopyRequest,
+    *,
+    title: str,
+    description: str | None,
+    privacy_policy: PrivacyPolicy | None,
+) -> dict[str, Any]:
+    title_from_source = request.title is UNSET
+    description_from_source = request.description is UNSET
+    return {
+        "schema": _COPY_REVIEW_SCHEMA,
+        "source": {
+            "class_id": request.source_class_id,
+            "activity_id": request.source_activity_id,
+            "title": source.title if title_from_source else None,
+            "description": source.description if description_from_source else None,
+            "activity_type": source.activity_type,
+            "scoring_orientation": source.scoring_orientation,
+            "standards_profile_id": source.standards_profile_id,
+            "focus_standard_ids": list(source.focus_standard_ids),
+            "privacy_policy": _privacy_payload(source.privacy_policy),
+        },
+        "target": {
+            "class_id": request.target_class_id,
+            "activity_id": request.target_activity_id,
+            "title_mode": "source" if title_from_source else "override",
+            "title": title,
+            "description_mode": "source" if description_from_source else "override",
+            "description": description,
+            "activity_type": source.activity_type,
+            "scoring_orientation": source.scoring_orientation,
+            "status": "draft",
+            "standards_profile_id": source.standards_profile_id,
+            "focus_standard_ids": list(source.focus_standard_ids),
+            "criterion_set_ids": [],
+            "privacy_policy": _privacy_payload(privacy_policy),
+            "external_reference_ids": [],
+            "first_session": {
+                "session_id": request.first_session_id,
+                "sequence": 1,
+                "status": "planned",
+                "label": request.first_session_label,
+            },
+        },
+    }
+
+
+def _review_digest(payload: dict[str, Any]) -> str:
+    data = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(data).hexdigest()
+
+
+def prepare_activity_copy(
+    request: PrepareActivityCopyRequest,
+    *,
+    workspace_root: str | Path | None = None,
+    standards_library: StandardsLibrary | None = None,
+) -> PreparedActivityCopy:
+    """Prepare an exact Activity copy without creating or mutating any state."""
+    root = resolve_read_workspace_root(workspace_root)
+    if root is None:
+        raise ConcordWorkflowNotFoundError("Paper Data Suite workspace does not exist.")
+
+    source = _source_activity(root, request)
+    _target_is_available(root, request)
+    target_metadata = require_core_class(root, request.target_class_id)
+    title = _resolve_title(source, request.title)
+    description = _resolve_description(source, request.description)
+    privacy_policy, diagnostics = _resolve_privacy(source.privacy_policy)
+
+    target_activity = Activity(
+        activity_id=request.target_activity_id,
+        class_reference=ModuleRecordRef(
+            module_id="core",
+            record_kind="class",
+            record_id=target_metadata.class_id,
+        ),
+        title=title,
+        activity_type=source.activity_type,
+        scoring_orientation=source.scoring_orientation,
+        status="draft",
+        created_provenance=_PREVIEW_PROVENANCE,
+        standards_profile_id=source.standards_profile_id,
+        focus_standard_ids=source.focus_standard_ids,
+        description=description,
+        criterion_set_ids=(),
+        privacy_policy=privacy_policy,
+        external_reference_ids=(),
+    )
+    first_session = Session(
+        session_id=request.first_session_id,
+        activity_id=target_activity.activity_id,
+        sequence=1,
+        status="planned",
+        created_provenance=_PREVIEW_PROVENANCE,
+        label=request.first_session_label,
+    )
+    _validate_prepared_graph(target_activity, first_session, standards_library)
+
+    extra_diagnostics: list[ActivityCopyDiagnostic] = list(diagnostics)
+    if source.criterion_set_ids:
+        extra_diagnostics.append(
+            ActivityCopyDiagnostic(
+                code="criterion_sets_not_copied",
+                message=(
+                    "Source Activity Criterion Set selections are Activity-owned and "
+                    "will not be copied. The target starts with criterion_set_ids=()."
+                ),
+            )
+        )
+    if source.external_reference_ids:
+        extra_diagnostics.append(
+            ActivityCopyDiagnostic(
+                code="external_references_not_copied",
+                message=(
+                    "Source external_reference_ids are contextual relationships and "
+                    "will not be copied."
+                ),
+            )
+        )
+
+    payload = _review_payload(
+        source,
+        request,
+        title=title,
+        description=description,
+        privacy_policy=privacy_policy,
+    )
+    return PreparedActivityCopy(
+        source_class_id=request.source_class_id,
+        source_activity_id=request.source_activity_id,
+        source_status=source.status,
+        target_class_id=request.target_class_id,
+        target_activity_id=request.target_activity_id,
+        title=title,
+        description=description,
+        activity_type=source.activity_type,
+        scoring_orientation=source.scoring_orientation,
+        standards_profile_id=source.standards_profile_id,
+        focus_standard_ids=source.focus_standard_ids,
+        privacy_policy=privacy_policy,
+        first_session_id=request.first_session_id,
+        first_session_label=request.first_session_label,
+        diagnostics=tuple(extra_diagnostics),
+        excluded_state=_EXCLUDED_STATE,
+        review_digest=_review_digest(payload),
+    )
+
+
+def _prepare_request(request: CopyActivityRequest) -> PrepareActivityCopyRequest:
+    return PrepareActivityCopyRequest(
+        source_class_id=request.source_class_id,
+        source_activity_id=request.source_activity_id,
+        target_class_id=request.target_class_id,
+        target_activity_id=request.target_activity_id,
+        first_session_id=request.first_session_id,
+        title=request.title,
+        description=request.description,
+        first_session_label=request.first_session_label,
+    )
+
+
+def copy_activity(
+    request: CopyActivityRequest,
+    *,
+    workspace_root: str | Path | None = None,
+    standards_library: StandardsLibrary | None = None,
+    clock: Clock | None = None,
+) -> ActivityCopyResult:
+    """Commit one exact reviewed copy as a fresh Activity plus fresh first Session."""
+    prepared = prepare_activity_copy(
+        _prepare_request(request),
+        workspace_root=workspace_root,
+        standards_library=standards_library,
+    )
+    if request.review_digest != prepared.review_digest:
+        raise ConcordWorkflowConflictError(
+            "Activity copy review is stale or does not match the requested target. "
+            "Run copy preparation again and review the new digest."
+        )
+
+    root = resolve_read_workspace_root(workspace_root)
+    if root is None:
+        raise ConcordWorkflowNotFoundError("Paper Data Suite workspace does not exist.")
+    target_metadata = require_core_class(root, prepared.target_class_id)
+    created = provenance(request.actor, clock=clock)
+    activity = Activity(
+        activity_id=prepared.target_activity_id,
+        class_reference=ModuleRecordRef(
+            module_id="core",
+            record_kind="class",
+            record_id=target_metadata.class_id,
+        ),
+        title=prepared.title,
+        activity_type=prepared.activity_type,
+        scoring_orientation=prepared.scoring_orientation,
+        status="draft",
+        created_provenance=created,
+        standards_profile_id=prepared.standards_profile_id,
+        focus_standard_ids=prepared.focus_standard_ids,
+        description=prepared.description,
+        criterion_set_ids=(),
+        privacy_policy=prepared.privacy_policy,
+        external_reference_ids=(),
+    )
+    session = Session(
+        session_id=prepared.first_session_id,
+        activity_id=activity.activity_id,
+        sequence=1,
+        status="planned",
+        created_provenance=created,
+        label=prepared.first_session_label,
+    )
+
+    try:
+        result = commit_record_batch(
+            root,
+            activity.work_reference,
+            (activity, session),
+            expected_snapshot_revision=None,
+            standards_library=standards_library,
+        )
+    except ConcordStorageConflictError as error:
+        raise ConcordWorkflowConflictError(str(error)) from error
+    if result.no_op:
+        # A concurrent creator may have won the race after preparation. Treat even
+        # byte-identical target state as a conflict: Activity copy is create-only.
+        raise ConcordWorkflowConflictError(
+            "Target Activity already exists; copy is create-only."
+        )
+
+    return ActivityCopyResult(
+        commit=WorkflowCommitResult.from_storage(result),
+        activity_id=activity.activity_id,
+        first_session_id=session.session_id,
+        review_digest=prepared.review_digest,
+    )

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,8 +19,9 @@ The v0.2.0 vertical slice, installed acceptance, release audit, compatibility
 freeze, and milestone closeout remain historically qualified against `pds-core`
 v0.6.0. Phase 1 v0.3.0 work is tracked by umbrella #47. Issue #48 froze the
 reusable-versus-instance boundaries; issue #49 establishes `0.3.0.dev0`,
-`pds-core>=0.6.1,<0.7`, and the neutral Core `grouping_signal_set_v1` consumer
-baseline without adding a Meridian runtime dependency. Issue #50 now adds the
+the neutral Core `grouping_signal_set_v1` consumer baseline without adding a
+Meridian runtime dependency. Current v0.3 development now targets the latest
+released Core baseline, `pds-core>=0.6.3,<0.7`. Issue #50 now adds the
 native planning-only GroupPlan/PlannedGroup record, immutable history, and typed
 create/replace/read/preview/approve/cancel lifecycle services. Issue #51 now
 implements manual plan-local authoring, exact roster placement and refresh,
@@ -59,7 +60,10 @@ qualification. Issue #62 now implements exact Activity-specific Packet
 instantiation, review-digest-bound commit, fresh Packet/Artifact/Page/Core PDS2
 identity allocation, deterministic starter PDF rendering, typed recovery/reprint,
 direct CLI and opened-Activity menu workflows, installed-wheel smoke, and the
-accepted all-30-starter visual-review gate.
+accepted all-30-starter visual-review gate. Issue #63 now implements safe
+Activity copying with explicit source/target identity, positive reusable
+configuration selection, privacy tightening, deterministic review digest,
+create-only Activity/Session commit, direct CLI, and teacher `COPY` flow.
 
 The repository now contains:
 
@@ -337,17 +341,24 @@ authorship boundaries, typed partial-success recovery, exact reprint, direct
 runtime Packet commands, opened-Activity `GENERATE` flow, installed-wheel smoke,
 and the accepted 30-starter / 35-QR visual-review gate.
 
+### 39. v0.3.0 safe Activity copying
+
+[`v0.3.0-activity-copying.md`](v0.3.0-activity-copying.md)
+
+Documents issue #63's exact source/target identity, positive copy allowlist, fresh first Session, privacy resolution, review-digest concurrency, create-only persistence, direct CLI, teacher `COPY` workflow, Core 0.6.3 development baseline, and installed-wheel qualification.
+
 ### Future v0.3.0 Group Planning / Template / Packet plan
 
 [`pds-group-planning-interoperability-development-plan.md`](pds-group-planning-interoperability-development-plan.md)
 
 This remains the roadmap for future v0.3.0 issues beyond the implemented
-#48-#61 foundations. Issue #57 defines the reusable Template contract, #58
+#48-#63 foundations. Issue #57 defines the reusable Template contract, #58
 implements its canonical storage/management layer, #59 defines the reusable
-Packet contract, #60 implements Packet storage/management, and #61 ships the
-starter collaborative-learning Template library. Activity-specific
-instantiation/copying, reusable presets, guided Activity setup, and final
-integrated teacher UI behavior remain later work.
+Packet contract, #60 implements Packet storage/management, #61 ships the
+starter collaborative-learning Template library, #62 implements Activity-
+specific Packet generation/rendering, and #63 implements safe Activity
+copying. Reusable presets, guided Activity setup, and final integrated
+teacher UI behavior remain later work.
 
 ### 14. PDS2 Artifact Page integration
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -2,8 +2,7 @@
 
 ## Status
 
-Implemented through the v0.3.0 Activity-specific Packet generation and PDS2
-rendering workflow in issue #62.
+Implemented through the v0.3.0 safe Activity-copying workflow in issue #63.
 
 ## Two interfaces, one service layer
 
@@ -36,6 +35,8 @@ concord workspace validate
 concord workspace reset
 
 concord activity create
+concord activity copy-preview
+concord activity copy
 concord activity list
 concord activity show
 concord activity update
@@ -213,6 +214,13 @@ Mutations support explicit actor context:
 
 `--actor-id` is required. Actor identity is provenance, not authentication and
 not Artifact authorship.
+
+Activity copying is a special create-only workflow. `activity copy-preview`
+performs strict zero-write preparation and prints a deterministic review
+digest. `activity copy` requires that exact digest, re-reads the source,
+revalidates Core class/standards/privacy, and creates a fresh draft Activity
+plus one fresh planned Session. It never accepts `--expected-snapshot`,
+overwrite, merge, force, source Session identity, or source operational state.
 
 Every write after initial Activity creation requires:
 
@@ -427,7 +435,7 @@ inspection and returned assembly, explicit Author/Subject management, Artifact
 Review, evidence Moderation, Criterion/Scale/Score workflows, and an explicit
 Publication surface immediately after Scoring. Teacher writes require
 operation-specific words such as `CREATE`, `RENDER`, `ASSEMBLE`, `ADD`,
-`UPDATE`, `CORRECT`, `REVIEW`, `MODERATE`, `SCORE`, `REVISE`, `REGISTER`,
+`UPDATE`, `COPY`, `CORRECT`, `REVIEW`, `MODERATE`, `SCORE`, `REVISE`, `REGISTER`,
 `GENERATE`, `CONFIRM`, `DISTRIBUTE`, `LEAVE`, `APPLY`, `PUBLISH`,
 `WITHDRAW`, `ACTIVATE`, `RETIRE`, and `REBUILD`.
 
@@ -465,7 +473,9 @@ Q. Quit
 ```
 
 Concord reuses Core’s B/M/Q parser and unwind semantics and adds only the H
-adapter. Input is case-insensitive. Ctrl+C and EOF exit cleanly.
+adapter. Navigation input is case-insensitive. The issue #63 Activity-copy
+write confirmation is deliberately stricter and requires uppercase `COPY`
+exactly. Ctrl+C and EOF exit cleanly.
 
 Teacher writes use staged disclosure:
 
@@ -499,8 +509,8 @@ commit success remains valid if disposable catalog rebuilding later fails.
 
 This contract includes returned Artifact assembly, Author/Subject management,
 Artifact Review, evidence Moderation, Criterion Set and Scoring Scale management,
-explicit Score entry/revision, explicit Academic Result Publication, and
-reusable Packet storage/management. It does not add Activity-specific Packet
-Instances or generation (#62), the issue #32 consumer-neutral reader, Meridian
-grading policy, Grade or proficiency calculation, or destructive
+explicit Score entry/revision, explicit Academic Result Publication, reusable
+Packet storage/management, Activity-specific Packet generation, and safe
+Activity copying. It does not add issue #64 reusable assignment/scoring presets,
+Meridian grading policy, Grade or proficiency calculation, or destructive
 collaboration-record deletion.

--- a/docs/design/pds-core-integration-requirements.md
+++ b/docs/design/pds-core-integration-requirements.md
@@ -1,6 +1,6 @@
 # PDS Core Integration Requirements
 
-**Status:** Accepted integration architecture record; Core v0.6.1 is the current v0.3 development baseline
+**Status:** Accepted integration architecture record; Core v0.6.3 is the current v0.3 development baseline
 **Project:** Paper Data Suite
 **Module:** `pds-concord`
 **Issue:** `Paper-Data-Suite/pds-concord#10`
@@ -9,8 +9,9 @@
 **Registry and Meridian reconciliation:** July 29, 2026
 **Core v0.6 reconciliation:** August 4, 2026
 **Core v0.6.1 grouping-signal reconciliation:** August 19, 2026
-**Revision:** 5 — preserves the released Core v0.6.0 routing/registry history and adopts the additive Core v0.6.1 grouping-signal boundary for v0.3 development
-**Current development Core baseline:** `pds-core` 0.6.1, Python 3.11+
+**Core v0.6.3 dependency-baseline reconciliation:** August 26, 2026
+**Revision:** 6 — preserves the released Core v0.6.0 routing/registry history, the additive Core v0.6.1 grouping-signal boundary, and reconciles active development to Core v0.6.3
+**Current development Core baseline:** `pds-core` 0.6.3, Python 3.11+
 **Historical v0.2.0 qualification baseline:** `pds-core` 0.6.0
 
 ## 1. Purpose
@@ -52,9 +53,9 @@ Concord still must implement and validate its own behavior before claiming
 routing or publication support; the Core release does not make Concord routable
 or a publication producer automatically.
 
-For the active v0.3 development line, Core v0.6.1 adds the neutral
-`grouping_signal_set_v1` interchange without changing the established v0.6
-routing or academic-registry ownership. Concord consumes that interchange only
+For the active v0.3 development line, current Core v0.6.3 preserves the neutral
+`grouping_signal_set_v1` interchange introduced in Core v0.6.1 without changing
+the established v0.6 routing or academic-registry ownership. Concord consumes that interchange only
 through Core's public model, CSV, storage, and diagnostic APIs and does not
 import Meridian. See `docs/v0.3.0-core-grouping-signal-integration.md` for the
 current grouping-signal qualification boundary. The historical v0.2.0 release

--- a/docs/v0.3.0-activity-copying.md
+++ b/docs/v0.3.0-activity-copying.md
@@ -1,0 +1,219 @@
+# v0.3.0 safe Activity copying
+
+**Issue:** #63  
+**Status:** Implemented development contract  
+**Development dependency baseline:** `pds-core>=0.6.3,<0.7`
+
+## Purpose
+
+Activity copying reuses selected configuration from one exact canonical Concord
+Activity while creating a completely independent target Activity. It is not a
+record-graph clone, a snapshot copy, or a successor revision of the source.
+
+```text
+copy Activity configuration != clone Activity state
+source Activity != target Activity revision
+```
+
+The workflow is:
+
+```text
+load exact source Activity
+  -> select a positive allowlist of reusable values
+  -> resolve one explicit target Core class
+  -> build a fresh draft target Activity
+  -> build one fresh planned first Session
+  -> zero-write preview and deterministic review_digest
+  -> explicit review
+  -> create one new target Activity work graph
+```
+
+## Exact identity
+
+The source is selected by exact `source_class_id` plus `source_activity_id` and
+resolved as the canonical class-qualified Concord `ModuleWorkRef`. The target is
+selected independently by `target_class_id` plus `target_activity_id`.
+
+Same-class copying is allowed only to a fresh Activity ID. Cross-class copying
+may reuse the same Activity ID because Concord work identity is class-qualified.
+The exact source work can never be its own destination.
+
+The destination is create-only. There is no overwrite, merge, replace, sync,
+force, or update-existing mode.
+
+## Positive reusable allowlist
+
+The target Activity is constructed explicitly from these eligible source values:
+
+- `title`, with an optional target override;
+- `description`, with keep/replace/clear semantics;
+- exact `activity_type`;
+- exact `scoring_orientation`;
+- `standards_profile_id` and ordered `focus_standard_ids`, revalidated against
+  the current Core standards library; and
+- privacy only after target-safe resolution.
+
+The target always receives:
+
+```text
+status = draft
+criterion_set_ids = ()
+external_reference_ids = ()
+fresh created_provenance
+```
+
+Issue #63 does not invent cross-Activity Criterion Set sharing. Reusable
+Criterion/Scale preset authority belongs to issue #64.
+
+## Fresh first Session
+
+Every copied Activity is created atomically with exactly one fresh Session:
+
+```text
+fresh session_id
+target activity_id
+sequence = 1
+status = planned
+fresh created_provenance
+optional target-only label
+```
+
+No source Session identity, lifecycle, dates, notes, chronology, provenance, or
+additional Session series is copied.
+
+## State explicitly excluded
+
+Activity copying does not carry source:
+
+- lifecycle status, source provenance, record revisions, snapshots, or history;
+- Sessions as historical records;
+- Groups, GroupMemberships, GroupPlans, grouping-signal state, Roles, or
+  Responsibilities;
+- PacketInstances or generation state;
+- Artifacts, Artifact Pages, Core PDS2 route IDs, scans, or evidence;
+- Authors, Subjects, Reviews, or Moderation;
+- Criterion Sets, Scoring Scales, Scores, or Score Evidence Links;
+- manifests, Academic Work Registration, Core Publication Records, or catalog
+  history; or
+- `external_reference_ids`.
+
+The source remains read-only. A successful copy does not create a new source
+revision or a source-side copied flag.
+
+## Privacy resolution
+
+Privacy never broadens silently.
+
+- `None` remains `None`.
+- Context-free `teacher_restricted` may remain `teacher_restricted`.
+- Context-free `classroom_shared` may remain `classroom_shared`, and the preview
+  displays that target classification.
+- Context-bound `teacher_and_subjects` or `group_and_teacher`, inherited privacy,
+  external-policy privacy, or any policy carrying source-specific audience or
+  resolution references is not transplanted. The target resolves to
+  `teacher_restricted` with a visible preview diagnostic.
+
+Source Subject, Group, Session, Activity, Artifact, inherited, and external
+policy references never leak into the target privacy policy.
+
+## Standards authority
+
+Core remains authoritative for standards. Concord copies only exact Core-owned
+references and revalidates them before both preview and commit. Missing profiles,
+unknown Focus Standards, standards outside the profile, inactive/deprecated
+selections, or a required-but-missing current standards library block the copy
+before target mutation.
+
+There is no label matching, silent dropping, substitution, or scoring-orientation
+downgrade.
+
+## Zero-write preparation and stale review
+
+`prepare_activity_copy` performs strict canonical reads and produces no target
+state. Its deterministic `review_digest` binds:
+
+- exact source class/Activity identity;
+- copy-relevant source configuration actually used;
+- target class/Activity identity;
+- title/description target choices;
+- Activity type and scoring orientation;
+- standards profile and ordered Focus Standards;
+- resolved target privacy; and
+- fresh first-Session identity/label.
+
+Operational source state that is not copyable is deliberately absent from the
+digest. Adding a Group or other historical/operational state after preview does
+not invalidate the reviewed reusable configuration. Changing a copy-relevant
+source value does invalidate it.
+
+`copy_activity` reruns preparation, compares the exact digest, revalidates the
+source, target Core class, standards, privacy, and target absence, then commits
+the fresh Activity and first Session through canonical Concord storage.
+
+## Direct CLI
+
+The direct interface is deterministic and fully noninteractive:
+
+```text
+concord activity copy-preview
+concord activity copy
+```
+
+Both accept explicit source/target identities, target first-Session identity,
+actor context, optional title/description/session-label choices, workspace root,
+and standards-library selection. `copy` additionally requires:
+
+```text
+--review-digest <exact digest from copy-preview>
+```
+
+`--description` and `--clear-description` are mutually exclusive. Omitting both
+keeps the source description. No copy command accepts an expected source
+snapshot as a substitute for semantic review, and no force/overwrite mode exists.
+
+## Teacher menu
+
+`Activity Management` exposes `Copy an Activity` immediately after ordinary
+Activity creation. The teacher selects one exact source Activity and target Core
+class, supplies a fresh target Activity ID and first Session ID, reviews copied
+configuration, target privacy, diagnostics, and explicit exclusions, then must
+type uppercase:
+
+```text
+COPY
+```
+
+to create the target. H/B/M/Q navigation remains available throughout.
+
+## Core v0.6.3 development baseline
+
+Current Concord v0.3 development targets the latest released Core version:
+
+```text
+pds-core>=0.6.3,<0.7
+pds_core-0.6.3-py3-none-any.whl
+SHA-256: 98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5
+```
+
+Historical v0.6.1 grouping-signal fixture assets may still be used where a test
+specifically authenticates those immutable synthetic fixture bytes. That does
+not make Core 0.6.1 the installed runtime or development dependency baseline.
+
+## Qualification
+
+Issue #63 qualification covers:
+
+- focused positive-allowlist and exclusion tests;
+- same-class/cross-class identity behavior and create-only conflicts;
+- the privacy matrix, including inherited/external/context-bound tightening;
+- deterministic zero-write preview and copy-relevant stale-review detection;
+- source immutability and dense source-history exclusion;
+- fully noninteractive `activity copy-preview` / `activity copy` CLI behavior;
+- teacher Activity Management exposure and exact uppercase `COPY` confirmation;
+- package metadata and release-compatibility checks for Core 0.6.3;
+- authenticated Core 0.6.3 CI on Windows and Ubuntu; and
+- isolated installed-wheel Activity-copy smoke against the released Core 0.6.3
+  wheel.
+
+Activity copying changes no PDF renderer or PDS2 route contract, so issue #63 has
+no new physical/visual PDF acceptance gate.

--- a/docs/v0.3.0-core-grouping-signal-integration.md
+++ b/docs/v0.3.0-core-grouping-signal-integration.md
@@ -2,8 +2,9 @@
 
 **Status:** Implemented development baseline for issue #49
 **Concord development version:** `0.3.0.dev0`
-**Current Core requirement:** `pds-core>=0.6.1,<0.7`
-**Exact qualification release:** `pds-core` v0.6.1
+**Current Core requirement:** `pds-core>=0.6.3,<0.7`
+**Current exact qualification release:** `pds-core` v0.6.3
+**Initial issue #49 qualification release:** `pds-core` v0.6.1
 
 ## Purpose
 
@@ -38,7 +39,7 @@ conforming producers are equally valid inputs.
 
 ## Release qualification
 
-The exact Core artifact used for the v0.3 development baseline is:
+The exact Core artifact originally used for issue #49 grouping-signal qualification was:
 
 ```text
 release tag:
@@ -66,14 +67,15 @@ SHA-256:
 The runtime requirement remains a compatible Core 0.6 range:
 
 ```text
-pds-core>=0.6.1,<0.7
+pds-core>=0.6.3,<0.7
 ```
 
-but repository and CI qualification anchor to the exact released 0.6.1 wheel.
+and current repository/CI qualification anchors to the exact released Core 0.6.3 wheel. The immutable grouping fixture ZIP remains the original 0.6.1 asset because those bytes are historical test evidence, not the runtime dependency.
 
 Historical `pds-concord` v0.2.0 release evidence remains unchanged: v0.2.0 was
-released and qualified against Core 0.6.0. Core 0.6.1 is the current v0.3
-development baseline because the grouping-signal APIs were added in 0.6.1.
+released and qualified against Core 0.6.0. The grouping-signal APIs were
+introduced in Core 0.6.1; current Concord v0.3 development nevertheless
+targets the latest released Core baseline, v0.6.3.
 
 ## Public Core APIs
 
@@ -305,7 +307,7 @@ The isolated-wheel smoke uses:
 ```text
 newly built pds-concord 0.3.0.dev0 wheel
 +
-authenticated pds-core 0.6.1 wheel
+authenticated pds-core 0.6.3 wheel
 ```
 
 and proves that the four Core grouping modules are importable from the installed
@@ -313,7 +315,7 @@ Core package, a synthetic signal can be constructed/canonicalized through Core,
 CSV conversion and signal digest calculation work, and no workspace or sibling
 module is required merely to use the contract.
 
-The existing v0.2 producer lifecycle is also rerun against Core 0.6.1 to prove
+The existing v0.2 producer lifecycle is also rerun against Core 0.6.3 to prove
 that the additive Core release does not regress Concord's established routing,
 publication, reader, Score, non-score, and immutable-history boundaries.
 
@@ -417,7 +419,7 @@ The completed boundary is therefore:
 
 ```text
 pds-concord 0.3.0.dev0
-    -> pds-core>=0.6.1,<0.7
+    -> pds-core>=0.6.3,<0.7
     -> public grouping_signal_set_v1 APIs
 ```
 

--- a/docs/v0.3.0-packet-instantiation-rendering.md
+++ b/docs/v0.3.0-packet-instantiation-rendering.md
@@ -298,7 +298,7 @@ not merely an automated-test artifact.
 ## Installed-wheel and repository qualification
 
 `scripts/smoke_test_wheel.py` includes an isolated installed-distribution Packet
-generation smoke against the released Core 0.6.1 baseline. It creates synthetic
+generation smoke against the released Core 0.6.3 baseline. It creates synthetic
 class/Activity/Group state, installs one packaged starter through canonical
 Template storage, creates an exact reusable Packet, performs zero-write prepare,
 commits native generation and Core routes, renders the Packet PDF, and verifies
@@ -307,7 +307,7 @@ runtime inspection/reprint identities.
 The full repository gate remains:
 
 ```text
-python scripts/validate_repository.py --core-wheel <pds-core-0.6.1 wheel>
+python scripts/validate_repository.py --core-wheel <pds-core-0.6.3 wheel>
 ```
 
 That gate covers pytest, Ruff, strict Mypy, documentation checks, compatibility,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 license-files = ["LICENSE"]
 authors = [{ name = "Stephen Severino" }]
 dependencies = [
-    "pds-core>=0.6.1,<0.7",
+    "pds-core>=0.6.3,<0.7",
     "Pillow>=11,<13",
     "qrcode>=8,<9",
     "pypdfium2>=4.30,<5",

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -69,6 +69,7 @@ STARTER_TEMPLATE_LIBRARY_DOC = (
 PACKET_INSTANTIATION_RENDERING_DOC = (
     ROOT / "docs" / "v0.3.0-packet-instantiation-rendering.md"
 )
+ACTIVITY_COPYING_DOC = ROOT / "docs" / "v0.3.0-activity-copying.md"
 REQUIRED_PACKET_INSTANTIATION_RENDERING_PHRASES = (
     'PacketInstance',
     'PacketTargetContext',
@@ -93,9 +94,23 @@ REQUIRED_PACKET_INSTANTIATION_RENDERING_PHRASES = (
     'artifact_page',
     '35 rendered physical pages',
     '26146b994a273a0ab377846494f5498bf2f16017e6c95b779540d976722874e9',
-    'Core 0.6.1',
+    'Core 0.6.3',
     'Issue #63',
     'Issue #64',
+)
+REQUIRED_ACTIVITY_COPYING_PHRASES = (
+    "copy Activity configuration != clone Activity state",
+    "prepare_activity_copy",
+    "copy_activity",
+    "review_digest",
+    "criterion_set_ids = ()",
+    "external_reference_ids = ()",
+    "teacher_restricted",
+    "concord activity copy-preview",
+    "concord activity copy",
+    "COPY",
+    "pds-core>=0.6.3,<0.7",
+    "pds_core-0.6.3-py3-none-any.whl",
 )
 REQUIRED_STARTER_TEMPLATE_LIBRARY_PHRASES = (
     "30",
@@ -280,7 +295,7 @@ REQUIRED_SIGNAL_GROUP_PLAN_DOC_PHRASES = (
     "Issue #56",
 )
 REQUIRED_GROUPING_SIGNAL_DOC_PHRASES = (
-    "pds-core>=0.6.1,<0.7",
+    "pds-core>=0.6.3,<0.7",
     "grouping_signal_set_v1",
     "pds_core.grouping_signal_storage",
     "pds_core.grouping_signal_diagnostics",
@@ -668,6 +683,20 @@ def check_documentation() -> None:
                 "Documentation index does not link the Packet "
                 "instantiation/rendering document."
             )
+    if not ACTIVITY_COPYING_DOC.is_file():
+        failures.append("Current v0.3.0 Activity-copying document is missing.")
+    else:
+        activity_copy_doc = ACTIVITY_COPYING_DOC.read_text(encoding="utf-8")
+        for phrase in REQUIRED_ACTIVITY_COPYING_PHRASES:
+            if phrase not in activity_copy_doc:
+                failures.append(
+                    "Activity-copying document is missing required boundary "
+                    f"wording {phrase!r}."
+                )
+        if ACTIVITY_COPYING_DOC.name not in docs_index:
+            failures.append(
+                "Documentation index does not link the Activity-copying document."
+            )
     for active_path in (
         ROOT / "README.md",
         ROOT / "docs" / "cli-contract.md",
@@ -690,6 +719,15 @@ def check_documentation() -> None:
         if "concord group-plan apply" not in active_group_plan_text:
             failures.append(
                 f"{active_path.relative_to(ROOT)} does not expose GroupPlan apply."
+            )
+        if "concord activity copy-preview" not in active_group_plan_text:
+            failures.append(
+                f"{active_path.relative_to(ROOT)} does not expose Activity "
+                "copy preview."
+            )
+        if "concord activity copy" not in active_group_plan_text:
+            failures.append(
+                f"{active_path.relative_to(ROOT)} does not expose Activity copy."
             )
         if "concord template create" not in active_group_plan_text:
             failures.append(
@@ -716,6 +754,8 @@ def check_documentation() -> None:
         "#48-#58 foundations",
         "#48-#59 foundations",
         "#48-#60 foundations",
+        "#48-#61 foundations",
+        "#48-#62 foundations",
         "canonical plan application remains reserved for #56",
         "canonical Template storage and revision workflows remain #58",
         "Template Definition / Template Version remain wholly undefined",
@@ -772,9 +812,9 @@ def check_documentation() -> None:
     integration = (
         ROOT / "docs" / "design" / "pds-core-integration-requirements.md"
     ).read_text(encoding="utf-8")
-    if "Current development Core baseline:** `pds-core` 0.6.1" not in integration:
+    if "Current development Core baseline:** `pds-core` 0.6.3" not in integration:
         failures.append(
-            "Integration requirements do not identify Core v0.6.1 "
+            "Integration requirements do not identify Core v0.6.3 "
             "for v0.3 development."
         )
     contracts = (ROOT / "docs" / "design" / "conceptual-data-contracts.md").read_text(

--- a/scripts/check_package.py
+++ b/scripts/check_package.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from packaging.requirements import Requirement
 
-EXPECTED_CORE_REQUIREMENT = Requirement("pds-core>=0.6.1,<0.7")
+EXPECTED_CORE_REQUIREMENT = Requirement("pds-core>=0.6.3,<0.7")
 EXPECTED_VERSION = "0.3.0.dev0"
 FORBIDDEN_PREFIXES = (
     "tests/",
@@ -108,7 +108,7 @@ def validate_wheel(path: str | Path) -> None:
     ]
     if runtime != [EXPECTED_CORE_REQUIREMENT]:
         raise PackageValidationError(
-            "Runtime Core requirement must be pds-core>=0.6.1,<0.7."
+            "Runtime Core requirement must be pds-core>=0.6.3,<0.7."
         )
     runtime_names = {item.name for item in requirements if item.marker is None}
     forbidden_runtime = runtime_names & FORBIDDEN_RUNTIME_DEPENDENCIES

--- a/scripts/smoke_test_activity_copying_wheel.py
+++ b/scripts/smoke_test_activity_copying_wheel.py
@@ -1,0 +1,211 @@
+"""Install Concord/Core wheels in isolation and smoke-test Activity copying."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import tempfile
+import textwrap
+import venv
+from pathlib import Path
+
+
+def _python(venv_root: Path) -> Path:
+    return (
+        venv_root / "Scripts" / "python.exe"
+        if os.name == "nt"
+        else venv_root / "bin" / "python"
+    )
+
+
+def _run(command: list[str], cwd: Path) -> None:
+    subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    )
+
+
+def _smoke_code() -> str:
+    return textwrap.dedent(
+        """
+        from datetime import datetime, timezone
+        from pathlib import Path
+        import tempfile
+
+        from pds_core.class_metadata import (
+            create_class_metadata,
+            write_class_metadata_for_class,
+        )
+        from pds_core.routing_models import ModuleWorkRef
+        from pds_core.workspace import ensure_workspace_root
+
+        from concord.models import PrivacyPolicy
+        from concord.storage import load_current_record_graph, load_current_snapshot
+        from concord.workflows import (
+            CopyActivityRequest,
+            CreateActivityContextRequest,
+            CreateGroupRequest,
+            PrepareActivityCopyRequest,
+            WorkflowActor,
+            copy_activity,
+            create_activity_context,
+            create_group,
+            prepare_activity_copy,
+        )
+
+        with tempfile.TemporaryDirectory(prefix="concord-copy-installed-") as raw:
+            root = ensure_workspace_root(Path(raw) / "workspace")
+            for class_id in ("source-class", "target-class"):
+                metadata = create_class_metadata(
+                    class_id,
+                    "2026-2027",
+                    created_at=datetime(2026, 8, 26, tzinfo=timezone.utc),
+                )
+                write_class_metadata_for_class(root, metadata)
+
+            actor = WorkflowActor(actor_id="teacher-copy-smoke")
+            created = create_activity_context(
+                CreateActivityContextRequest(
+                    class_id="source-class",
+                    activity_id="seminar-1",
+                    title="Synthetic Seminar",
+                    description="Reusable seminar configuration.",
+                    activity_type="socratic_seminar",
+                    scoring_orientation="evidence_only",
+                    activity_status="active",
+                    session_id="source-session",
+                    session_status="active",
+                    privacy_policy=PrivacyPolicy(
+                        classification="classroom_shared"
+                    ),
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            create_group(
+                CreateGroupRequest(
+                    class_id="source-class",
+                    activity_id="seminar-1",
+                    group_id="source-group",
+                    label="Historical Group",
+                    status="active",
+                    expected_snapshot_revision=created.commit.snapshot_revision,
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+
+            source_work = ModuleWorkRef("concord", "source-class", "seminar-1")
+            source_before = load_current_snapshot(root, source_work)
+            prepared = prepare_activity_copy(
+                PrepareActivityCopyRequest(
+                    source_class_id="source-class",
+                    source_activity_id="seminar-1",
+                    target_class_id="target-class",
+                    target_activity_id="seminar-1",
+                    first_session_id="target-session",
+                    first_session_label="Opening",
+                ),
+                workspace_root=root,
+            )
+            assert load_current_snapshot(root, source_work) == source_before
+            assert prepared.source_status == "active"
+            assert prepared.title == "Synthetic Seminar"
+            assert prepared.privacy_policy is not None
+            assert prepared.privacy_policy.classification == "classroom_shared"
+
+            result = copy_activity(
+                CopyActivityRequest(
+                    source_class_id="source-class",
+                    source_activity_id="seminar-1",
+                    target_class_id="target-class",
+                    target_activity_id="seminar-1",
+                    first_session_id="target-session",
+                    first_session_label="Opening",
+                    actor=actor,
+                    review_digest=prepared.review_digest,
+                ),
+                workspace_root=root,
+            )
+            assert result.commit.snapshot_revision == 1
+            assert load_current_snapshot(root, source_work) == source_before
+
+            target_work = ModuleWorkRef("concord", "target-class", "seminar-1")
+            target = load_current_record_graph(root, target_work)
+            assert target.snapshot_revision == 1
+            assert len(target.graph.activities) == 1
+            assert len(target.graph.sessions) == 1
+            assert not target.graph.groups
+            assert not target.graph.group_plans
+            assert not target.graph.memberships
+            assert not target.graph.packet_instances
+            assert not target.graph.artifact_instances
+            assert not target.graph.criterion_sets
+            assert not target.graph.score_records
+            activity = target.graph.activities[0]
+            session = target.graph.sessions[0]
+            assert activity.status == "draft"
+            assert activity.title == "Synthetic Seminar"
+            assert activity.description == "Reusable seminar configuration."
+            assert activity.criterion_set_ids == ()
+            assert activity.external_reference_ids == ()
+            assert activity.created_provenance != (
+                load_current_record_graph(root, source_work).graph.activities[0]
+                .created_provenance
+            )
+            assert session.session_id == "target-session"
+            assert session.sequence == 1
+            assert session.status == "planned"
+            assert session.label == "Opening"
+
+            continued = create_group(
+                CreateGroupRequest(
+                    class_id="target-class",
+                    activity_id="seminar-1",
+                    group_id="target-group",
+                    label="Fresh target Group",
+                    expected_snapshot_revision=target.snapshot_revision,
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert continued.commit.snapshot_revision == 2
+            continued_target = load_current_record_graph(root, target_work)
+            assert len(continued_target.graph.groups) == 1
+            assert continued_target.graph.groups[0].group_id == "target-group"
+            assert load_current_snapshot(root, source_work) == source_before
+        """
+    )
+
+
+def smoke(concord_wheel: Path, core_wheel: Path) -> None:
+    if not concord_wheel.is_file():
+        raise FileNotFoundError(concord_wheel)
+    if not core_wheel.is_file():
+        raise FileNotFoundError(core_wheel)
+    with tempfile.TemporaryDirectory(prefix="concord-copy-wheel-") as raw:
+        work = Path(raw)
+        env_root = work / "venv"
+        venv.EnvBuilder(with_pip=True).create(env_root)
+        python = _python(env_root)
+        _run([str(python), "-m", "pip", "install", str(core_wheel.resolve())], work)
+        _run([str(python), "-m", "pip", "install", str(concord_wheel.resolve())], work)
+        smoke_path = work / "copy_smoke.py"
+        smoke_path.write_text(_smoke_code(), encoding="utf-8")
+        _run([str(python), str(smoke_path)], work)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("concord_wheel", type=Path)
+    parser.add_argument("core_wheel", type=Path)
+    args = parser.parse_args()
+    smoke(args.concord_wheel, args.core_wheel)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_test_wheel.py
+++ b/scripts/smoke_test_wheel.py
@@ -962,7 +962,7 @@ def smoke_test(concord_wheel: Path, core_wheel: Path) -> None:
                 (
                     "import importlib.metadata as m, concord, pds_core; "
                     "assert concord.__version__ == m.version('pds-concord'); "
-                    "assert m.version('pds-core') == '0.6.1'"
+                    "assert m.version('pds-core') == '0.6.3'"
                 ),
             ],
             outside,
@@ -1095,7 +1095,7 @@ def smoke_test(concord_wheel: Path, core_wheel: Path) -> None:
                 "--version",
                 _wheel_version(concord_wheel),
                 "--expected-core-version",
-                "0.6.1",
+                "0.6.3",
             ],
             outside,
         )

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -84,6 +84,14 @@ def validate(core_wheel: Path, *, allow_dirty: bool) -> None:
         _run([python, "scripts/check_package.py", str(wheels[0])])
         _run([python, "scripts/verify_release_artifacts.py", str(dist)])
         _run([python, "scripts/smoke_test_wheel.py", str(wheels[0]), str(core_wheel)])
+        _run(
+            [
+                python,
+                "scripts/smoke_test_activity_copying_wheel.py",
+                str(wheels[0]),
+                str(core_wheel),
+            ]
+        )
     _run(["git", "diff", "--check"])
     if not allow_dirty:
         result = subprocess.run(

--- a/scripts/verify_core_wheel.py
+++ b/scripts/verify_core_wheel.py
@@ -1,4 +1,4 @@
-"""Authenticate the exact released pds-core v0.6.1 wheel and installation."""
+"""Authenticate the exact released pds-core v0.6.3 wheel and installation."""
 
 from __future__ import annotations
 
@@ -12,10 +12,10 @@ from pathlib import Path
 
 CORE_DISTRIBUTION_NAME = "pds-core"
 CORE_IMPORT_NAME = "pds_core"
-EXPECTED_CORE_VERSION = "0.6.1"
-EXPECTED_CORE_WHEEL_FILENAME = "pds_core-0.6.1-py3-none-any.whl"
+EXPECTED_CORE_VERSION = "0.6.3"
+EXPECTED_CORE_WHEEL_FILENAME = "pds_core-0.6.3-py3-none-any.whl"
 EXPECTED_CORE_WHEEL_SHA256 = (
-    "ae22826bc9591740dbfa961e3fb7ccb1a42314b59a30780aeab9db07747dba6e"
+    "98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5"
 )
 
 
@@ -72,7 +72,7 @@ def verify_core_wheel(path: str | Path) -> None:
     if metadata["Name"] != CORE_DISTRIBUTION_NAME:
         raise CoreVerificationError("Core wheel distribution name is not pds-core.")
     if metadata["Version"] != EXPECTED_CORE_VERSION:
-        raise CoreVerificationError("Core wheel version is not exactly 0.6.1.")
+        raise CoreVerificationError("Core wheel version is not exactly 0.6.3.")
 
 
 def verify_installed_core() -> None:
@@ -80,7 +80,7 @@ def verify_installed_core() -> None:
     version = importlib.metadata.version(CORE_DISTRIBUTION_NAME)
     if version != EXPECTED_CORE_VERSION:
         raise CoreVerificationError(
-            f"Installed pds-core must be exactly 0.6.1; found {version}."
+            f"Installed pds-core must be exactly 0.6.3; found {version}."
         )
     import pds_core
 

--- a/scripts/verify_installed_producer_acceptance.py
+++ b/scripts/verify_installed_producer_acceptance.py
@@ -430,9 +430,9 @@ def _installed_provenance(
         "installed Concord metadata version disagrees.",
     )
     _require(
-        metadata.version("pds-core") == core_version == "0.6.1",
+        metadata.version("pds-core") == core_version,
         "installed provenance",
-        "installed Core version is not exactly 0.6.1.",
+        "installed Core version disagrees with the expected baseline.",
     )
     _require(
         getattr(pds_core, "__version__", None) == core_version,
@@ -449,7 +449,7 @@ def _installed_provenance(
         len(core_requirements) == 1
         and Version(core_version) in core_requirements[0].specifier,
         "installed provenance",
-        "Concord dependency metadata rejects Core 0.6.1.",
+        "Concord dependency metadata rejects the expected Core baseline.",
     )
     modules = (
         "concord",

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -23,7 +23,7 @@ RELEASE_VERSION = "0.3.0.dev0"
 EXPECTED_WHEEL = "pds_concord-0.3.0.dev0-py3-none-any.whl"
 EXPECTED_SDIST = "pds_concord-0.3.0.dev0.tar.gz"
 EXPECTED_DIST_INFO = "pds_concord-0.3.0.dev0.dist-info"
-EXPECTED_CORE_SPECIFIER = SpecifierSet(">=0.6.1,<0.7")
+EXPECTED_CORE_SPECIFIER = SpecifierSet(">=0.6.3,<0.7")
 EXPECTED_PYTHON_SPECIFIER = SpecifierSet(">=3.11")
 EXPECTED_ENTRY_POINTS = {
     "console_scripts": {"concord": "concord.cli:main"},
@@ -183,7 +183,7 @@ def validate_requirements(values: list[str], label: str) -> None:
     ]
     if len(core) != 1 or core[0].specifier != EXPECTED_CORE_SPECIFIER:
         raise ArtifactValidationError(
-            f"{label} must require exactly pds-core>=0.6.1,<0.7"
+            f"{label} must require exactly pds-core>=0.6.3,<0.7"
         )
     if core[0].url is not None or core[0].marker is not None or core[0].extras:
         raise ArtifactValidationError(

--- a/scripts/verify_release_compatibility.py
+++ b/scripts/verify_release_compatibility.py
@@ -29,7 +29,7 @@ from concord.pds_publication import get_publication_producer_profile
 
 ROOT = Path(__file__).resolve().parents[1]
 DEVELOPMENT_VERSION = "0.3.0.dev0"
-EXPECTED_CORE_SPECIFIER = SpecifierSet(">=0.6.1,<0.7")
+EXPECTED_CORE_SPECIFIER = SpecifierSet(">=0.6.3,<0.7")
 EXPECTED_PYTHON_SPECIFIER = SpecifierSet(">=3.11")
 EXPECTED_CAPABILITIES = frozenset(
     {"criterion_scores", "moderated_scores", "standards_ratings"}
@@ -143,7 +143,7 @@ def validate_release_metadata(project: Mapping[str, object], version: str) -> No
         if canonicalize_name(item.name) == canonicalize_name("pds-core")
     )
     if len(core) != 1 or core[0].specifier != EXPECTED_CORE_SPECIFIER:
-        raise ReleaseCompatibilityError("Core requirement must be exactly >=0.6.1,<0.7")
+        raise ReleaseCompatibilityError("Core requirement must be exactly >=0.6.3,<0.7")
     if core[0].url is not None or core[0].marker is not None or core[0].extras:
         raise ReleaseCompatibilityError(
             "Core requirement cannot use URL, marker, or extras"
@@ -403,7 +403,7 @@ def main() -> int:
         print(f"Development compatibility audit failed: {error}")
         return 1
     print(
-        "Concord v0.3.0.dev0 development compatibility passed: Core >=0.6.1,<0.7; "
+        "Concord v0.3.0.dev0 development compatibility passed: Core >=0.6.3,<0.7; "
         "contracts/profile exact; reader consumer-neutral; Artifact gate separate; "
         "sibling and grading/selection policy absent."
     )

--- a/tests/test_activity_copying_cli_menu_issue63.py
+++ b/tests/test_activity_copying_cli_menu_issue63.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.routing_models import ModuleWorkRef
+from pds_core.workspace import ensure_workspace_root
+
+from concord.cli import main
+from concord.menu_activity import (
+    _confirm_copy,
+    _copy_review_lines,
+    launch_activity_management_menu,
+)
+from concord.models import PrivacyPolicy
+from concord.storage import load_current_record_graph
+from concord.workflows import PreparedActivityCopy
+
+
+def _inputs(monkeypatch: pytest.MonkeyPatch, values: list[str]) -> None:
+    iterator: Iterator[str] = iter(values)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(iterator))
+
+
+@pytest.fixture
+def copy_cli_workspace(tmp_path: Path) -> Path:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    for class_id in ("class-source", "class-target"):
+        metadata = create_class_metadata(
+            class_id,
+            "2026-2027",
+            created_at=datetime(2026, 8, 26, tzinfo=timezone.utc),
+        )
+        write_class_metadata_for_class(root, metadata)
+    return root
+
+
+def _create_source(root: Path) -> None:
+    assert (
+        main(
+            [
+                "activity",
+                "create",
+                "--workspace-root",
+                str(root),
+                "--class-id",
+                "class-source",
+                "--activity-id",
+                "activity-source",
+                "--title",
+                "Source Seminar",
+                "--description",
+                "Source description",
+                "--activity-type",
+                "socratic_seminar",
+                "--scoring-orientation",
+                "evidence_only",
+                "--session-id",
+                "source-session",
+                "--actor-id",
+                "teacher-1",
+            ]
+        )
+        == 0
+    )
+
+
+def _copy_args(root: Path) -> list[str]:
+    return [
+        "--workspace-root",
+        str(root),
+        "--source-class-id",
+        "class-source",
+        "--source-activity-id",
+        "activity-source",
+        "--target-class-id",
+        "class-target",
+        "--target-activity-id",
+        "activity-copy",
+        "--title",
+        "Copied Seminar",
+        "--clear-description",
+        "--session-id",
+        "copy-session",
+        "--session-label",
+        "Opening Copy Session",
+        "--actor-id",
+        "teacher-1",
+    ]
+
+
+def test_direct_copy_preview_and_copy_are_noninteractive(
+    copy_cli_workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _create_source(copy_cli_workspace)
+    capsys.readouterr()
+    monkeypatch.setattr(
+        "builtins.input",
+        lambda *_args, **_kwargs: pytest.fail("direct Activity copy must not prompt"),
+    )
+
+    assert main(["activity", "copy-preview", *_copy_args(copy_cli_workspace)]) == 0
+    preview = capsys.readouterr()
+    assert preview.err == ""
+    assert "Source Activity: class-source/activity-source" in preview.out
+    assert "Target Activity: class-target/activity-copy" in preview.out
+    assert "Target status: draft" in preview.out
+    assert "Description: -" in preview.out
+    assert "Will not copy:" in preview.out
+    digest_match = re.search(r"Review digest: ([0-9a-f]{64})", preview.out)
+    assert digest_match is not None
+    digest = digest_match.group(1)
+
+    assert (
+        main(
+            [
+                "activity",
+                "copy",
+                *_copy_args(copy_cli_workspace),
+                "--review-digest",
+                digest,
+            ]
+        )
+        == 0
+    )
+    committed = capsys.readouterr()
+    assert committed.err == ""
+    assert "Committed snapshot 1." in committed.out
+    assert "First Session: copy-session" in committed.out
+    assert f"Review digest: {digest}" in committed.out
+
+    target = load_current_record_graph(
+        copy_cli_workspace,
+        ModuleWorkRef("concord", "class-target", "activity-copy"),
+    )
+    assert len(target.graph.activities) == 1
+    assert len(target.graph.sessions) == 1
+    assert not target.graph.groups
+    activity = target.graph.activities[0]
+    session = target.graph.sessions[0]
+    assert activity.title == "Copied Seminar"
+    assert activity.description is None
+    assert activity.status == "draft"
+    assert session.session_id == "copy-session"
+    assert session.status == "planned"
+
+
+def test_direct_copy_requires_exact_review_digest(
+    copy_cli_workspace: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _create_source(copy_cli_workspace)
+    capsys.readouterr()
+    result = main(
+        [
+            "activity",
+            "copy",
+            *_copy_args(copy_cli_workspace),
+            "--review-digest",
+            "0" * 64,
+        ]
+    )
+    captured = capsys.readouterr()
+    assert result == 3
+    assert "Conflict:" in captured.err
+    assert "review is stale" in captured.err
+
+
+def test_activity_copy_commands_have_help() -> None:
+    for arguments in (
+        ["activity", "copy-preview", "--help"],
+        ["activity", "copy", "--help"],
+    ):
+        with pytest.raises(SystemExit) as exit_info:
+            main(arguments)
+        assert exit_info.value.code == 0
+
+
+def test_activity_management_exposes_copy(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _inputs(monkeypatch, ["b"])
+    monkeypatch.setattr("concord.menu_activity.clear_screen", lambda: None)
+    launch_activity_management_menu()
+    output = capsys.readouterr().out
+    assert "1. Create an Activity" in output
+    assert "2. Copy an Activity" in output
+    assert "3. List Activities" in output
+    assert "4. Open an Activity" in output
+
+
+def test_copy_review_lines_show_config_ordered_standards_and_exclusions() -> None:
+    prepared = PreparedActivityCopy(
+        source_class_id="class-source",
+        source_activity_id="activity-source",
+        source_status="completed",
+        target_class_id="class-target",
+        target_activity_id="activity-copy",
+        title="Copied title",
+        description="Copied description",
+        activity_type="project",
+        scoring_orientation="standards_based",
+        standards_profile_id="profile-1",
+        focus_standard_ids=("standard-b", "standard-a"),
+        privacy_policy=PrivacyPolicy(classification="teacher_restricted"),
+        first_session_id="session-copy",
+        first_session_label="Opening",
+        diagnostics=(),
+        excluded_state=("source Groups",),
+        review_digest="a" * 64,
+    )
+    lines = _copy_review_lines(prepared)
+    assert "Source status (not copied): completed" in lines
+    assert "Description: Copied description" in lines
+    start = lines.index("Focus Standards (ordered):")
+    assert lines[start + 1 : start + 3] == (
+        "  1. standard-b",
+        "  2. standard-a",
+    )
+    assert any(line.startswith("NOT COPIED:") for line in lines)
+
+
+def test_copy_confirmation_requires_uppercase_copy(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _inputs(monkeypatch, ["copy", "", "COPY"])
+    monkeypatch.setattr("concord.menu_activity.clear_screen", lambda: None)
+    assert _confirm_copy(("Target: class-target/activity-copy",))
+    output = capsys.readouterr().out
+    assert "Type uppercase COPY exactly" in output

--- a/tests/test_activity_copying_issue63.py
+++ b/tests/test_activity_copying_issue63.py
@@ -1,0 +1,784 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.rosters import create_roster
+from pds_core.routing_models import ModuleRecordRef, ModuleWorkRef
+from pds_core.standards import StandardDefinition, StandardsLibrary, StandardsProfile
+from pds_core.workspace import ensure_workspace_root
+
+from concord.models import ConcordRecordReference, PrivacyPolicy, SubjectReference
+from concord.storage import load_current_record_graph, load_current_snapshot
+from concord.storage_errors import ConcordStorageNotFoundError
+from concord.workflows.activity import create_activity_context, update_activity
+from concord.workflows.activity_copy import (
+    CopyActivityRequest,
+    PrepareActivityCopyRequest,
+    copy_activity,
+    prepare_activity_copy,
+)
+from concord.workflows.criterion_sets import (
+    CreateCriterionSetRequest,
+    CriterionSpec,
+    SelectActivityCriterionSetsRequest,
+    create_criterion_set,
+    select_activity_criterion_sets,
+)
+from concord.workflows.errors import (
+    ConcordWorkflowConflictError,
+    ConcordWorkflowValidationError,
+)
+from concord.workflows.group import create_group
+from concord.workflows.group_plan import CreateGroupPlanRequest, create_group_plan
+from concord.workflows.models import (
+    CreateActivityContextRequest,
+    CreateGroupRequest,
+    UpdateActivityRequest,
+    WorkflowActor,
+)
+
+
+def _workspace(tmp_path: Path) -> Path:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    for class_id in ("class-a", "class-b"):
+        metadata = create_class_metadata(
+            class_id,
+            "2026-2027",
+            created_at=datetime(2026, 8, 26, tzinfo=timezone.utc),
+        )
+        write_class_metadata_for_class(root, metadata)
+        roster = create_roster(
+            class_id,
+            (
+                {
+                    "student_id": f"{class_id}-student-1",
+                    "last_name": "Student",
+                    "first_name": "Synthetic",
+                    "period": "1",
+                },
+            ),
+        )
+        write_class_roster(root, roster)
+    return root
+
+
+def _standards_library(
+    *,
+    profile_standards: tuple[str, ...] = ("standard-1", "standard-2"),
+    include_profile: bool = True,
+) -> StandardsLibrary:
+    standards = (
+        StandardDefinition(
+            standard_id="standard-1",
+            code="S1",
+            source="synthetic",
+            short_name="Standard 1",
+            description="Synthetic standard one.",
+        ),
+        StandardDefinition(
+            standard_id="standard-2",
+            code="S2",
+            source="synthetic",
+            short_name="Standard 2",
+            description="Synthetic standard two.",
+        ),
+    )
+    profiles = (
+        StandardsProfile(
+            profile_id="profile-1",
+            standards=profile_standards,
+            source="synthetic",
+            title="Synthetic profile",
+        ),
+    ) if include_profile else ()
+    return StandardsLibrary(standards=standards, profiles=profiles)
+
+
+def _standards_source(
+    root: Path, library: StandardsLibrary
+) -> WorkflowActor:
+    actor = WorkflowActor(actor_id="teacher-standards")
+    create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-a",
+            activity_id="standards-activity",
+            title="Standards Activity",
+            activity_type="project",
+            scoring_orientation="standards_based",
+            session_id="standards-session",
+            actor=actor,
+            standards_profile_id="profile-1",
+            focus_standard_ids=("standard-2", "standard-1"),
+        ),
+        workspace_root=root,
+        standards_library=library,
+    )
+    return actor
+
+
+def _source(
+    root: Path, *, privacy: PrivacyPolicy | None = None
+) -> tuple[WorkflowActor, int]:
+    actor = WorkflowActor(actor_id="teacher-1", display_label="Teacher One")
+    created = create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-a",
+            activity_id="seminar-1",
+            title="Seminar One",
+            description="Reusable seminar configuration.",
+            activity_type="socratic_seminar",
+            scoring_orientation="evidence_only",
+            session_id="source-session",
+            actor=actor,
+            activity_status="completed",
+            session_status="completed",
+            privacy_policy=privacy,
+            external_reference_ids=("source-external",),
+        ),
+        workspace_root=root,
+    )
+    return actor, created.commit.snapshot_revision
+
+
+def test_prepare_is_zero_write_and_copy_is_fresh_positive_allowlist(
+    tmp_path: Path,
+) -> None:
+    root = _workspace(tmp_path)
+    actor, _ = _source(
+        root,
+        privacy=PrivacyPolicy(classification="teacher_restricted"),
+    )
+    source_work = ModuleWorkRef(
+        module_id="concord", class_id="class-a", work_id="seminar-1"
+    )
+    source_before = load_current_snapshot(root, source_work)
+
+    request = PrepareActivityCopyRequest(
+        source_class_id="class-a",
+        source_activity_id="seminar-1",
+        target_class_id="class-b",
+        target_activity_id="seminar-copy",
+        first_session_id="copy-session",
+        first_session_label="First copied session",
+    )
+    prepared = prepare_activity_copy(request, workspace_root=root)
+
+    assert prepared.source_status == "completed"
+    assert prepared.title == "Seminar One"
+    assert prepared.description == "Reusable seminar configuration."
+    assert prepared.activity_type == "socratic_seminar"
+    assert prepared.scoring_orientation == "evidence_only"
+    assert prepared.privacy_policy == PrivacyPolicy(classification="teacher_restricted")
+    assert len(prepared.review_digest) == 64
+    assert load_current_snapshot(root, source_work) == source_before
+    with pytest.raises(ConcordStorageNotFoundError):
+        load_current_snapshot(
+            root,
+            ModuleWorkRef(
+                module_id="concord", class_id="class-b", work_id="seminar-copy"
+            ),
+        )
+
+    result = copy_activity(
+        CopyActivityRequest(
+            source_class_id=request.source_class_id,
+            source_activity_id=request.source_activity_id,
+            target_class_id=request.target_class_id,
+            target_activity_id=request.target_activity_id,
+            first_session_id=request.first_session_id,
+            first_session_label=request.first_session_label,
+            actor=actor,
+            review_digest=prepared.review_digest,
+        ),
+        workspace_root=root,
+    )
+    loaded = load_current_record_graph(root, result.commit.work)
+    assert len(loaded.graph.activities) == 1
+    assert len(loaded.graph.sessions) == 1
+    assert not loaded.graph.groups
+    target = loaded.graph.activities[0]
+    session = loaded.graph.sessions[0]
+    assert target.activity_id == "seminar-copy"
+    assert target.class_reference.record_id == "class-b"
+    assert target.status == "draft"
+    assert target.title == "Seminar One"
+    assert target.description == "Reusable seminar configuration."
+    assert target.criterion_set_ids == ()
+    assert target.external_reference_ids == ()
+    source_activity = load_current_record_graph(root, source_work).graph.activities[0]
+    assert target.created_provenance != source_activity.created_provenance
+    assert target.updated_provenance is None
+    assert session.session_id == "copy-session"
+    assert session.sequence == 1
+    assert session.status == "planned"
+    assert session.label == "First copied session"
+    assert load_current_snapshot(root, source_work) == source_before
+
+
+def test_selected_activity_owned_criterion_set_is_explicitly_not_copied(
+    tmp_path: Path,
+) -> None:
+    root = _workspace(tmp_path)
+    actor = WorkflowActor(actor_id="teacher-criteria")
+    created = create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-a",
+            activity_id="criteria-source",
+            title="Criteria Source",
+            activity_type="project",
+            scoring_orientation="local_criteria_only",
+            session_id="criteria-session",
+            actor=actor,
+        ),
+        workspace_root=root,
+    )
+    criterion = create_criterion_set(
+        CreateCriterionSetRequest(
+            class_id="class-a",
+            activity_id="criteria-source",
+            criterion_set_id="source-criterion-set",
+            lineage_id="source-criterion-lineage",
+            name="Source Criteria",
+            purpose="Synthetic source-only local criteria.",
+            revision=1,
+            scope="activity_specific",
+            criterion_set_kind="local",
+            criteria=(
+                CriterionSpec(
+                    criterion_id="source-local-criterion",
+                    key="local_quality",
+                    label="Local Quality",
+                    definition="Synthetic local criterion.",
+                    criterion_kind="local",
+                    supported_target_kinds=("core_student",),
+                ),
+            ),
+            status="active",
+            expected_snapshot_revision=created.commit.snapshot_revision,
+            actor=actor,
+        ),
+        workspace_root=root,
+    )
+    selected = select_activity_criterion_sets(
+        SelectActivityCriterionSetsRequest(
+            class_id="class-a",
+            activity_id="criteria-source",
+            criterion_set_ids=("source-criterion-set",),
+            expected_snapshot_revision=criterion.commit.snapshot_revision,
+            actor=actor,
+        ),
+        workspace_root=root,
+    )
+    assert selected.criterion_set_ids == ("source-criterion-set",)
+
+    request = PrepareActivityCopyRequest(
+        source_class_id="class-a",
+        source_activity_id="criteria-source",
+        target_class_id="class-b",
+        target_activity_id="criteria-copy",
+        first_session_id="criteria-copy-session",
+    )
+    prepared = prepare_activity_copy(request, workspace_root=root)
+    assert "criterion_sets_not_copied" in {item.code for item in prepared.diagnostics}
+    copied = copy_activity(
+        CopyActivityRequest(
+            source_class_id=request.source_class_id,
+            source_activity_id=request.source_activity_id,
+            target_class_id=request.target_class_id,
+            target_activity_id=request.target_activity_id,
+            first_session_id=request.first_session_id,
+            actor=actor,
+            review_digest=prepared.review_digest,
+        ),
+        workspace_root=root,
+    )
+    target = load_current_record_graph(root, copied.commit.work)
+    assert target.graph.activities[0].criterion_set_ids == ()
+    assert not target.graph.criterion_sets
+    assert not target.graph.criteria
+
+
+def test_review_digest_ignores_unrelated_operational_state(tmp_path: Path) -> None:
+    root = _workspace(tmp_path)
+    actor, revision = _source(root)
+    request = PrepareActivityCopyRequest(
+        source_class_id="class-a",
+        source_activity_id="seminar-1",
+        target_class_id="class-b",
+        target_activity_id="seminar-copy",
+        first_session_id="copy-session",
+    )
+    prepared = prepare_activity_copy(request, workspace_root=root)
+    repeated = prepare_activity_copy(request, workspace_root=root)
+    assert repeated.review_digest == prepared.review_digest
+    group = create_group(
+        CreateGroupRequest(
+            class_id="class-a",
+            activity_id="seminar-1",
+            group_id="new-operational-group",
+            label="Operational Group",
+            expected_snapshot_revision=revision,
+            actor=actor,
+        ),
+        workspace_root=root,
+    )
+    assert group.commit.snapshot_revision > revision
+    plan = create_group_plan(
+        CreateGroupPlanRequest(
+            class_id="class-a",
+            activity_id="seminar-1",
+            group_plan_id="signal-sentinel-plan",
+            strategy="similar_signal",
+            expected_snapshot_revision=group.commit.snapshot_revision,
+            actor=actor,
+            source_signal_set_id="privacy-sentinel-signal",
+            source_signal_set_digest="a" * 64,
+            source_signal_dimension_id="privacy-sentinel-dimension",
+        ),
+        workspace_root=root,
+    )
+    assert plan.commit.snapshot_revision > group.commit.snapshot_revision
+
+    copied = copy_activity(
+        CopyActivityRequest(
+            source_class_id=request.source_class_id,
+            source_activity_id=request.source_activity_id,
+            target_class_id=request.target_class_id,
+            target_activity_id=request.target_activity_id,
+            first_session_id=request.first_session_id,
+            actor=actor,
+            review_digest=prepared.review_digest,
+        ),
+        workspace_root=root,
+    )
+    target = load_current_record_graph(root, copied.commit.work)
+    assert not target.graph.groups
+    assert not target.graph.group_plans
+
+
+def test_copy_relevant_source_change_invalidates_review(tmp_path: Path) -> None:
+    root = _workspace(tmp_path)
+    actor, revision = _source(root)
+    request = PrepareActivityCopyRequest(
+        source_class_id="class-a",
+        source_activity_id="seminar-1",
+        target_class_id="class-b",
+        target_activity_id="seminar-copy",
+        first_session_id="copy-session",
+    )
+    prepared = prepare_activity_copy(request, workspace_root=root)
+    update_activity(
+        UpdateActivityRequest(
+            class_id="class-a",
+            activity_id="seminar-1",
+            expected_snapshot_revision=revision,
+            actor=actor,
+            title="Changed source title",
+        ),
+        workspace_root=root,
+    )
+    with pytest.raises(ConcordWorkflowConflictError, match="review is stale"):
+        copy_activity(
+            CopyActivityRequest(
+                source_class_id=request.source_class_id,
+                source_activity_id=request.source_activity_id,
+                target_class_id=request.target_class_id,
+                target_activity_id=request.target_activity_id,
+                first_session_id=request.first_session_id,
+                actor=actor,
+                review_digest=prepared.review_digest,
+            ),
+            workspace_root=root,
+        )
+
+
+def test_overridden_title_is_not_bound_to_later_source_title_changes(
+    tmp_path: Path,
+) -> None:
+    root = _workspace(tmp_path)
+    actor, revision = _source(root)
+    request = PrepareActivityCopyRequest(
+        source_class_id="class-a",
+        source_activity_id="seminar-1",
+        target_class_id="class-b",
+        target_activity_id="seminar-copy",
+        first_session_id="copy-session",
+        title="Independent target title",
+        description=None,
+    )
+    prepared = prepare_activity_copy(request, workspace_root=root)
+    update_activity(
+        UpdateActivityRequest(
+            class_id="class-a",
+            activity_id="seminar-1",
+            expected_snapshot_revision=revision,
+            actor=actor,
+            title="Changed source title",
+        ),
+        workspace_root=root,
+    )
+    copied = copy_activity(
+        CopyActivityRequest(
+            source_class_id=request.source_class_id,
+            source_activity_id=request.source_activity_id,
+            target_class_id=request.target_class_id,
+            target_activity_id=request.target_activity_id,
+            first_session_id=request.first_session_id,
+            title="Independent target title",
+            description=None,
+            actor=actor,
+            review_digest=prepared.review_digest,
+        ),
+        workspace_root=root,
+    )
+    target = load_current_record_graph(root, copied.commit.work).graph.activities[0]
+    assert target.title == "Independent target title"
+    assert target.description is None
+
+
+def test_context_free_privacy_copies_classification_without_source_reason(
+    tmp_path: Path,
+) -> None:
+    root = _workspace(tmp_path)
+    _source(
+        root,
+        privacy=PrivacyPolicy(
+            classification="teacher_restricted",
+            reason="Source-only rationale",
+        ),
+    )
+    prepared = prepare_activity_copy(
+        PrepareActivityCopyRequest(
+            source_class_id="class-a",
+            source_activity_id="seminar-1",
+            target_class_id="class-b",
+            target_activity_id="seminar-copy",
+            first_session_id="copy-session",
+        ),
+        workspace_root=root,
+    )
+    assert prepared.privacy_policy == PrivacyPolicy(
+        classification="teacher_restricted"
+    )
+
+
+def test_contextual_privacy_is_tightened_and_source_audience_is_not_copied(
+    tmp_path: Path,
+) -> None:
+    root = _workspace(tmp_path)
+    _source(
+        root,
+        privacy=PrivacyPolicy(
+            classification="teacher_and_subjects",
+            audience_references=(
+                SubjectReference(
+                    subject_kind="core_student",
+                    subject_id="student-source",
+                    owning_system="core",
+                ),
+            ),
+        ),
+    )
+    prepared = prepare_activity_copy(
+        PrepareActivityCopyRequest(
+            source_class_id="class-a",
+            source_activity_id="seminar-1",
+            target_class_id="class-b",
+            target_activity_id="seminar-copy",
+            first_session_id="copy-session",
+        ),
+        workspace_root=root,
+    )
+    assert prepared.privacy_policy == PrivacyPolicy(classification="teacher_restricted")
+    assert [item.code for item in prepared.diagnostics] == [
+        "privacy_context_not_copied",
+        "external_references_not_copied",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("source_policy", "expected_classification", "expects_privacy_diagnostic"),
+    (
+        (None, None, False),
+        (
+            PrivacyPolicy(classification="teacher_restricted"),
+            "teacher_restricted",
+            False,
+        ),
+        (PrivacyPolicy(classification="classroom_shared"), "classroom_shared", False),
+        (
+            PrivacyPolicy(
+                classification="group_and_teacher",
+                audience_references=(
+                    SubjectReference(
+                        subject_kind="concord_group",
+                        subject_id="source-group",
+                        owning_system="concord",
+                    ),
+                ),
+            ),
+            "teacher_restricted",
+            True,
+        ),
+        (
+            PrivacyPolicy(
+                classification="inherited",
+                inherited_from=ConcordRecordReference(
+                    record_kind="group",
+                    record_id="source-group",
+                ),
+            ),
+            "teacher_restricted",
+            True,
+        ),
+        (
+            PrivacyPolicy(
+                classification="external_policy",
+                policy_reference=ModuleRecordRef(
+                    module_id="core",
+                    record_kind="privacy_policy",
+                    record_id="source-policy",
+                ),
+            ),
+            "teacher_restricted",
+            True,
+        ),
+    ),
+)
+def test_privacy_resolution_matrix(
+    tmp_path: Path,
+    source_policy: PrivacyPolicy | None,
+    expected_classification: str | None,
+    expects_privacy_diagnostic: bool,
+) -> None:
+    root = _workspace(tmp_path)
+    _source(root, privacy=source_policy)
+    prepared = prepare_activity_copy(
+        PrepareActivityCopyRequest(
+            source_class_id="class-a",
+            source_activity_id="seminar-1",
+            target_class_id="class-b",
+            target_activity_id="seminar-copy",
+            first_session_id="copy-session",
+        ),
+        workspace_root=root,
+    )
+    actual_classification = (
+        None
+        if prepared.privacy_policy is None
+        else prepared.privacy_policy.classification
+    )
+    assert actual_classification == expected_classification
+    privacy_codes = {
+        item.code
+        for item in prepared.diagnostics
+        if item.code == "privacy_context_not_copied"
+    }
+    assert bool(privacy_codes) is expects_privacy_diagnostic
+
+def test_destination_is_create_only_and_exact_source_cannot_be_target(
+    tmp_path: Path,
+) -> None:
+    root = _workspace(tmp_path)
+    actor, _ = _source(root)
+    with pytest.raises(ConcordWorkflowValidationError, match="cannot be its own"):
+        prepare_activity_copy(
+            PrepareActivityCopyRequest(
+                source_class_id="class-a",
+                source_activity_id="seminar-1",
+                target_class_id="class-a",
+                target_activity_id="seminar-1",
+                first_session_id="copy-session",
+            ),
+            workspace_root=root,
+        )
+
+    prepared = prepare_activity_copy(
+        PrepareActivityCopyRequest(
+            source_class_id="class-a",
+            source_activity_id="seminar-1",
+            target_class_id="class-b",
+            target_activity_id="seminar-1",
+            first_session_id="copy-session",
+        ),
+        workspace_root=root,
+    )
+    copy_activity(
+        CopyActivityRequest(
+            source_class_id="class-a",
+            source_activity_id="seminar-1",
+            target_class_id="class-b",
+            target_activity_id="seminar-1",
+            first_session_id="copy-session",
+            actor=actor,
+            review_digest=prepared.review_digest,
+        ),
+        workspace_root=root,
+    )
+    with pytest.raises(ConcordWorkflowConflictError, match="already exists"):
+        prepare_activity_copy(
+            PrepareActivityCopyRequest(
+                source_class_id="class-a",
+                source_activity_id="seminar-1",
+                target_class_id="class-b",
+                target_activity_id="seminar-1",
+                first_session_id="another-session",
+            ),
+            workspace_root=root,
+        )
+
+
+def test_standards_references_are_revalidated_and_order_is_preserved(
+    tmp_path: Path,
+) -> None:
+    root = _workspace(tmp_path)
+    library = _standards_library()
+    actor = _standards_source(root, library)
+    request = PrepareActivityCopyRequest(
+        source_class_id="class-a",
+        source_activity_id="standards-activity",
+        target_class_id="class-b",
+        target_activity_id="standards-copy",
+        first_session_id="copy-session",
+    )
+    prepared = prepare_activity_copy(
+        request, workspace_root=root, standards_library=library
+    )
+    assert prepared.standards_profile_id == "profile-1"
+    assert prepared.focus_standard_ids == ("standard-2", "standard-1")
+    result = copy_activity(
+        CopyActivityRequest(
+            source_class_id=request.source_class_id,
+            source_activity_id=request.source_activity_id,
+            target_class_id=request.target_class_id,
+            target_activity_id=request.target_activity_id,
+            first_session_id=request.first_session_id,
+            actor=actor,
+            review_digest=prepared.review_digest,
+        ),
+        workspace_root=root,
+        standards_library=library,
+    )
+    target = load_current_record_graph(
+        root, result.commit.work, standards_library=library
+    ).graph.activities[0]
+    assert target.standards_profile_id == "profile-1"
+    assert target.focus_standard_ids == ("standard-2", "standard-1")
+
+
+@pytest.mark.parametrize(
+    "stale_library",
+    (
+        _standards_library(include_profile=False),
+        _standards_library(profile_standards=("standard-2",)),
+    ),
+)
+def test_invalid_current_standards_block_before_target_mutation(
+    tmp_path: Path, stale_library: StandardsLibrary
+) -> None:
+    root = _workspace(tmp_path)
+    valid_library = _standards_library()
+    _standards_source(root, valid_library)
+    target_work = ModuleWorkRef("concord", "class-b", "standards-copy")
+    with pytest.raises(ConcordWorkflowValidationError, match="standards"):
+        prepare_activity_copy(
+            PrepareActivityCopyRequest(
+                source_class_id="class-a",
+                source_activity_id="standards-activity",
+                target_class_id="class-b",
+                target_activity_id="standards-copy",
+                first_session_id="copy-session",
+            ),
+            workspace_root=root,
+            standards_library=stale_library,
+        )
+    with pytest.raises(ConcordStorageNotFoundError):
+        load_current_snapshot(root, target_work)
+
+
+@pytest.mark.parametrize(
+    "source_status",
+    ("draft", "configured", "active", "completed", "cancelled", "archived"),
+)
+def test_source_lifecycle_is_display_only_and_target_always_starts_draft(
+    tmp_path: Path, source_status: str
+) -> None:
+    root = _workspace(tmp_path)
+    actor = WorkflowActor(actor_id="teacher-status")
+    created = create_activity_context(
+        CreateActivityContextRequest(
+            class_id="class-a",
+            activity_id="status-source",
+            title="Lifecycle source",
+            activity_type="project",
+            scoring_orientation="evidence_only",
+            session_id="source-session",
+            actor=actor,
+            activity_status=source_status,
+        ),
+        workspace_root=root,
+    )
+    prepared = prepare_activity_copy(
+        PrepareActivityCopyRequest(
+            source_class_id="class-a",
+            source_activity_id="status-source",
+            target_class_id="class-b",
+            target_activity_id="status-copy",
+            first_session_id="target-session",
+        ),
+        workspace_root=root,
+    )
+    assert prepared.source_status == source_status
+    result = copy_activity(
+        CopyActivityRequest(
+            source_class_id="class-a",
+            source_activity_id="status-source",
+            target_class_id="class-b",
+            target_activity_id="status-copy",
+            first_session_id="target-session",
+            actor=actor,
+            review_digest=prepared.review_digest,
+        ),
+        workspace_root=root,
+    )
+    target = load_current_record_graph(root, result.commit.work)
+    assert target.graph.activities[0].status == "draft"
+    assert target.graph.sessions[0].status == "planned"
+    assert created.commit.work != result.commit.work
+
+
+def test_same_class_copy_requires_only_a_fresh_activity_id(tmp_path: Path) -> None:
+    root = _workspace(tmp_path)
+    actor, _ = _source(root)
+    prepared = prepare_activity_copy(
+        PrepareActivityCopyRequest(
+            source_class_id="class-a",
+            source_activity_id="seminar-1",
+            target_class_id="class-a",
+            target_activity_id="seminar-repeat",
+            first_session_id="repeat-session",
+        ),
+        workspace_root=root,
+    )
+    result = copy_activity(
+        CopyActivityRequest(
+            source_class_id="class-a",
+            source_activity_id="seminar-1",
+            target_class_id="class-a",
+            target_activity_id="seminar-repeat",
+            first_session_id="repeat-session",
+            actor=actor,
+            review_digest=prepared.review_digest,
+        ),
+        workspace_root=root,
+    )
+    assert result.commit.work == ModuleWorkRef(
+        "concord", "class-a", "seminar-repeat"
+    )

--- a/tests/test_core_baseline.py
+++ b/tests/test_core_baseline.py
@@ -37,7 +37,7 @@ from concord.constants import CONCORD_MODULE_ID
 
 def test_core_version_and_contract_values() -> None:
     version = Version(importlib.metadata.version("pds-core"))
-    assert Version("0.6.1") <= version < Version("0.7")
+    assert Version("0.6.3") <= version < Version("0.7")
     assert CORE_ROUTING_CONTRACT_VERSION == "1"
     assert PDS2_SCHEMA == "PDS2"
     assert ROUTE_REGISTRATION_SCHEMA_VERSION == "1"
@@ -48,6 +48,16 @@ def test_core_version_and_contract_values() -> None:
     assert PUBLICATION_WITHDRAWAL_SCHEMA_VERSION == "1"
     assert CORE_PUBLICATION_COMPATIBILITY_CONTRACT_VERSION == "1"
     assert get_args(ManifestDigestAlgorithm) == ("sha256",)
+
+
+def test_installed_wheel_smoke_uses_current_core_baseline() -> None:
+    smoke = (
+        Path(__file__).resolve().parents[1] / "scripts" / "smoke_test_wheel.py"
+    ).read_text(encoding="utf-8")
+    assert "m.version(\'pds-core\') == \'0.6.3\'" in smoke
+    assert '"--expected-core-version",' in smoke
+    assert '"0.6.3",' in smoke
+    assert "0.6.1" not in smoke
 
 
 def test_concord_core_identity_and_paths(

--- a/tests/test_installed_producer_acceptance_issue33.py
+++ b/tests/test_installed_producer_acceptance_issue33.py
@@ -47,6 +47,14 @@ def test_issue33_stage_contract_is_bounded_and_complete() -> None:
         acceptance.AcceptanceFailure("registry audit", "private\npayload")
 
 
+def test_issue33_installed_provenance_uses_requested_core_baseline() -> None:
+    source = inspect.getsource(acceptance._installed_provenance)
+    assert 'metadata.version("pds-core") == core_version' in source
+    assert "Version(core_version) in core_requirements[0].specifier" in source
+    assert 'core_version == "0.6.1"' not in source
+    assert '== core_version == "0.6.1"' not in source
+
+
 def test_issue33_uses_only_synthetic_fixed_identities() -> None:
     assert acceptance.CLASS_ID == "acceptance_class"
     assert acceptance.ACTIVITY_ID == "acceptance_activity"

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -30,7 +30,7 @@ def test_built_wheel_metadata_and_contents(built_wheel: Path) -> None:
         for item in metadata.get_all("Requires-Dist", [])
         if Requirement(item).name == "pds-core" and Requirement(item).marker is None
     ]
-    assert runtime == [Requirement("pds-core>=0.6.1,<0.7")]
+    assert runtime == [Requirement("pds-core>=0.6.3,<0.7")]
     assert "concord/py.typed" in names
     assert any(name.endswith(".dist-info/licenses/LICENSE") for name in names)
     assert "[console_scripts]\nconcord = concord.cli:main" in entry_points

--- a/tests/test_release_artifacts_issue34.py
+++ b/tests/test_release_artifacts_issue34.py
@@ -23,7 +23,7 @@ METADATA = """Metadata-Version: 2.4
 Name: pds-concord
 Version: 0.3.0.dev0
 Requires-Python: >=3.11
-Requires-Dist: pds-core<0.7,>=0.6.1
+Requires-Dist: pds-core<0.7,>=0.6.3
 
 Synthetic test package.
 """
@@ -40,7 +40,7 @@ PYPROJECT = """[project]
 name = "pds-concord"
 dynamic = ["version"]
 requires-python = ">=3.11"
-dependencies = ["pds-core>=0.6.1,<0.7"]
+dependencies = ["pds-core>=0.6.3,<0.7"]
 
 [project.scripts]
 concord = "concord.cli:main"
@@ -157,7 +157,7 @@ def test_dangerous_archive_member_is_rejected(name: str) -> None:
     "metadata",
     [
         METADATA.replace(
-            "Requires-Dist: pds-core<0.7,>=0.6.1",
+            "Requires-Dist: pds-core<0.7,>=0.6.3",
             "Requires-Dist: pds-core<0.7,>=0.6",
         ),
         METADATA.replace(

--- a/tests/test_release_compatibility_issue34.py
+++ b/tests/test_release_compatibility_issue34.py
@@ -16,7 +16,7 @@ from scripts.verify_release_compatibility import (
 )
 
 
-def _project(*, core: str = "pds-core>=0.6.1,<0.7") -> dict[str, object]:
+def _project(*, core: str = "pds-core>=0.6.3,<0.7") -> dict[str, object]:
     return {
         "name": "pds-concord",
         "requires-python": ">=3.11",
@@ -60,9 +60,9 @@ def test_live_release_compatibility_audit_passes() -> None:
 @pytest.mark.parametrize(
     ("version", "core", "extra"),
     [
-        ("0.2.0", "pds-core>=0.6.1,<0.7", None),
-        ("0.3.0.dev0", "pds-core>=0.6,<0.7", None),
-        ("0.3.0.dev0", "pds-core>=0.6.1,<0.7", "pds-meridian>=0.1"),
+        ("0.2.0", "pds-core>=0.6.3,<0.7", None),
+        ("0.3.0.dev0", "pds-core>=0.6.1,<0.7", None),
+        ("0.3.0.dev0", "pds-core>=0.6.3,<0.7", "pds-meridian>=0.1"),
     ],
 )
 def test_release_metadata_rejects_version_core_and_sibling_drift(


### PR DESCRIPTION
## Summary

Implements Activity copying for Concord's v0.3.0 workflow.

This adds an explicit, teacher-reviewed copy workflow that reuses safe Activity configuration as starting values while creating a completely fresh target Activity and first Session.

The central invariant is:

```text
copy Activity configuration != clone Activity state
source Activity != target Activity revision
```

The implementation deliberately does not duplicate the source Activity's operational graph, identities, assignments, evidence, scoring, publications, or history.

Closes #63.

## What changed

### Activity-copy workflow

Added a new Activity-copy workflow with separate preparation and commit phases:

- `prepare_activity_copy(...)`
- `copy_activity(...)`

Preparation is zero-write and:

- loads the exact source Activity using its class-qualified Core work identity;
- validates the explicit target Core class;
- verifies that the target Activity identity does not already exist;
- copies only the approved reusable/default configuration;
- revalidates standards against the current Core standards library;
- resolves privacy conservatively for the target context;
- creates an in-memory preview of:
  - one fresh draft Activity; and
  - one fresh planned first Session;
- reports state that is intentionally excluded from copying;
- calculates a deterministic review digest binding the teacher-reviewed configuration.

Commit:

- requires the exact review digest;
- rereads the source canonical Activity;
- rejects stale review if copy-relevant source configuration changed;
- revalidates the target class, target identity, standards, and privacy;
- creates fresh provenance;
- creates exactly one new draft Activity and one new planned Session;
- uses create-only canonical storage semantics;
- refuses overwrite, merge, replacement, revision reuse, or self-copy.

## Positive copy allowlist

The copy workflow may reuse the following source Activity values as starting configuration:

- title, unless explicitly overridden;
- description, unless overridden or cleared;
- Activity type;
- scoring orientation;
- standards profile;
- ordered Focus Standards;
- privacy classification only when safe in the target context.

The target Activity always receives:

- its explicitly selected Core class;
- its explicitly selected new Activity ID;
- `status="draft"`;
- fresh provenance;
- no selected Criterion Sets;
- no external references.

The first Session always receives:

- a fresh Session ID;
- the target Activity ID;
- sequence `1`;
- `status="planned"`;
- fresh provenance;
- only the optional new Session label supplied for the copy.

## State intentionally not copied

Activity copying does **not** copy or infer:

- existing Sessions;
- Groups;
- Memberships;
- GroupPlans;
- grouping signals or grouping history;
- Roles;
- Responsibilities;
- PacketInstances or Packet generations;
- Artifacts or ArtifactPages;
- Core route identities;
- rendered PDFs;
- scans or evidence;
- Authors or Subjects;
- Reviews or Moderation;
- Criterion Sets or Criteria;
- Scoring Scales;
- Scores;
- academic-result manifests;
- Academic Work Registrations;
- publication/catalog history;
- snapshot history;
- revision history.

This preserves the v0.3.0 ownership boundary that reusable definitions or starting values may be reused, but prior canonical identities, assignments, evidence, judgments, routes, publications, and history are not transferable Activity state.

## Privacy handling

Copying preserves privacy only when the source policy is context-free and safe to reuse.

Supported direct reuse:

- no explicit policy;
- `teacher_restricted`;
- `classroom_shared`.

Source-specific privacy context is not remapped.

Policies such as:

- `teacher_and_subjects`;
- `group_and_teacher`;
- `inherited`;
- `external_policy`;
- policies containing source-context references;

are tightened to `teacher_restricted` for the target preview and produce a visible diagnostic for teacher review.

Source privacy reason prose is not copied.

The workflow never attempts to infer replacement students, Groups, subjects, or external policy references in the target class.

## Standards handling

Core remains authoritative for standards.

Copied standards configuration is revalidated against the currently selected Core standards library before writing.

The workflow blocks rather than silently modifying configuration when:

- the source standards profile no longer exists;
- a Focus Standard is unknown;
- a Focus Standard falls outside the selected profile.

A source Activity with no profile or Focus Standards remains valid where the normal Activity contract permits that configuration.

Ordered Focus Standards retain their reviewed ordering.

## Concurrency and stale-review protection

Preparation returns a deterministic review digest.

The digest binds the configuration that matters to the requested copy, including:

- exact source class and Activity identity;
- inherited source title or description when those values are being reused;
- Activity type;
- scoring orientation;
- standards profile;
- ordered Focus Standards;
- source privacy configuration;
- resolved target privacy;
- target class;
- target Activity ID;
- title/description overrides;
- first Session configuration.

Changes to copy-relevant source configuration invalidate an earlier preview.

Operational source changes that are explicitly outside the copy boundary, such as adding Groups or GroupPlans, do not invalidate the review because that state is never copied.

## Direct CLI

Added typed, noninteractive commands:

```text
concord activity copy-preview
concord activity copy
```

The direct CLI supports explicit source and target identities, teacher actor metadata, first-Session configuration, title/description overrides, workspace/standards options, and the required review digest.

`copy` requires the exact digest returned by `copy-preview`.

No interactive prompts are used by the direct-command surface.

## Teacher menu

Activity Management now exposes:

```text
Copy an Activity
```

The teacher workflow:

1. identifies the exact source Activity;
2. selects the explicit target Core class;
3. chooses a new target Activity ID;
4. reviews or edits title and description;
5. reviews Activity type and scoring orientation;
6. reviews the standards profile and ordered Focus Standards;
7. reviews target privacy resolution;
8. supplies a fresh first Session ID and optional label;
9. sees the state explicitly excluded from copying;
10. receives the zero-write preview;
11. confirms using the exact uppercase token `COPY`;
12. creates the fresh target Activity and first Session.

Any other confirmation input leaves the workspace unchanged.

## Core baseline

During qualification, Concord's active development baseline was advanced to the latest released Core version:

```text
pds-core>=0.6.3,<0.7
```

The repository's package metadata, compatibility checks, CI configuration, documentation, wheel verification, release-artifact checks, and installed-wheel acceptance now consistently use Core 0.6.3 as the active development/release baseline.

Historical Core 0.6.1 grouping-signal qualification material remains historical evidence rather than the active runtime dependency baseline.

The installed producer-acceptance verifier was also corrected to honor its explicit `expected_core_version` argument instead of independently hard-coding an obsolete Core version.

## Documentation

Added:

- `docs/v0.3.0-activity-copying.md`

Updated relevant:

- README documentation;
- CLI contract;
- Core integration requirements;
- v0.3.0 integration documentation;
- documentation index;
- changelog;
- documentation validation.

The documentation records the positive copy allowlist, explicit exclusions, privacy behavior, standards validation, stale-review rules, create-only semantics, CLI contract, and teacher workflow.

## Qualification

Added focused coverage for:

- zero-write preparation;
- source immutability;
- positive configuration copying;
- fresh target Activity and Session identities;
- same-class copying;
- cross-class copying;
- reuse of the same Activity ID in a different class;
- exact self-copy rejection;
- existing-target conflict;
- create-only commit behavior;
- title and description overrides;
- explicit description clearing;
- deterministic review digests;
- stale review after copy-relevant source changes;
- non-stale review after unrelated Group/GroupPlan changes;
- source lifecycle status being display-only;
- target always beginning as draft/planned;
- Criterion Sets and Criteria not being copied;
- privacy-resolution matrix;
- source-context privacy references not being transferred;
- standards profile and Focus Standard revalidation;
- ordered Focus Standards;
- missing/invalid standards blocking before write;
- direct `copy-preview`;
- direct `copy`;
- digest enforcement;
- noninteractive CLI behavior;
- teacher-menu exposure;
- exact uppercase `COPY` confirmation.

Added an isolated installed-wheel Activity-copy smoke test that verifies:

- exact Core 0.6.3 wheel installation;
- built Concord wheel installation outside the checkout;
- zero-write preview;
- cross-class copying;
- source snapshot immutability;
- exactly one fresh draft Activity;
- exactly one fresh planned Session;
- absence of copied Groups, GroupPlans, Memberships, PacketInstances, Artifacts, Criterion Sets, and Scores;
- fresh provenance;
- empty target Criterion Set and external-reference selections;
- normal post-copy use of the target Activity through existing Concord services.

## Validation

Final repository qualification passed with the exact released Core 0.6.3 wheel.

Validation included:

```text
focused Activity-copy tests
full pytest suite
Ruff
Mypy
documentation validation
release compatibility validation
Core wheel verification
package build
wheel + sdist validation
Twine checks
release-artifact verification
isolated installed Concord producer acceptance
isolated installed Activity-copy wheel smoke
git diff --check
```

The installed producer acceptance completed the full academic-result publication lifecycle, including Core verification, supersession, withdrawal, registry audit, and immutability checks.

The built `pds_concord-0.3.0.dev0` wheel and sdist both passed packaging and release-artifact validation.

## Boundary with follow-up work

This issue intentionally does not introduce reusable presets for:

- Roles;
- Responsibilities;
- Criterion Sets;
- Scoring Scales;

and does not copy their assignments, criteria, or Scores.

Those concerns remain outside Activity copying and belong to the subsequent reusable-configuration work.