### PR TITLE
feat: reorganize Activity menus around teacher tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+
+- Opened Activities now use task-oriented `Plan`, `Prepare`, `Collect`, `Review`,
+  `Score`, and `Share` teacher navigation with one bounded Advanced escape hatch
+  that preserves the exact record-oriented workflows.
+- Assessment configuration now lives under Plan while routine Score contains only
+  explicit Score record/view/revision actions; Collect and Review likewise expose
+  focused existing Artifact services without collapsing Author, Subject, Review,
+  Moderation, or Score authority.
+- Routine Share now presents existing Core-backed registration/publication
+  behavior in teacher language while hiding manifest paths, hashes, publication
+  IDs, catalog internals, and first-versus-superseding mechanics.
+- Issue #66 qualification adds isolated installed-wheel task-navigation acceptance
+  against released Core v0.6.3 and preserves the #65 Information Density
+  clear/redraw contract.
+
 - Guided `Create Classroom Activity` and recoverable `Continue setup` teacher
   workflows now compose existing Activity-copy, Group/GroupPlan, reusable-preset,
   assessment, and Packet preparation services without persistent wizard state.

--- a/README.md
+++ b/README.md
@@ -168,6 +168,39 @@ complete #65 contract.
 
 [guided-activity-doc]: docs/v0.3.0-guided-create-classroom-activity.md
 
+
+## Task-oriented opened Activity navigation
+
+After an Activity is opened, routine teacher navigation is organized around the
+classroom task rather than Concord's record families:
+
+```text
+Plan
+Prepare
+Collect
+Review
+Score
+Share
+Advanced Activity tools
+```
+
+Plan contains setup, Sessions, student grouping, Roles/Responsibilities, and
+assessment configuration. Prepare contains the classroom-material workflow.
+Collect contains returned work, assembly, Author, and Subject actions. Review
+contains Artifact Review and Moderation. Score contains actual Score
+record/view/revision actions. Share presents existing registration/manifest/
+publication services in teacher language.
+
+The exact record-oriented Activity menu remains available through Advanced
+Activity tools, and the deterministic direct CLI is unchanged. Task navigation
+creates no canonical task state and follows the same Information Density
+clear/redraw contract as guided setup.
+
+See [task-oriented Activity menu documentation][task-activity-menu-doc] for the
+complete #66 contract.
+
+[task-activity-menu-doc]: docs/v0.3.0-task-oriented-activity-menus.md
+
 ## Direct CLI
 
 Direct commands are deterministic and fully noninteractive. They never clear

--- a/concord/menu_activity.py
+++ b/concord/menu_activity.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 from pds_core.standards import StandardsLibrary
 from pds_core.workspace import WorkspaceRootError
 
-from concord.menu_artifact import launch_artifact_page_menu
+from concord.menu_artifact import (
+    launch_artifact_page_menu,
+    launch_collect_work_menu,
+    launch_review_work_menu,
+)
 from concord.menu_context import CancelMenuAction, MenuSessionContext
 from concord.menu_group import launch_group_menu
 from concord.menu_guided_activity import (
+    launch_classroom_materials_menu,
     launch_guided_activity_menu,
     launch_guided_continue_setup,
     launch_guided_setup_for_activity,
+    launch_manage_saved_materials_menu,
 )
 from concord.menu_navigation import (
     ConcordMenuChoice,
@@ -19,7 +25,10 @@ from concord.menu_navigation import (
     navigation_hint_with_help,
     parse_menu_navigation,
 )
-from concord.menu_packet_generation import launch_packet_generation_menu
+from concord.menu_packet_generation import (
+    launch_packet_generation_menu,
+    show_prepared_materials,
+)
 from concord.menu_prompts import (
     choose_class,
     choose_focus_standards,
@@ -33,10 +42,17 @@ from concord.menu_prompts import (
     show_result,
     slug_identifier,
 )
-from concord.menu_publication import launch_publication_menu
+from concord.menu_publication import (
+    launch_publication_menu,
+    launch_share_results_menu,
+)
 from concord.menu_responsibility import launch_responsibility_menu
 from concord.menu_role import launch_role_menu
-from concord.menu_scoring import launch_scoring_menu
+from concord.menu_scoring import (
+    launch_assessment_setup_menu,
+    launch_score_menu,
+    launch_scoring_menu,
+)
 from concord.menu_session import launch_session_menu
 from concord.menu_ui import (
     clear_screen,
@@ -715,19 +731,179 @@ def _edit_activity(activity: ActivitySummary, state: MenuSessionContext) -> None
             pause_for_user()
 
 
-def launch_activity_context_menu(
+def _task_help(title: str, lines: tuple[str, ...]) -> None:
+    clear_screen()
+    print_menu_header(f"{title} Help")
+    for line in lines:
+        print(line)
+    print()
+    pause_for_user()
+
+
+def _task_header(title: str, activity: ActivitySummary) -> None:
+    clear_screen()
+    print_menu_header(title)
+    print(f"Activity: {activity.title}")
+    print()
+
+
+def _launch_roles_and_responsibilities_menu(
     activity: ActivitySummary,
-    state: MenuSessionContext | None = None,
+    state: MenuSessionContext,
 ) -> None:
-    """Open one Activity with only essential persistent context in the header."""
-    session_state = MenuSessionContext() if state is None else state
+    while True:
+        _task_header("Roles and Responsibilities", activity)
+        print("1. Who has which role?")
+        print("2. What does each person need to do?")
+        print_navigation()
+        print()
+        choice = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(choice)
+        if navigation is ConcordMenuChoice.HELP:
+            _task_help(
+                "Roles and Responsibilities",
+                (
+                    "Roles describe who is serving in a classroom role.",
+                    "Responsibilities describe what someone is expected to do.",
+                ),
+            )
+        elif navigation is NavigationChoice.BACK:
+            return
+        elif choice == "1":
+            launch_role_menu(activity, state)
+        elif choice == "2":
+            launch_responsibility_menu(activity, state)
+        else:
+            print(navigation_hint_with_help())
+            pause_for_user()
+
+
+def launch_plan_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+) -> None:
+    """Open the teacher-facing planning area for one Activity."""
+    while True:
+        _task_header("Plan", activity)
+        print("1. Continue classroom setup")
+        print("2. Sessions")
+        print("3. Student groups")
+        print("4. Roles and responsibilities")
+        print("5. Assessment setup")
+        print("6. Edit Activity")
+        print_navigation()
+        print()
+        choice = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(choice)
+        if navigation is ConcordMenuChoice.HELP:
+            _task_help(
+                "Plan",
+                (
+                    "Plan how this Activity will work.",
+                    "Set up sessions, student groups, classroom roles,",
+                    "responsibilities, and assessment before recording Scores.",
+                ),
+            )
+        elif navigation is NavigationChoice.BACK:
+            return
+        elif choice == "1":
+            launch_guided_setup_for_activity(activity, state)
+        elif choice == "2":
+            launch_session_menu(activity, state)
+        elif choice == "3":
+            launch_group_menu(activity, state)
+        elif choice == "4":
+            _launch_roles_and_responsibilities_menu(activity, state)
+        elif choice == "5":
+            launch_assessment_setup_menu(activity, state)
+        elif choice == "6":
+            _edit_activity(activity, state)
+        else:
+            print(navigation_hint_with_help())
+            pause_for_user()
+
+
+def launch_prepare_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+) -> None:
+    """Open the teacher-facing classroom-material preparation area."""
+    while True:
+        _task_header("Prepare", activity)
+        print("1. Prepare classroom materials")
+        print("2. View prepared materials")
+        print("3. Manage saved materials")
+        print_navigation()
+        print()
+        choice = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(choice)
+        if navigation is ConcordMenuChoice.HELP:
+            _task_help(
+                "Prepare",
+                (
+                    "Choose and prepare printable classroom materials.",
+                    "View what is ready without exposing routing or storage details.",
+                    "Manage reusable Packets and Templates when needed.",
+                ),
+            )
+        elif navigation is NavigationChoice.BACK:
+            return
+        elif choice == "1":
+            launch_classroom_materials_menu(activity, state)
+        elif choice == "2":
+            show_prepared_materials(activity)
+        elif choice == "3":
+            launch_manage_saved_materials_menu(state)
+        else:
+            print(navigation_hint_with_help())
+            pause_for_user()
+
+
+def launch_collect_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+) -> None:
+    """Open the teacher-facing returned-work collection area."""
+    launch_collect_work_menu(activity, state)
+
+
+def launch_review_task_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+) -> None:
+    """Open the teacher-facing evidence Review area."""
+    launch_review_work_menu(activity, state)
+
+
+def launch_score_task_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+) -> None:
+    """Open the teacher-facing Score area."""
+    launch_score_menu(activity, state)
+
+
+def launch_share_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+) -> None:
+    """Open the teacher-facing sharing area."""
+    launch_share_results_menu(activity, state)
+
+
+def launch_advanced_open_activity_tools_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+) -> None:
+    """Preserve the pre-#66 exact opened-Activity tools."""
     while True:
         try:
             activity = show_activity(activity.class_id, activity.activity_id).summary
         except ConcordWorkflowError:
             pass
         clear_screen()
-        print_menu_header(f"Activity: {activity.title}")
+        print_menu_header("Advanced Activity Tools")
+        print(f"Activity: {activity.title}")
         print(f"Class: {activity.class_id}")
         print(f"Status: {activity.status}")
         print()
@@ -756,30 +932,86 @@ def launch_activity_context_menu(
         elif choice == "2":
             _read_context_counts(activity)
         elif choice == "3":
-            launch_session_menu(activity, session_state)
+            launch_session_menu(activity, state)
         elif choice == "4":
-            launch_group_menu(activity, session_state)
+            launch_group_menu(activity, state)
         elif choice == "5":
-            launch_role_menu(activity, session_state)
+            launch_role_menu(activity, state)
         elif choice == "6":
-            launch_responsibility_menu(activity, session_state)
+            launch_responsibility_menu(activity, state)
         elif choice == "7":
-            launch_artifact_page_menu(activity, session_state)
+            launch_artifact_page_menu(activity, state)
         elif choice == "8":
-            launch_scoring_menu(activity, session_state)
+            launch_scoring_menu(activity, state)
         elif choice == "9":
-            launch_publication_menu(activity, session_state)
+            launch_publication_menu(activity, state)
         elif choice == "10":
-            _edit_activity(activity, session_state)
+            _edit_activity(activity, state)
         elif choice == "11":
-            launch_packet_generation_menu(activity, session_state)
+            launch_packet_generation_menu(activity, state)
         elif choice == "12":
-            launch_guided_setup_for_activity(activity, session_state)
+            launch_guided_setup_for_activity(activity, state)
         else:
             print(navigation_hint_with_help())
             pause_for_user()
 
 
+def launch_activity_context_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext | None = None,
+) -> None:
+    """Open one Activity around teacher tasks instead of record families."""
+    session_state = MenuSessionContext() if state is None else state
+    while True:
+        try:
+            activity = show_activity(activity.class_id, activity.activity_id).summary
+        except ConcordWorkflowError:
+            pass
+        clear_screen()
+        print_menu_header(f"Activity: {activity.title}")
+        print("1. Plan")
+        print("2. Prepare")
+        print("3. Collect")
+        print("4. Review")
+        print("5. Score")
+        print("6. Share")
+        print("7. Advanced Activity tools")
+        print_navigation()
+        print()
+        choice = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(choice)
+        if navigation is ConcordMenuChoice.HELP:
+            _task_help(
+                "Activity",
+                (
+                    "Plan how the Activity will work.",
+                    "Prepare classroom materials.",
+                    "Collect returned work.",
+                    "Review evidence and moderation.",
+                    "Score teacher-approved judgments.",
+                    "Share results deliberately.",
+                    "Advanced tools preserve exact record-level operations.",
+                ),
+            )
+        elif navigation is NavigationChoice.BACK:
+            return
+        elif choice == "1":
+            launch_plan_menu(activity, session_state)
+        elif choice == "2":
+            launch_prepare_menu(activity, session_state)
+        elif choice == "3":
+            launch_collect_menu(activity, session_state)
+        elif choice == "4":
+            launch_review_task_menu(activity, session_state)
+        elif choice == "5":
+            launch_score_task_menu(activity, session_state)
+        elif choice == "6":
+            launch_share_menu(activity, session_state)
+        elif choice == "7":
+            launch_advanced_open_activity_tools_menu(activity, session_state)
+        else:
+            print(navigation_hint_with_help())
+            pause_for_user()
 def select_activity() -> ActivitySummary | None:
     """Select one Activity from a paginated compact list."""
     try:

--- a/concord/menu_artifact.py
+++ b/concord/menu_artifact.py
@@ -2236,6 +2236,100 @@ def _launch_moderation_menu(
             _handle_error(activity, error, title="Moderation Error")
 
 
+def launch_collect_work_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+) -> None:
+    """Work with returned evidence without entering Review or scoring."""
+    while True:
+        clear_screen()
+        print_menu_header("Collect")
+        print(f"Activity: {activity.title}")
+        print()
+        print("1. View returned work")
+        print("2. Assemble returned work")
+        print("3. Confirm who produced the work")
+        print("4. Confirm who or what the work is about")
+        print_navigation()
+        print()
+        choice = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(choice)
+        try:
+            if navigation is ConcordMenuChoice.HELP:
+                clear_screen()
+                print_menu_header("Collect Help")
+                print("Use Collect for work that has come back from students.")
+                print("Assembly joins returned pages into the intended work.")
+                print("Who produced the work and what it concerns stay separate.")
+                print("Collect does not Review, Moderate, or Score the work.")
+                print()
+                pause_for_user()
+            elif navigation is NavigationChoice.BACK:
+                return
+            elif choice == "1":
+                _list_artifacts(activity)
+            elif choice == "2":
+                _assemble(activity, state)
+            elif choice == "3":
+                _launch_author_menu(activity, state)
+            elif choice == "4":
+                _launch_subject_menu(activity, state)
+            else:
+                print(navigation_hint_with_help())
+                pause_for_user()
+        except CancelMenuAction:
+            continue
+        except (ReturnToMainMenu, QuitPDS, KeyboardInterrupt, EOFError):
+            raise
+        except Exception as error:
+            _handle_error(activity, error, title="Collect Error")
+
+
+def launch_review_work_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+) -> None:
+    """Review collected evidence without recording Scores."""
+    while True:
+        clear_screen()
+        print_menu_header("Review")
+        print(f"Activity: {activity.title}")
+        print()
+        print("1. Review collected work")
+        print("2. Moderation")
+        print_navigation()
+        print()
+        choice = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(choice)
+        try:
+            if navigation is ConcordMenuChoice.HELP:
+                clear_screen()
+                print_menu_header("Review Help")
+                print("Review records explicit human evidence-readiness judgments.")
+                print(
+                    "Moderation is a separate reliability and "
+                    "permitted-use decision."
+                )
+                print("Neither Review nor Moderation creates a Score.")
+                print()
+                pause_for_user()
+            elif navigation is NavigationChoice.BACK:
+                return
+            elif choice == "1":
+                _launch_review_menu(activity, state)
+            elif choice == "2":
+                _launch_moderation_menu(activity, state)
+            else:
+                print(navigation_hint_with_help())
+                pause_for_user()
+        except CancelMenuAction:
+            continue
+        except (ReturnToMainMenu, QuitPDS, KeyboardInterrupt, EOFError):
+            raise
+        except Exception as error:
+            _handle_error(activity, error, title="Review Error")
+
+
 def launch_artifact_page_menu(
     activity: ActivitySummary, state: MenuSessionContext
 ) -> None:
@@ -2304,4 +2398,8 @@ def launch_artifact_page_menu(
             return
 
 
-__all__ = ["launch_artifact_page_menu"]
+__all__ = [
+    "launch_artifact_page_menu",
+    "launch_collect_work_menu",
+    "launch_review_work_menu",
+]

--- a/concord/menu_guided_activity.py
+++ b/concord/menu_guided_activity.py
@@ -711,6 +711,19 @@ def _launch_materials(activity: ActivitySummary, state: MenuSessionContext) -> N
         pause_for_user()
 
 
+def launch_classroom_materials_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+) -> None:
+    """Open the reusable teacher-facing classroom-material chooser."""
+    _launch_materials(activity, state)
+
+
+def launch_manage_saved_materials_menu(state: MenuSessionContext) -> None:
+    """Open saved Packet and Template management without Activity writes."""
+    _manage_saved_materials(state)
+
+
 def _launch_groups(activity: ActivitySummary, state: MenuSessionContext) -> None:
     while True:
         clear_screen()

--- a/concord/menu_packet_generation.py
+++ b/concord/menu_packet_generation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from concord.menu_context import CancelMenuAction, MenuSessionContext
 from concord.menu_navigation import (
     ConcordMenuChoice,
@@ -416,6 +418,45 @@ def _preview_lines(
             for item in prepared.diagnostics
         )
     return tuple(lines)
+
+
+def show_prepared_materials(activity: ActivitySummary) -> None:
+    """Show a low-density, read-only summary of prepared classroom materials."""
+    try:
+        items = list_packet_instances(activity.class_id, activity.activity_id)
+        if not items:
+            show_result(
+                "Prepared Materials",
+                ("No classroom materials have been prepared yet.",),
+            )
+            return
+
+        ready_count = sum(
+            1 for item in items if item.generation_status == "generated"
+        )
+        attention_count = len(items) - ready_count
+        lines = [
+            f"Prepared sets: {len(items)}",
+            f"Ready to print: {ready_count}",
+        ]
+        if attention_count:
+            lines.append(f"Need attention: {attention_count}")
+
+        filenames = tuple(
+            dict.fromkeys(
+                Path(item.output_relative_path).name
+                for item in items
+                if item.output_relative_path
+            )
+        )
+        if filenames:
+            lines.append("")
+            lines.append("Files:")
+            lines.extend(filenames)
+
+        show_result("Prepared Materials", tuple(lines))
+    except Exception as error:
+        show_result("Prepared Materials", (str(error),))
 
 
 def _list_instances(activity: ActivitySummary) -> None:

--- a/concord/menu_publication.py
+++ b/concord/menu_publication.py
@@ -381,6 +381,7 @@ def _publish(
     session: MenuSessionContext,
     *,
     superseding: bool,
+    teacher_facing: bool = False,
 ) -> None:
     state = load_concord_publication_series_status(
         activity.class_id, activity.activity_id, workspace_root=_root()
@@ -399,18 +400,36 @@ def _publish(
         _root(), activity.class_id, activity.activity_id
     )
     assert registration is not None
-    review = list(
-        _review_lines(
-            preview,
-            academic_intent=registration.academic_intent,
-            lifecycle=registration.lifecycle,
+    if teacher_facing:
+        review = list(
+            _share_review_lines(
+                activity,
+                preview,
+                academic_intent=registration.academic_intent,
+                lifecycle=registration.lifecycle,
+            )
         )
+    else:
+        review = list(
+            _review_lines(
+                preview,
+                academic_intent=registration.academic_intent,
+                lifecycle=registration.lifecycle,
+            )
+        )
+        if state.core_head is not None:
+            review.append(f"Expected Core head: {state.core_head.publication_id}")
+            withdrawn_label = "yes" if state.core_head_withdrawal else "no"
+            review.append(f"Expected Core head withdrawn: {withdrawn_label}")
+    confirmation_title = (
+        "Share Results" if teacher_facing else "Publish Academic Results"
     )
-    if state.core_head is not None:
-        review.append(f"Expected Core head: {state.core_head.publication_id}")
-        withdrawn_label = "yes" if state.core_head_withdrawal else "no"
-        review.append(f"Expected Core head withdrawn: {withdrawn_label}")
-    if not confirm_write("Publish Academic Results", "PUBLISH", tuple(review)):
+    confirmation_word = "SHARE" if teacher_facing else "PUBLISH"
+    if not confirm_write(
+        confirmation_title,
+        confirmation_word,
+        tuple(review),
+    ):
         return
     if not superseding:
         result = publish_concord_academic_results(
@@ -437,49 +456,98 @@ def _publish(
                 standards_library=load_menu_standards_library(),
                 clock=lambda: preview.manifest.generated_at,
             )
-    show_result(
-        "Publication Result",
-        (
-            f"Disposition: {result.disposition}",
-            f"Publication: {result.publication.publication_id}",
-            f"Record-set revision: {result.publication.record_set_revision}",
-        ),
-    )
+    if teacher_facing:
+        show_result(
+            "Results Shared",
+            (
+                "The Activity results are now shared through Paper Data Suite.",
+                f"Shared revision: {result.publication.record_set_revision}",
+            ),
+        )
+    else:
+        show_result(
+            "Publication Result",
+            (
+                f"Disposition: {result.disposition}",
+                f"Publication: {result.publication.publication_id}",
+                f"Record-set revision: {result.publication.record_set_revision}",
+            ),
+        )
 
 
-def _withdraw(activity: ActivitySummary) -> None:
+def _withdraw(
+    activity: ActivitySummary,
+    *,
+    teacher_facing: bool = False,
+) -> None:
     state = load_concord_publication_series_status(
         activity.class_id, activity.activity_id, workspace_root=_root()
     )
-    if not state.publications:
-        show_result("Withdraw Publication", ("No Core publications exist.",))
-        return
-    publication_id = prompt_text(
-        "Withdraw Publication",
-        "Publication ID",
-        help_text="Enter the exact Core Publication Record ID to withdraw.",
-        default=(state.core_head.publication_id if state.core_head else None),
-    )
-    assert publication_id is not None
-    reason = prompt_text(
-        "Withdraw Publication",
-        "Publication-safe reason",
-        help_text=(
-            "Use deliberate operational text only; do not paste student or "
-            "moderation narrative."
-        ),
-    )
-    assert reason is not None
-    if not confirm_write(
-        "Withdraw Publication",
-        "WITHDRAW",
-        (
-            f"Activity: {activity.title}",
-            f"Publication: {publication_id}",
-            f"Reason: {reason}",
-        ),
-    ):
-        return
+    publication_id: str
+    if teacher_facing:
+        current = state.current_selectable_publication
+        if current is None:
+            show_result(
+                "Stop Sharing",
+                ("There are no currently shared results to stop sharing.",),
+            )
+            return
+        current_publication_id = current.publication_id
+        if current_publication_id is None:
+            raise ValueError(
+                "Current shared results have no publication identifier."
+            )
+        publication_id = current_publication_id
+        reason = prompt_text(
+            "Stop Sharing",
+            "Reason",
+            help_text=(
+                "Use a short operational reason. Do not include student "
+                "or moderation narrative."
+            ),
+        )
+        assert reason is not None
+        if not confirm_write(
+            "Stop Sharing",
+            "STOP",
+            (
+                f"Activity: {activity.title}",
+                f"Current shared revision: {current.record_set_revision}",
+                f"Reason: {reason}",
+            ),
+        ):
+            return
+    else:
+        if not state.publications:
+            show_result("Withdraw Publication", ("No Core publications exist.",))
+            return
+        publication_id_value = prompt_text(
+            "Withdraw Publication",
+            "Publication ID",
+            help_text="Enter the exact Core Publication Record ID to withdraw.",
+            default=(state.core_head.publication_id if state.core_head else None),
+        )
+        assert publication_id_value is not None
+        publication_id = publication_id_value
+        reason = prompt_text(
+            "Withdraw Publication",
+            "Publication-safe reason",
+            help_text=(
+                "Use deliberate operational text only; do not paste student or "
+                "moderation narrative."
+            ),
+        )
+        assert reason is not None
+        if not confirm_write(
+            "Withdraw Publication",
+            "WITHDRAW",
+            (
+                f"Activity: {activity.title}",
+                f"Publication: {publication_id}",
+                f"Reason: {reason}",
+            ),
+        ):
+            return
     result = withdraw_concord_academic_result_publication(
         activity.class_id,
         activity.activity_id,
@@ -487,14 +555,20 @@ def _withdraw(activity: ActivitySummary) -> None:
         reason=reason,
         workspace_root=_root(),
     )
-    show_result(
-        "Withdrawal Result",
-        (
-            f"Disposition: {result.disposition}",
-            f"Publication: {result.publication.publication_id}",
-            f"Manifest verification: {result.manifest_verification}",
-        ),
-    )
+    if teacher_facing:
+        show_result(
+            "Sharing Stopped",
+            ("The current shared results are no longer selectable.",),
+        )
+    else:
+        show_result(
+            "Withdrawal Result",
+            (
+                f"Disposition: {result.disposition}",
+                f"Publication: {result.publication.publication_id}",
+                f"Manifest verification: {result.manifest_verification}",
+            ),
+        )
 
 
 def _catalog_status(activity: ActivitySummary) -> None:
@@ -595,6 +669,223 @@ def _publication_help() -> None:
             "Publication does not calculate Grades, proficiency, or reporting policy.",
         ),
     )
+
+
+def _sharing_setup_status(activity: ActivitySummary) -> None:
+    registration = load_current_concord_academic_work_registration(
+        _root(), activity.class_id, activity.activity_id
+    )
+    lines = [f"Activity: {activity.title}"]
+    if registration is None:
+        lines.append("Sharing setup: not configured")
+    else:
+        lines.extend(
+            (
+                "Sharing setup: configured",
+                (
+                    "Academic intent: "
+                    + registration.academic_intent.replace("_", " ").title()
+                ),
+                f"Activity status: {registration.lifecycle.title()}",
+            )
+        )
+    show_result("Sharing Setup", tuple(lines))
+
+
+def _launch_sharing_setup_menu(activity: ActivitySummary) -> None:
+    while True:
+        clear_screen()
+        print_menu_header("Set Up Sharing")
+        print(f"Activity: {activity.title}")
+        print()
+        print("1. View sharing setup")
+        print("2. Set up this Activity for sharing")
+        print("3. Update sharing setup")
+        print_navigation()
+        print()
+        choice = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(choice)
+        if navigation is ConcordMenuChoice.HELP:
+            show_result(
+                "Sharing Setup Help",
+                (
+                    "Set the Activity's academic intent and lifecycle.",
+                    "This does not share results by itself.",
+                ),
+            )
+        elif navigation is NavigationChoice.BACK:
+            return
+        elif choice == "1":
+            _sharing_setup_status(activity)
+        elif choice == "2":
+            _register(activity)
+        elif choice == "3":
+            _update_registration(activity)
+        else:
+            print(navigation_hint_with_help())
+            pause_for_user()
+
+
+def _share_review_lines(
+    activity: ActivitySummary,
+    preview: AcademicResultManifestPreview,
+    *,
+    academic_intent: str,
+    lifecycle: str,
+) -> tuple[str, ...]:
+    summary = manifest_preview_summary(preview)
+    return (
+        f"Activity: {activity.title}",
+        f"Academic intent: {academic_intent.replace('_', ' ').title()}",
+        f"Activity status: {lifecycle.title()}",
+        f"Scores included: {summary['score_count']}",
+        (
+            "Current / historical Scores: "
+            f"{summary['current_score_count']} / {summary['historical_score_count']}"
+        ),
+        (
+            "Standards-backed / Activity-specific Scores: "
+            f"{summary['standard_backed_score_count']} / "
+            f"{summary['local_score_count']}"
+        ),
+        f"Non-score records included: {summary['non_score_count']}",
+        (
+            "Scores requiring moderation: "
+            f"{summary['moderation_dependent_count']}"
+        ),
+    )
+
+
+def _show_share_preview(
+    activity: ActivitySummary,
+    session: MenuSessionContext,
+) -> None:
+    _request_value, preview = _preview(activity, session)
+    registration = load_current_concord_academic_work_registration(
+        _root(), activity.class_id, activity.activity_id
+    )
+    assert registration is not None
+    show_result(
+        "Review What Will Be Shared",
+        _share_review_lines(
+            activity,
+            preview,
+            academic_intent=registration.academic_intent,
+            lifecycle=registration.lifecycle,
+        ),
+    )
+
+
+def _share_results(
+    activity: ActivitySummary,
+    session: MenuSessionContext,
+) -> None:
+    state = load_concord_publication_series_status(
+        activity.class_id,
+        activity.activity_id,
+        workspace_root=_root(),
+    )
+    _publish(
+        activity,
+        session,
+        superseding=state.core_head is not None,
+        teacher_facing=True,
+    )
+
+
+def _share_history(activity: ActivitySummary) -> None:
+    state = load_concord_publication_series_status(
+        activity.class_id,
+        activity.activity_id,
+        workspace_root=_root(),
+    )
+    lines = [f"Shared revisions: {len(state.publications)}"]
+    if state.current_selectable_publication is None:
+        lines.append("Currently shared: no")
+    else:
+        lines.extend(
+            (
+                "Currently shared: yes",
+                (
+                    "Current shared revision: "
+                    f"{state.current_selectable_publication.record_set_revision}"
+                ),
+            )
+        )
+    for publication in state.publications:
+        withdrawn = any(
+            item.publication_id == publication.publication_id
+            for item in state.withdrawals
+        )
+        current = (
+            state.current_selectable_publication is not None
+            and state.current_selectable_publication.publication_id
+            == publication.publication_id
+        )
+        if current:
+            status = "current"
+        elif withdrawn:
+            status = "withdrawn"
+        else:
+            status = "earlier"
+        lines.append(f"Revision {publication.record_set_revision}: {status}")
+    show_result("Sharing History", tuple(lines))
+
+
+def launch_share_results_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+) -> None:
+    """Open the focused teacher-facing result-sharing surface."""
+    while True:
+        clear_screen()
+        print_menu_header("Share")
+        print(f"Activity: {activity.title}")
+        print()
+        print("1. Set up sharing")
+        print("2. Review what will be shared")
+        print("3. Share results")
+        print("4. View sharing history")
+        print("5. Stop sharing current results")
+        print_navigation()
+        print()
+        choice = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(choice)
+        if navigation is ConcordMenuChoice.HELP:
+            show_result(
+                "Share Help",
+                (
+                    "Share deliberate Activity results through Paper Data Suite.",
+                    "Review the result set before sharing it.",
+                    "Sharing does not calculate Grades or reporting policy.",
+                ),
+            )
+            continue
+        if navigation is NavigationChoice.BACK:
+            return
+        try:
+            activity = show_activity(
+                activity.class_id,
+                activity.activity_id,
+                workspace_root=_root(),
+            ).summary
+            if choice == "1":
+                _launch_sharing_setup_menu(activity)
+            elif choice == "2":
+                _show_share_preview(activity, state)
+            elif choice == "3":
+                _share_results(activity, state)
+            elif choice == "4":
+                _share_history(activity)
+            elif choice == "5":
+                _withdraw(activity, teacher_facing=True)
+            else:
+                print(navigation_hint_with_help())
+                pause_for_user()
+        except CancelMenuAction:
+            continue
+        except Exception as error:
+            _handle_error(error)
 
 
 def launch_publication_menu(

--- a/concord/menu_scoring.py
+++ b/concord/menu_scoring.py
@@ -2035,6 +2035,94 @@ def _scale_menu(
             pause_for_user()
 
 
+def launch_assessment_setup_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext | None = None,
+) -> None:
+    """Configure how an Activity will be assessed without recording Scores."""
+    session_state = MenuSessionContext() if state is None else state
+    while True:
+        try:
+            activity = _latest(activity)
+        except Exception:
+            pass
+        clear_screen()
+        print_menu_header("Assessment Setup")
+        print(f"Activity: {activity.title}")
+        print()
+        print("1. Use saved assessment setup")
+        print("2. Criteria")
+        print("3. Scoring scales")
+        print_navigation()
+        print()
+        choice = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(choice)
+        if navigation is ConcordMenuChoice.HELP:
+            show_result(
+                "Assessment Setup Help",
+                (
+                    "Set up criteria and scoring scales for this Activity.",
+                    "This setup creates no Scores.",
+                    "Actual teacher judgments are recorded from the Score task.",
+                ),
+            )
+        elif navigation is NavigationChoice.BACK:
+            return
+        elif choice == "1":
+            _use_saved_scoring_setup(activity, session_state)
+        elif choice == "2":
+            _criterion_set_menu(activity, session_state)
+        elif choice == "3":
+            _scale_menu(activity, session_state)
+        else:
+            print(navigation_hint_with_help())
+            pause_for_user()
+
+
+def launch_score_menu(
+    activity: ActivitySummary,
+    state: MenuSessionContext | None = None,
+) -> None:
+    """Record, inspect, or revise explicit teacher Score judgments."""
+    session_state = MenuSessionContext() if state is None else state
+    while True:
+        try:
+            activity = _latest(activity)
+        except Exception:
+            pass
+        clear_screen()
+        print_menu_header("Score")
+        print(f"Activity: {activity.title}")
+        print()
+        print("1. Record a Score")
+        print("2. View Scores")
+        print("3. Revise a Score")
+        print_navigation()
+        print()
+        choice = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(choice)
+        if navigation is ConcordMenuChoice.HELP:
+            clear_screen()
+            print_menu_header("Score Help")
+            print("Record explicit teacher-approved judgments here.")
+            print("Assessment criteria and scales are configured under Plan.")
+            print("Concord never infers a Score from evidence.")
+            print("A Group Score never creates individual student Scores.")
+            print()
+            pause_for_user()
+        elif navigation is NavigationChoice.BACK:
+            return
+        elif choice == "1":
+            _record_score(activity, session_state)
+        elif choice == "2":
+            _browse_scores(activity)
+        elif choice == "3":
+            _revise_score(activity, session_state)
+        else:
+            print(navigation_hint_with_help())
+            pause_for_user()
+
+
 def launch_scoring_menu(
     activity: ActivitySummary,
     state: MenuSessionContext | None = None,
@@ -2091,4 +2179,8 @@ def launch_scoring_menu(
             pause_for_user()
 
 
-__all__ = ["launch_scoring_menu"]
+__all__ = [
+    "launch_assessment_setup_menu",
+    "launch_score_menu",
+    "launch_scoring_menu",
+]

--- a/docs/README.md
+++ b/docs/README.md
@@ -363,6 +363,17 @@ Criterion/Scale setup, Core standards revalidation, Score exclusion,
 positive-allowlist save-from-existing workflows, direct CLI, teacher Preset
 Library, Core 0.6.3 baseline, and installed-wheel qualification.
 
+
+### v0.3.0 task-oriented Activity menus
+
+[`v0.3.0-task-oriented-activity-menus.md`](v0.3.0-task-oriented-activity-menus.md)
+
+Documents issue #66's Plan / Prepare / Collect / Review / Score / Share opened-
+Activity model, assessment-setup versus Score boundary, low-density task screens,
+teacher-facing Share wrapper, exact Advanced escape hatch, #65 guided-workflow
+composition, #67/#68 handoffs, direct-CLI preservation, and isolated installed-
+wheel qualification against released Core 0.6.3.
+
 ### Future v0.3.0 Group Planning / Template / Packet plan
 
 [`pds-group-planning-interoperability-development-plan.md`](pds-group-planning-interoperability-development-plan.md)

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented through the v0.3.0 reusable-preset workflow in issue #64.
+Implemented through the v0.3.0 task-oriented Activity menu workflow in issue #66.
 
 ## Two interfaces, one service layer
 
@@ -507,6 +507,44 @@ Effective Context offers one Session, several selected Sessions, or a starting
 Session through the remaining Activity. Group revision exposes ordinary label,
 description, status, parent, and Effective Context changes without changing the
 Group identity.
+
+
+### Task-oriented opened Activities
+
+Issue #66 changes the routine opened-Activity menu from a record-family list to:
+
+```text
+1. Plan
+2. Prepare
+3. Collect
+4. Review
+5. Score
+6. Share
+7. Advanced Activity tools
+```
+
+Plan composes Continue setup, Sessions, student Groups/GroupPlans,
+Roles/Responsibilities, assessment configuration, and Activity editing. Prepare
+uses the existing saved-material and reviewed Packet-generation paths. Collect
+routes returned work, assembly, Authors, and Subjects. Review routes Artifact
+Review and Moderation. Score exposes only actual Score record/view/revision;
+Criterion Set and Scale configuration remain under Plan. Share wraps the existing
+registration/manifest/publication services in teacher language.
+
+Advanced Activity tools preserves the complete exact record-oriented menu,
+including Artifact Pages, Scoring, Publication, Packet generation/recovery, and
+diagnostic detail. The task layer adds no canonical task-status records.
+
+The task screens extend the Information Density contract: clearing/redrawing is
+the default, only current-action context remains visible, and routine screens
+avoid IDs, paths, hashes, digests, raw JSON, grouping-signal internals, and
+publication internals that are unnecessary for the current teacher decision.
+
+This reorganization is interactive presentation only. The direct command
+inventory above remains unchanged and noninteractive.
+
+See `docs/v0.3.0-task-oriented-activity-menus.md` for the complete issue #66
+contract.
 
 ## Concurrency and no-op behavior
 

--- a/docs/v0.3.0-guided-create-classroom-activity.md
+++ b/docs/v0.3.0-guided-create-classroom-activity.md
@@ -291,3 +291,21 @@ by their existing #62 and #64 installed smokes, which the repository validator
 continues to run alongside the #65 smoke.
 
 Milestone-wide representative physical print/scan acceptance remains issue #70.
+
+
+## Handoff to task-oriented opened Activity navigation
+
+Issue #66 builds directly on this guide without replacing it. **Continue setup**
+is reachable from the opened Activity's Plan task and still uses the same
+canonical-state-derived workflow documented here.
+
+The routine opened Activity is now organized as Plan, Prepare, Collect, Review,
+Score, Share, and Advanced Activity tools. Assessment setup belongs under Plan;
+actual Score judgment belongs under Score. The exact record-oriented menus remain
+available under Advanced.
+
+The same Information Density contract applies to every #66 task screen:
+**Clearing/redrawing the screen is the default. Information remains visible only
+when the teacher needs it to complete the current action.**
+
+See `v0.3.0-task-oriented-activity-menus.md` for the complete #66 boundary.

--- a/docs/v0.3.0-task-oriented-activity-menus.md
+++ b/docs/v0.3.0-task-oriented-activity-menus.md
@@ -1,0 +1,368 @@
+# v0.3.0 Task-Oriented Activity Menus
+
+**Status:** Implemented for issue #66  
+**Development baseline:** `pds-concord 0.3.0.dev0`  
+**Core compatibility:** `pds-core>=0.6.3,<0.7`
+
+## Purpose
+
+Issue #66 reorganizes the routine teacher experience after an Activity is opened.
+The teacher starts from the classroom task they are trying to complete rather
+than from Concord's internal record families.
+
+The normal opened-Activity mental model is:
+
+```text
+Plan     What will happen?
+Prepare  What materials do I need?
+Collect  What work came back?
+Review   Is this evidence ready and appropriate to use?
+Score    What judgment am I recording?
+Share    What results am I deliberately making available?
+```
+
+The architecture remains:
+
+```text
+teacher task
+    ->
+focused task menu
+    ->
+existing Concord workflow/service
+    ->
+existing canonical records
+```
+
+In other words:
+
+```text
+presentation routing != domain mutation logic
+```
+
+No `ActivityTaskState`, task-status record family, or other second source of
+truth is introduced. Navigation itself is read-only.
+
+## Opened Activity
+
+The routine opened-Activity surface is intentionally bounded:
+
+```text
+Activity: Macbeth Seminar
+
+1. Plan
+2. Prepare
+3. Collect
+4. Review
+5. Score
+6. Share
+7. Advanced Activity tools
+
+H. Help
+B. Back
+M. Main Menu
+Q. Quit
+```
+
+The long record-family interface remains available through **Advanced Activity
+tools** for diagnostics, recovery, troubleshooting, and exact expert operations.
+
+The routine screen is not an attention dashboard. Issue #66 answers:
+
+> Where does the teacher go to do a task?
+
+Issue #67 separately answers:
+
+> What currently needs the teacher's attention?
+
+Counts, badges, cross-Activity prioritization, and recommended-next-action logic
+remain outside #66.
+
+## Plan
+
+Plan coordinates the Activity's intended classroom structure:
+
+```text
+1. Continue classroom setup
+2. Sessions
+3. Student groups
+4. Roles and responsibilities
+5. Assessment setup
+6. Edit Activity
+```
+
+**Continue classroom setup** reuses issue #65's canonical-state-derived guided
+workflow. There is no second setup-state reader and no persistent wizard state.
+
+Student grouping retains the existing distinction:
+
+```text
+GroupPlan != Group != GroupMembership
+```
+
+Opening Plan never approves or applies a GroupPlan. Existing explicit review and
+approval remain authoritative.
+
+Roles and Responsibilities are presented together as a teacher task while their
+native authorities remain distinct:
+
+```text
+Role != Responsibility
+Role preset != RoleAssignment
+Responsibility preset != ResponsibilityAssignment
+```
+
+Assessment configuration also belongs here. The required boundary is:
+
+```text
+assessment setup != Score
+```
+
+Saved/manual Criterion Set and Scoring Scale workflows continue to create fresh
+Activity-native configuration and **zero Scores**.
+
+## Prepare
+
+Prepare is the routine classroom-material surface:
+
+```text
+1. Prepare classroom materials
+2. View prepared materials
+3. Manage saved materials
+```
+
+It reuses issue #65's saved Packet and saved Template orchestration. A standalone
+Template still becomes a normal reusable Packet before Activity-specific
+generation. Runtime paper authority remains:
+
+```text
+Template Version
+    ->
+Packet Version
+    ->
+Activity-specific Packet preparation
+    ->
+Artifact / Artifact Page
+    ->
+Core PDS2 routing
+```
+
+There is no `Template -> Artifact` shortcut and no second print, QR, or routing
+architecture.
+
+The prepared-material summary is read-only and low-density. It may show useful
+counts and generated PDF basenames, but it does not expose PacketInstance IDs,
+generation IDs, route internals, storage roots, hashes, or review digests.
+
+Exact PacketInstance inspection, recovery, route preparation, reprint, and
+low-level Artifact/Page preparation remain under Advanced tools.
+
+## Collect
+
+Collect is for evidence that has come back:
+
+```text
+1. View returned work
+2. Assemble returned work
+3. Confirm who produced the work
+4. Confirm who or what the work is about
+```
+
+These actions route to the existing Artifact listing, returned-Artifact assembly,
+Author, and Subject workflows.
+
+Concord preserves:
+
+```text
+Author != Subject
+```
+
+Membership does not prove authorship. Authorship does not automatically establish
+Subject. Collection also does not imply Review, Moderation, or Score.
+
+Issue #66 does not create a second scan-routing architecture. Core's PDS2 and
+retained-source authority remain unchanged; mixed suite intake remains issue #68.
+
+## Review
+
+Review contains only the existing evidence-readiness and moderation authorities:
+
+```text
+1. Review collected work
+2. Moderation
+```
+
+The existing detailed Review and Moderation submenus retain history, correction,
+scope, and applicability behavior.
+
+The domain distinctions remain:
+
+```text
+returned != reviewed
+assembled != reviewed
+Review != Moderation
+Review != Score
+Moderation != Score
+```
+
+Entering Review is read-only. Review and Moderation mutations retain their own
+explicit confirmation and never create a Score merely because the teacher enters
+or leaves this task.
+
+## Score
+
+The routine Score surface contains actual teacher judgment only:
+
+```text
+1. Record a Score
+2. View Scores
+3. Revise a Score
+```
+
+Criterion Set, Scale, and reusable assessment configuration are deliberately not
+routine Score navigation; they are under Plan -> Assessment setup. The complete
+technical Scoring menu remains under Advanced Activity tools.
+
+Existing Score semantics are unchanged. Concord does not infer Score values from
+evidence, Review, Moderation, grouping signals, or missing evidence. Group Scores
+do not become individual student Scores. Concord does not calculate Grades or
+proficiency.
+
+## Share
+
+Share translates the existing registration/manifest/publication workflow into
+teacher language:
+
+```text
+1. Set up sharing
+2. Review what will be shared
+3. Share results
+4. View sharing history
+5. Stop sharing current results
+```
+
+Routine Share hides implementation-oriented details such as manifest paths,
+SHA-256 values, Core Publication IDs, catalog internals, and first-versus-
+superseding mechanics.
+
+`Share results` still uses the exact existing publication services. Concord
+selects the correct first publication, superseding publication, or supported
+republish-after-withdrawal path from current canonical state.
+
+Teacher-facing sharing requires its own explicit `SHARE` confirmation. Stopping
+the current selectable result requires its own `STOP` confirmation. A Score
+confirmation never authorizes Share.
+
+The underlying architecture remains:
+
+```text
+Concord canonical result state
+    ->
+Concord Academic Result Manifest
+    ->
+Core Publication Record
+    ->
+authorized compatible consumer discovery
+```
+
+And the boundaries remain:
+
+```text
+manifest generation != publication
+publication != downstream ingestion
+publication != authorization
+publication != Grade
+```
+
+There are no direct Meridian writes and no Meridian runtime dependency.
+
+## Advanced Activity tools
+
+Advanced preserves the exact record-oriented surface, including Activity detail,
+collaboration counts, Sessions, Groups/Memberships, Roles, Responsibilities,
+Artifact Pages, the complete Scoring menu, the complete Publication menu,
+Activity editing, Packet generation/recovery, and Continue Classroom Setup.
+
+This is an escape hatch, not a second implementation. Routine task menus call or
+compose the same existing Concord functions and services.
+
+## Relationship to issue #65
+
+Issue #65 owns **Create Classroom Activity** and **Continue setup**. Issue #66
+does not replace that guide. Plan exposes the same Continue setup workflow so a
+teacher can naturally return to incomplete setup from an opened Activity.
+
+The recoverable/incremental rule remains unchanged: confirmed canonical work
+stays committed, and setup state is derived from canonical records.
+
+## Information Density and screen refresh
+
+Issue #66 carries forward the suite interface contract established by #65:
+
+> **Clearing/redrawing the screen is the default. Information remains visible
+> only when the teacher needs it to complete the current action.**
+
+A routine task screen normally contains only:
+
+1. the task name;
+2. the Activity title;
+3. context needed for the current choice;
+4. current actions; and
+5. H/B/M/Q navigation.
+
+Routine task screens avoid generated IDs, class/Activity IDs, raw JSON, storage
+paths, snapshot/revision values, review digests, provenance objects, grouping-
+signal internals, PDS2 internals, and publication internals unless a specific
+teacher action genuinely requires a detail.
+
+Long selections continue to use shared bounded paging/selection helpers.
+
+## Privacy
+
+Task-oriented routing does not broaden visibility or persistence.
+
+Grouping signals remain teacher-restricted planning inputs and do not leak into
+Prepare, Collect, Review, Score, or Share. Review/Moderation and Score list
+surfaces remain concise and do not become bulk private-rationale dumps. Share
+shows only the result-set information necessary for a deliberate teacher
+decision.
+
+Tests and examples use synthetic data only.
+
+## Direct CLI preservation
+
+The deterministic direct CLI remains domain-oriented and fully noninteractive.
+Issue #66 does not create `plan`, `prepare`, `collect`, `review`, `score`, or
+`share` wrapper commands. Existing command families remain the scripting,
+diagnostic, recovery, and expert interface.
+
+Direct commands do not clear the screen or launch the teacher menu. Both
+presentations converge on the same domain services.
+
+## Issue #67 and #68 boundaries
+
+Issue #67 owns attention and next-action summaries. Issue #66 does not add task
+badges, pending counts, ranking, or a dashboard.
+
+Issue #68 owns suite doctor, launcher, and mixed paper intake integration. Issue
+#66 remains Concord-local and adds no sibling PDS dependency or suite-owned
+Concord writes.
+
+## Installed qualification
+
+`scripts/smoke_test_task_oriented_activity_menu_wheel.py` installs the exact
+Concord and Core wheels into an isolated environment and verifies that:
+
+- `pds-core` is exactly 0.6.3 and Concord is `0.3.0.dev0`;
+- Concord imports from the isolated installed distribution;
+- no sibling PDS module distribution is installed;
+- one synthetic Activity opens to Plan, Prepare, Collect, Review, Score, Share,
+  and Advanced Activity tools;
+- representative navigation through every task returns cleanly;
+- the exact Scoring and Publication surfaces remain reachable under Advanced;
+- navigation alone does not advance the Activity snapshot.
+
+The smoke is wired into `scripts/validate_repository.py` after the existing #65
+installed guided-workflow smoke.
+
+Issue #66 changes no printable layout, QR/PDS2 grammar, page allocation, or
+physical rendering. Milestone-level physical acceptance remains issue #70.

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -76,6 +76,10 @@ REUSABLE_PRESETS_DOC = (
 GUIDED_ACTIVITY_WORKFLOW_DOC = (
     ROOT / "docs" / "v0.3.0-guided-create-classroom-activity.md"
 )
+
+TASK_ORIENTED_ACTIVITY_MENU_DOC = (
+    ROOT / "docs" / "v0.3.0-task-oriented-activity-menus.md"
+)
 REQUIRED_PACKET_INSTANTIATION_RENDERING_PHRASES = (
     'PacketInstance',
     'PacketTargetContext',
@@ -116,6 +120,25 @@ REQUIRED_GUIDED_ACTIVITY_WORKFLOW_PHRASES = (
     "GroupPlan != Group != GroupMembership",
     "Score != reusable configuration",
     "scripts/smoke_test_guided_activity_wheel.py",
+    "pds-core>=0.6.3,<0.7",
+)
+
+REQUIRED_TASK_ORIENTED_ACTIVITY_MENU_PHRASES = (
+    "Plan",
+    "Prepare",
+    "Collect",
+    "Review",
+    "Score",
+    "Share",
+    "assessment setup != Score",
+    "Advanced Activity tools",
+    "GroupPlan != Group != GroupMembership",
+    "Clearing/redrawing the screen is the default",
+    "Where does the teacher go to do a task?",
+    "What currently needs the teacher's attention?",
+    "publication != downstream ingestion",
+    "presentation routing != domain mutation logic",
+    "scripts/smoke_test_task_oriented_activity_menu_wheel.py",
     "pds-core>=0.6.3,<0.7",
 )
 REQUIRED_REUSABLE_PRESETS_PHRASES = (
@@ -763,6 +786,27 @@ def check_documentation() -> None:
             failures.append(
                 "Documentation index does not link the guided Activity document."
             )
+
+    if not TASK_ORIENTED_ACTIVITY_MENU_DOC.is_file():
+        failures.append(
+            "Current v0.3.0 task-oriented Activity menu document is missing."
+        )
+    else:
+        task_menu_doc = TASK_ORIENTED_ACTIVITY_MENU_DOC.read_text(
+            encoding="utf-8"
+        )
+        for phrase in REQUIRED_TASK_ORIENTED_ACTIVITY_MENU_PHRASES:
+            if phrase not in task_menu_doc:
+                failures.append(
+                    "Task-oriented Activity menu document is missing required "
+                    f"boundary wording {phrase!r}."
+                )
+        if TASK_ORIENTED_ACTIVITY_MENU_DOC.name not in docs_index:
+            failures.append(
+                "Documentation index does not link the task-oriented Activity "
+                "menu document."
+            )
+
     for active_path in (
         ROOT / "README.md",
         ROOT / "docs" / "cli-contract.md",

--- a/scripts/smoke_test_task_oriented_activity_menu_wheel.py
+++ b/scripts/smoke_test_task_oriented_activity_menu_wheel.py
@@ -1,0 +1,236 @@
+"""Install Concord/Core wheels in isolation and smoke-test issue #66 menus."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import tempfile
+import textwrap
+import venv
+from pathlib import Path
+
+
+def _python(venv_root: Path) -> Path:
+    return (
+        venv_root / "Scripts" / "python.exe"
+        if os.name == "nt"
+        else venv_root / "bin" / "python"
+    )
+
+
+def _run(command: list[str], cwd: Path) -> None:
+    subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    )
+
+
+def _smoke_code() -> str:
+    return textwrap.dedent(
+        """
+        from datetime import datetime, timezone
+        from importlib import metadata
+        from pathlib import Path
+        from types import SimpleNamespace
+        from unittest.mock import patch
+        import contextlib
+        import io
+        import tempfile
+
+        import concord
+        import concord.menu_activity as activity_menu
+        import concord.menu_artifact as artifact_menu
+        import concord.menu_publication as publication_menu
+        import concord.menu_scoring as scoring_menu
+        from pds_core.class_metadata import (
+            create_class_metadata,
+            write_class_metadata_for_class,
+        )
+        from pds_core.classes import write_class_roster
+        from pds_core.rosters import create_roster
+        from pds_core.workspace import ensure_workspace_root
+
+        from concord.menu_context import MenuSessionContext
+        from concord.workflows import (
+            CreateActivityContextRequest,
+            WorkflowActor,
+            create_activity_context,
+            show_activity,
+        )
+
+        assert metadata.version("pds-core") == "0.6.3"
+        assert metadata.version("pds-concord") == "0.3.0.dev0"
+
+        module_path = Path(concord.__file__).resolve().as_posix().lower()
+        assert "site-packages" in module_path, module_path
+
+        for distribution in (
+            "pds-meridian",
+            "scoreform",
+            "quillan",
+            "pds-vitrine",
+            "pds-portia",
+            "paper-data-suite",
+        ):
+            try:
+                metadata.version(distribution)
+            except metadata.PackageNotFoundError:
+                pass
+            else:
+                raise AssertionError(
+                    f"unexpected sibling distribution installed: {distribution}"
+                )
+
+        with tempfile.TemporaryDirectory(prefix="concord-task-menu-installed-") as raw:
+            root = ensure_workspace_root(Path(raw) / "workspace")
+            write_class_metadata_for_class(
+                root,
+                create_class_metadata(
+                    "class-1",
+                    "2026-2027",
+                    created_at=datetime(2026, 8, 27, tzinfo=timezone.utc),
+                ),
+            )
+            write_class_roster(
+                root,
+                create_roster(
+                    "class-1",
+                    (
+                        {
+                            "student_id": "student-1",
+                            "last_name": "One",
+                            "first_name": "Alex",
+                            "period": "1",
+                        },
+                    ),
+                ),
+            )
+            actor = WorkflowActor(
+                actor_id="teacher-task-menu-smoke",
+                display_label="Synthetic Teacher",
+                role_label="teacher",
+            )
+            created = create_activity_context(
+                CreateActivityContextRequest(
+                    class_id="class-1",
+                    activity_id="activity-1",
+                    title="Task Menu Smoke Activity",
+                    activity_type="project",
+                    scoring_orientation="evidence_only",
+                    session_id="session-1",
+                    session_label="Day 1",
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            activity = show_activity(
+                "class-1",
+                "activity-1",
+                workspace_root=root,
+            ).summary
+            before_revision = activity.snapshot_revision
+            assert before_revision == created.commit.snapshot_revision
+
+            responses = iter(
+                (
+                    "1", "b",
+                    "2", "b",
+                    "3", "b",
+                    "4", "b",
+                    "5", "b",
+                    "6", "b",
+                    "7", "b",
+                    "b",
+                )
+            )
+            output = io.StringIO()
+
+            with (
+                patch(
+                    "builtins.input",
+                    side_effect=lambda _prompt="": next(responses),
+                ),
+                patch.object(
+                    activity_menu,
+                    "show_activity",
+                    lambda *_args, **_kwargs: SimpleNamespace(summary=activity),
+                ),
+                patch.object(activity_menu, "clear_screen", lambda: None),
+                patch.object(artifact_menu, "clear_screen", lambda: None),
+                patch.object(publication_menu, "clear_screen", lambda: None),
+                patch.object(scoring_menu, "clear_screen", lambda: None),
+                patch.object(scoring_menu, "_latest", lambda selected: selected),
+                contextlib.redirect_stdout(output),
+            ):
+                activity_menu.launch_activity_context_menu(
+                    activity,
+                    MenuSessionContext(actor=actor),
+                )
+
+            rendered = output.getvalue()
+            for label in (
+                "1. Plan",
+                "2. Prepare",
+                "3. Collect",
+                "4. Review",
+                "5. Score",
+                "6. Share",
+                "7. Advanced Activity tools",
+                "1. Continue classroom setup",
+                "1. Prepare classroom materials",
+                "1. View returned work",
+                "1. Review collected work",
+                "1. Record a Score",
+                "1. Set up sharing",
+                "8. Scoring",
+                "9. Publication",
+            ):
+                assert label in rendered, label
+
+            after_revision = show_activity(
+                "class-1",
+                "activity-1",
+                workspace_root=root,
+            ).summary.snapshot_revision
+            assert after_revision == before_revision
+        """
+    )
+
+
+def smoke(concord_wheel: Path, core_wheel: Path) -> None:
+    if not concord_wheel.is_file():
+        raise FileNotFoundError(concord_wheel)
+    if not core_wheel.is_file():
+        raise FileNotFoundError(core_wheel)
+    with tempfile.TemporaryDirectory(prefix="concord-task-menu-wheel-") as raw:
+        work = Path(raw)
+        env_root = work / "venv"
+        venv.EnvBuilder(with_pip=True).create(env_root)
+        python = _python(env_root)
+        _run(
+            [str(python), "-m", "pip", "install", str(core_wheel.resolve())],
+            work,
+        )
+        _run(
+            [str(python), "-m", "pip", "install", str(concord_wheel.resolve())],
+            work,
+        )
+        smoke_path = work / "task_oriented_activity_menu_smoke.py"
+        smoke_path.write_text(_smoke_code(), encoding="utf-8")
+        _run([str(python), str(smoke_path)], work)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("concord_wheel", type=Path)
+    parser.add_argument("core_wheel", type=Path)
+    args = parser.parse_args()
+    smoke(args.concord_wheel, args.core_wheel)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -108,6 +108,15 @@ def validate(core_wheel: Path, *, allow_dirty: bool) -> None:
                 str(core_wheel),
             ]
         )
+
+        _run(
+            [
+                python,
+                "scripts/smoke_test_task_oriented_activity_menu_wheel.py",
+                str(wheels[0]),
+                str(core_wheel),
+            ]
+        )
     _run(["git", "diff", "--check"])
     if not allow_dirty:
         result = subprocess.run(

--- a/tests/test_academic_result_publication_cli_menu_issue31.py
+++ b/tests/test_academic_result_publication_cli_menu_issue31.py
@@ -387,12 +387,20 @@ def test_publication_errors_preserve_cli_exit_contract(
     assert "rebuild catalog" in error
 
 
-def test_activity_menu_places_publication_immediately_after_scoring() -> None:
-    source = inspect.getsource(menu_activity.launch_activity_context_menu)
-    assert source.index('print("8. Scoring")') < source.index(
+def test_activity_menu_places_share_after_score_and_preserves_advanced_order() -> None:
+    routine = inspect.getsource(menu_activity.launch_activity_context_menu)
+    assert routine.index('print("5. Score")') < routine.index('print("6. Share")')
+    assert routine.index('print("6. Share")') < routine.index(
+        'print("7. Advanced Activity tools")'
+    )
+
+    advanced = inspect.getsource(
+        menu_activity.launch_advanced_open_activity_tools_menu
+    )
+    assert advanced.index('print("8. Scoring")') < advanced.index(
         'print("9. Publication")'
     )
-    assert source.index('print("9. Publication")') < source.index(
+    assert advanced.index('print("9. Publication")') < advanced.index(
         'print("10. Edit Activity")'
     )
 

--- a/tests/test_menu_foundation.py
+++ b/tests/test_menu_foundation.py
@@ -96,8 +96,11 @@ def test_activity_context_keeps_only_compact_parent_header(
     activity_module.launch_activity_context_menu(activity)
     output = capsys.readouterr().out
     assert "Activity: Seminar One" in output
-    assert "Class: class-1" in output
-    assert "Status: draft" in output
+    assert "1. Plan" in output
+    assert "6. Share" in output
+    assert "7. Advanced Activity tools" in output
+    assert "Class: class-1" not in output
+    assert "Status: draft" not in output
     assert "Snapshot: 4" not in output
     assert "Scoring: evidence_only" not in output
 

--- a/tests/test_menu_workflows.py
+++ b/tests/test_menu_workflows.py
@@ -306,7 +306,7 @@ def test_activity_context_delegates_to_session_menu_with_same_state(
     activity = _activity()
     state = _state()
     called: list[object] = []
-    inputs = iter(["3", "b"])
+    inputs = iter(["1", "2", "b", "b"])
     monkeypatch.setattr("builtins.input", lambda _prompt="": next(inputs))
     monkeypatch.setattr(activity_menu, "clear_screen", lambda: None)
     monkeypatch.setattr(

--- a/tests/test_packet_instantiation_cli_menu_issue62.py
+++ b/tests/test_packet_instantiation_cli_menu_issue62.py
@@ -268,7 +268,7 @@ def test_open_activity_menu_dispatches_packet_generation(
         "launch_packet_generation_menu",
         fake_packet_menu,
     )
-    responses = iter(("11", "b"))
+    responses = iter(("7", "11", "b", "b"))
     monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
 
     launch_activity_context_menu(activity, MenuSessionContext())

--- a/tests/test_scoring_issue30_menu.py
+++ b/tests/test_scoring_issue30_menu.py
@@ -149,7 +149,7 @@ def test_activity_context_menu_dispatches_to_scoring(
         focus_standard_ids=(),
     )
     calls: list[str] = []
-    answers = iter(("8", "b"))
+    answers = iter(("5", "b"))
 
     monkeypatch.setattr(
         menu_activity,
@@ -158,7 +158,7 @@ def test_activity_context_menu_dispatches_to_scoring(
     )
     monkeypatch.setattr(
         menu_activity,
-        "launch_scoring_menu",
+        "launch_score_menu",
         lambda selected, state: calls.append(selected.activity_id),
     )
     monkeypatch.setattr("builtins.input", lambda prompt="": next(answers))

--- a/tests/test_task_oriented_activity_menu_issue66.py
+++ b/tests/test_task_oriented_activity_menu_issue66.py
@@ -1,0 +1,787 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import concord.menu_activity as activity_module
+from concord.menu_context import MenuSessionContext
+from concord.workflows import ActivitySummary
+
+CLEAR = "<<<CLEAR>>>"
+
+
+def _inputs(monkeypatch: pytest.MonkeyPatch, values: list[str]) -> None:
+    iterator: Iterator[str] = iter(values)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(iterator))
+
+
+def _activity() -> ActivitySummary:
+    return ActivitySummary(
+        class_id="class-1",
+        activity_id="activity-1",
+        title="Macbeth Seminar",
+        status="active",
+        scoring_orientation="mixed",
+        session_count=2,
+        group_count=4,
+        snapshot_revision=9,
+    )
+
+
+def _stable_activity(
+    monkeypatch: pytest.MonkeyPatch,
+    activity: ActivitySummary,
+) -> None:
+    monkeypatch.setattr(
+        activity_module,
+        "show_activity",
+        lambda *_args, **_kwargs: SimpleNamespace(summary=activity),
+    )
+
+
+def _record_clear() -> None:
+    print(CLEAR)
+
+
+def test_open_activity_uses_six_teacher_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    activity = _activity()
+    _stable_activity(monkeypatch, activity)
+    _inputs(monkeypatch, ["b"])
+    monkeypatch.setattr(activity_module, "clear_screen", lambda: None)
+
+    activity_module.launch_activity_context_menu(activity)
+
+    output = capsys.readouterr().out
+    assert "Activity: Macbeth Seminar" in output
+    assert "1. Plan" in output
+    assert "2. Prepare" in output
+    assert "3. Collect" in output
+    assert "4. Review" in output
+    assert "5. Score" in output
+    assert "6. Share" in output
+    assert "7. Advanced Activity tools" in output
+    assert "Class: class-1" not in output
+    assert "Status: active" not in output
+    assert "View collaboration counts" not in output
+    assert "Artifact Pages" not in output
+    assert "Prepare / Generate Packet" not in output
+
+
+def test_advanced_activity_tools_preserve_pre_issue66_exact_menu(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    activity = _activity()
+    _stable_activity(monkeypatch, activity)
+    _inputs(monkeypatch, ["7", "b", "b"])
+    monkeypatch.setattr(activity_module, "clear_screen", lambda: None)
+
+    activity_module.launch_activity_context_menu(activity)
+
+    output = capsys.readouterr().out
+    assert "Advanced Activity Tools" in output
+    assert "1. View Activity summary" in output
+    assert "2. View collaboration counts" in output
+    assert "3. Sessions" in output
+    assert "4. Groups and participants" in output
+    assert "5. Roles" in output
+    assert "6. Responsibilities" in output
+    assert "7. Artifact Pages" in output
+    assert "8. Scoring" in output
+    assert "9. Publication" in output
+    assert "10. Edit Activity" in output
+    assert "11. Prepare / Generate Packet" in output
+    assert "12. Continue Classroom Setup" in output
+
+
+def test_plan_starts_with_existing_guided_setup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    activity = _activity()
+    _stable_activity(monkeypatch, activity)
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        activity_module,
+        "launch_guided_setup_for_activity",
+        lambda selected, _state: calls.append(
+            (selected.class_id, selected.activity_id)
+        ),
+    )
+    _inputs(monkeypatch, ["1", "1", "b", "b"])
+    monkeypatch.setattr(activity_module, "clear_screen", lambda: None)
+
+    activity_module.launch_activity_context_menu(activity)
+
+    assert calls == [("class-1", "activity-1")]
+
+
+@pytest.mark.parametrize(
+    ("task_choice", "target_name"),
+    (
+        ("2", "launch_classroom_materials_menu"),
+        ("3", "launch_collect_work_menu"),
+        ("4", "launch_review_work_menu"),
+        ("5", "launch_score_menu"),
+        ("6", "launch_share_results_menu"),
+    ),
+)
+def test_initial_task_submenus_keep_existing_workflows_reachable(
+    monkeypatch: pytest.MonkeyPatch,
+    task_choice: str,
+    target_name: str,
+) -> None:
+    activity = _activity()
+    _stable_activity(monkeypatch, activity)
+    calls: list[str] = []
+    monkeypatch.setattr(
+        activity_module,
+        target_name,
+        lambda selected, _state: calls.append(selected.activity_id),
+    )
+    _inputs(monkeypatch, [task_choice, "1", "b", "b"])
+    monkeypatch.setattr(activity_module, "clear_screen", lambda: None)
+
+    activity_module.launch_activity_context_menu(activity)
+
+    assert calls == ["activity-1"]
+
+
+def test_task_transition_redraws_only_current_action(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    activity = _activity()
+    _stable_activity(monkeypatch, activity)
+    _inputs(monkeypatch, ["1", "b", "b"])
+    monkeypatch.setattr(activity_module, "clear_screen", _record_clear)
+
+    activity_module.launch_activity_context_menu(activity)
+
+    screens = [
+        screen for screen in capsys.readouterr().out.split(CLEAR) if screen.strip()
+    ]
+    plan_screens = [
+        screen
+        for screen in screens
+        if "1. Continue classroom setup" in screen
+    ]
+    assert len(plan_screens) == 1
+    assert "Activity: Macbeth Seminar" in plan_screens[0]
+    assert "2. Prepare" not in plan_screens[0]
+    assert "6. Share" not in plan_screens[0]
+
+def test_plan_exposes_classroom_planning_tasks_without_score_recording(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    activity = _activity()
+    _stable_activity(monkeypatch, activity)
+    _inputs(monkeypatch, ["1", "b", "b"])
+    monkeypatch.setattr(activity_module, "clear_screen", lambda: None)
+
+    activity_module.launch_activity_context_menu(activity)
+
+    output = capsys.readouterr().out
+    assert "1. Continue classroom setup" in output
+    assert "2. Sessions" in output
+    assert "3. Student groups" in output
+    assert "4. Roles and responsibilities" in output
+    assert "5. Assessment setup" in output
+    assert "6. Edit Activity" in output
+    assert "Record a Score" not in output
+
+
+@pytest.mark.parametrize(
+    ("choice", "target_name"),
+    (
+        ("2", "launch_session_menu"),
+        ("3", "launch_group_menu"),
+        ("5", "launch_assessment_setup_menu"),
+    ),
+)
+def test_plan_routes_existing_services(
+    monkeypatch: pytest.MonkeyPatch,
+    choice: str,
+    target_name: str,
+) -> None:
+    activity = _activity()
+    _stable_activity(monkeypatch, activity)
+    calls: list[str] = []
+    monkeypatch.setattr(
+        activity_module,
+        target_name,
+        lambda selected, _state: calls.append(selected.activity_id),
+    )
+    _inputs(monkeypatch, ["1", choice, "b", "b"])
+    monkeypatch.setattr(activity_module, "clear_screen", lambda: None)
+
+    activity_module.launch_activity_context_menu(activity)
+
+    assert calls == ["activity-1"]
+
+
+def test_plan_combines_roles_and_responsibilities_in_teacher_language(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    activity = _activity()
+    _stable_activity(monkeypatch, activity)
+    role_calls: list[str] = []
+    responsibility_calls: list[str] = []
+    monkeypatch.setattr(
+        activity_module,
+        "launch_role_menu",
+        lambda selected, _state: role_calls.append(selected.activity_id),
+    )
+    monkeypatch.setattr(
+        activity_module,
+        "launch_responsibility_menu",
+        lambda selected, _state: responsibility_calls.append(
+            selected.activity_id
+        ),
+    )
+    _inputs(monkeypatch, ["1", "4", "1", "2", "b", "b", "b"])
+    monkeypatch.setattr(activity_module, "clear_screen", lambda: None)
+
+    activity_module.launch_activity_context_menu(activity)
+
+    output = capsys.readouterr().out
+    assert "Who has which role?" in output
+    assert "What does each person need to do?" in output
+    assert role_calls == ["activity-1"]
+    assert responsibility_calls == ["activity-1"]
+
+
+def test_assessment_setup_contains_configuration_only(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import concord.menu_scoring as scoring_module
+
+    activity = _activity()
+    monkeypatch.setattr(scoring_module, "_latest", lambda _activity: activity)
+    _inputs(monkeypatch, ["b"])
+    monkeypatch.setattr(scoring_module, "clear_screen", lambda: None)
+
+    scoring_module.launch_assessment_setup_menu(activity)
+
+    output = capsys.readouterr().out
+    assert "Assessment Setup" in output
+    assert "1. Use saved assessment setup" in output
+    assert "2. Criteria" in output
+    assert "3. Scoring scales" in output
+    assert "Record a Score" not in output
+    assert "Browse current Scores" not in output
+    assert "Revise a Score" not in output
+
+def test_prepare_exposes_low_density_material_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    activity = _activity()
+    _stable_activity(monkeypatch, activity)
+    _inputs(monkeypatch, ["2", "b", "b"])
+    monkeypatch.setattr(activity_module, "clear_screen", lambda: None)
+
+    activity_module.launch_activity_context_menu(activity)
+
+    output = capsys.readouterr().out
+    assert "1. Prepare classroom materials" in output
+    assert "2. View prepared materials" in output
+    assert "3. Manage saved materials" in output
+    assert "Packet Instances" not in output
+    assert "Artifact Pages" not in output
+    assert "Review digest" not in output
+    assert "Routes" not in output
+
+
+@pytest.mark.parametrize(
+    ("choice", "target_name"),
+    (
+        ("1", "launch_classroom_materials_menu"),
+        ("2", "show_prepared_materials"),
+    ),
+)
+def test_prepare_routes_activity_material_actions(
+    monkeypatch: pytest.MonkeyPatch,
+    choice: str,
+    target_name: str,
+) -> None:
+    activity = _activity()
+    _stable_activity(monkeypatch, activity)
+    calls: list[str] = []
+    monkeypatch.setattr(
+        activity_module,
+        target_name,
+        lambda selected, *_args: calls.append(selected.activity_id),
+    )
+    _inputs(monkeypatch, ["2", choice, "b", "b"])
+    monkeypatch.setattr(activity_module, "clear_screen", lambda: None)
+
+    activity_module.launch_activity_context_menu(activity)
+
+    assert calls == ["activity-1"]
+
+
+def test_prepare_routes_saved_material_management(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    activity = _activity()
+    _stable_activity(monkeypatch, activity)
+    calls: list[object] = []
+    monkeypatch.setattr(
+        activity_module,
+        "launch_manage_saved_materials_menu",
+        lambda state: calls.append(state),
+    )
+    _inputs(monkeypatch, ["2", "3", "b", "b"])
+    monkeypatch.setattr(activity_module, "clear_screen", lambda: None)
+
+    activity_module.launch_activity_context_menu(activity)
+
+    assert len(calls) == 1
+
+
+def test_prepared_materials_summary_hides_instance_and_storage_internals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import concord.menu_packet_generation as packet_generation
+
+    activity = _activity()
+    captured: list[tuple[str, tuple[str, ...]]] = []
+    items = (
+        SimpleNamespace(
+            generation_status="generated",
+            output_relative_path="generated/class-1/activity-1/student-a.pdf",
+            packet_instance_id="packet-instance-secret",
+            generation_id="generation-secret",
+            target_key="participant:student-secret",
+            output_sha256="hash-secret",
+        ),
+        SimpleNamespace(
+            generation_status="routes_pending",
+            output_relative_path=None,
+            packet_instance_id="packet-instance-secret-2",
+            generation_id="generation-secret-2",
+            target_key="group:group-secret",
+            output_sha256=None,
+        ),
+    )
+    monkeypatch.setattr(
+        packet_generation,
+        "list_packet_instances",
+        lambda _class_id, _activity_id: items,
+    )
+    monkeypatch.setattr(
+        packet_generation,
+        "show_result",
+        lambda title, lines: captured.append((title, tuple(lines))),
+    )
+
+    packet_generation.show_prepared_materials(activity)
+
+    assert len(captured) == 1
+    title, lines = captured[0]
+    rendered = "\\n".join(lines)
+    assert title == "Prepared Materials"
+    assert "Prepared sets: 2" in rendered
+    assert "Ready to print: 1" in rendered
+    assert "Need attention: 1" in rendered
+    assert "student-a.pdf" in rendered
+    assert "packet-instance-secret" not in rendered
+    assert "generation-secret" not in rendered
+    assert "student-secret" not in rendered
+    assert "group-secret" not in rendered
+    assert "hash-secret" not in rendered
+    assert "generated/class-1/activity-1" not in rendered
+
+
+def test_prepared_materials_summary_is_read_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import concord.menu_packet_generation as packet_generation
+
+    activity = _activity()
+    monkeypatch.setattr(
+        packet_generation,
+        "list_packet_instances",
+        lambda _class_id, _activity_id: (),
+    )
+    monkeypatch.setattr(packet_generation, "show_result", lambda *_args: None)
+    monkeypatch.setattr(
+        packet_generation,
+        "commit_packet_instantiation",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("read-only summary must not commit")
+        ),
+    )
+    monkeypatch.setattr(
+        packet_generation,
+        "render_packet_instance",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("read-only summary must not render")
+        ),
+    )
+
+    packet_generation.show_prepared_materials(activity)
+
+def test_collect_screen_separates_returned_work_from_review(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import concord.menu_artifact as artifact_module
+
+    activity = _activity()
+    _inputs(monkeypatch, ["b"])
+    monkeypatch.setattr(artifact_module, "clear_screen", lambda: None)
+
+    artifact_module.launch_collect_work_menu(activity, MenuSessionContext())
+
+    output = capsys.readouterr().out
+    assert "1. View returned work" in output
+    assert "2. Assemble returned work" in output
+    assert "3. Confirm who produced the work" in output
+    assert "4. Confirm who or what the work is about" in output
+    assert "Prepare Artifact Pages" not in output
+    assert "Render prepared pages" not in output
+    assert "Moderation" not in output
+    assert "Record Review" not in output
+
+
+@pytest.mark.parametrize(
+    ("choice", "target_name"),
+    (
+        ("1", "_list_artifacts"),
+        ("2", "_assemble"),
+        ("3", "_launch_author_menu"),
+        ("4", "_launch_subject_menu"),
+    ),
+)
+def test_collect_routes_existing_artifact_services(
+    monkeypatch: pytest.MonkeyPatch,
+    choice: str,
+    target_name: str,
+) -> None:
+    import concord.menu_artifact as artifact_module
+
+    activity = _activity()
+    calls: list[str] = []
+    monkeypatch.setattr(
+        artifact_module,
+        target_name,
+        lambda selected, *_args: calls.append(selected.activity_id),
+    )
+    _inputs(monkeypatch, [choice, "b"])
+    monkeypatch.setattr(artifact_module, "clear_screen", lambda: None)
+
+    artifact_module.launch_collect_work_menu(activity, MenuSessionContext())
+
+    assert calls == ["activity-1"]
+
+
+def test_review_screen_separates_review_and_moderation_from_collection(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import concord.menu_artifact as artifact_module
+
+    activity = _activity()
+    _inputs(monkeypatch, ["b"])
+    monkeypatch.setattr(artifact_module, "clear_screen", lambda: None)
+
+    artifact_module.launch_review_work_menu(activity, MenuSessionContext())
+
+    output = capsys.readouterr().out
+    assert "1. Review collected work" in output
+    assert "2. Moderation" in output
+    assert "Assemble returned work" not in output
+    assert "Confirm who produced the work" not in output
+    assert "Confirm who or what the work is about" not in output
+    assert "Record a Score" not in output
+
+
+@pytest.mark.parametrize(
+    ("choice", "target_name"),
+    (
+        ("1", "_launch_review_menu"),
+        ("2", "_launch_moderation_menu"),
+    ),
+)
+def test_review_routes_existing_review_services(
+    monkeypatch: pytest.MonkeyPatch,
+    choice: str,
+    target_name: str,
+) -> None:
+    import concord.menu_artifact as artifact_module
+
+    activity = _activity()
+    calls: list[str] = []
+    monkeypatch.setattr(
+        artifact_module,
+        target_name,
+        lambda selected, *_args: calls.append(selected.activity_id),
+    )
+    _inputs(monkeypatch, [choice, "b"])
+    monkeypatch.setattr(artifact_module, "clear_screen", lambda: None)
+
+    artifact_module.launch_review_work_menu(activity, MenuSessionContext())
+
+    assert calls == ["activity-1"]
+
+
+@pytest.mark.parametrize(
+    "menu_name",
+    ("launch_collect_work_menu", "launch_review_work_menu"),
+)
+def test_collect_and_review_navigation_alone_do_not_write(
+    monkeypatch: pytest.MonkeyPatch,
+    menu_name: str,
+) -> None:
+    import concord.menu_artifact as artifact_module
+
+    activity = _activity()
+
+    def unexpected(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("navigation alone must not run a workflow action")
+
+    for name in (
+        "_list_artifacts",
+        "_assemble",
+        "_launch_author_menu",
+        "_launch_subject_menu",
+        "_launch_review_menu",
+        "_launch_moderation_menu",
+    ):
+        monkeypatch.setattr(artifact_module, name, unexpected)
+
+    _inputs(monkeypatch, ["b"])
+    monkeypatch.setattr(artifact_module, "clear_screen", lambda: None)
+
+    menu = getattr(artifact_module, menu_name)
+    menu(activity, MenuSessionContext())
+
+def test_score_screen_contains_judgment_actions_only(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import concord.menu_scoring as scoring_module
+
+    activity = _activity()
+    monkeypatch.setattr(scoring_module, "_latest", lambda _activity: activity)
+    _inputs(monkeypatch, ["b"])
+    monkeypatch.setattr(scoring_module, "clear_screen", lambda: None)
+
+    scoring_module.launch_score_menu(activity)
+
+    output = capsys.readouterr().out
+    assert "1. Record a Score" in output
+    assert "2. View Scores" in output
+    assert "3. Revise a Score" in output
+    assert "Criterion Sets" not in output
+    assert "Scoring Scales" not in output
+    assert "Use Saved Scoring Setup" not in output
+    assert "Orientation:" not in output
+
+
+@pytest.mark.parametrize(
+    ("choice", "target_name"),
+    (
+        ("1", "_record_score"),
+        ("2", "_browse_scores"),
+        ("3", "_revise_score"),
+    ),
+)
+def test_score_routes_existing_score_services(
+    monkeypatch: pytest.MonkeyPatch,
+    choice: str,
+    target_name: str,
+) -> None:
+    import concord.menu_scoring as scoring_module
+
+    activity = _activity()
+    calls: list[str] = []
+    monkeypatch.setattr(scoring_module, "_latest", lambda _activity: activity)
+    monkeypatch.setattr(
+        scoring_module,
+        target_name,
+        lambda selected, *_args: calls.append(selected.activity_id),
+    )
+    _inputs(monkeypatch, [choice, "b"])
+    monkeypatch.setattr(scoring_module, "clear_screen", lambda: None)
+
+    scoring_module.launch_score_menu(activity, MenuSessionContext())
+
+    assert calls == ["activity-1"]
+
+
+def test_score_navigation_alone_does_not_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import concord.menu_scoring as scoring_module
+
+    activity = _activity()
+    monkeypatch.setattr(scoring_module, "_latest", lambda _activity: activity)
+
+    def unexpected(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("opening Score must not record or revise anything")
+
+    monkeypatch.setattr(scoring_module, "_record_score", unexpected)
+    monkeypatch.setattr(scoring_module, "_revise_score", unexpected)
+    _inputs(monkeypatch, ["b"])
+    monkeypatch.setattr(scoring_module, "clear_screen", lambda: None)
+
+    scoring_module.launch_score_menu(activity, MenuSessionContext())
+
+def test_share_screen_uses_teacher_language_without_publication_internals(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    import concord.menu_publication as publication_module
+
+    activity = _activity()
+    _inputs(monkeypatch, ["b"])
+    monkeypatch.setattr(publication_module, "clear_screen", lambda: None)
+
+    publication_module.launch_share_results_menu(activity, MenuSessionContext())
+
+    output = capsys.readouterr().out
+    assert "1. Set up sharing" in output
+    assert "2. Review what will be shared" in output
+    assert "3. Share results" in output
+    assert "4. View sharing history" in output
+    assert "5. Stop sharing current results" in output
+    assert "Generate immutable manifest" not in output
+    assert "Catalog" not in output
+    assert "Publication ID" not in output
+    assert "SHA-256" not in output
+
+
+def test_share_preview_hides_manifest_storage_and_identity_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import concord.menu_publication as publication_module
+
+    activity = _activity()
+    preview = SimpleNamespace()
+    registration = SimpleNamespace(
+        academic_intent="summative",
+        lifecycle="active",
+    )
+    captured: list[tuple[str, tuple[str, ...]]] = []
+    monkeypatch.setattr(
+        publication_module,
+        "_preview",
+        lambda _activity, _state: (SimpleNamespace(), preview),
+    )
+    monkeypatch.setattr(
+        publication_module,
+        "load_current_concord_academic_work_registration",
+        lambda *_args, **_kwargs: registration,
+    )
+    monkeypatch.setattr(publication_module, "_root", lambda: Path("."))
+    monkeypatch.setattr(
+        publication_module,
+        "manifest_preview_summary",
+        lambda _preview: {
+            "score_count": 8,
+            "current_score_count": 6,
+            "historical_score_count": 2,
+            "standard_backed_score_count": 5,
+            "local_score_count": 3,
+            "non_score_count": 1,
+            "moderation_dependent_count": 2,
+            "manifest_path": "secret/path/manifest.json",
+            "manifest_sha256": "secret-hash",
+            "record_set_id": "secret-record-set",
+        },
+    )
+    monkeypatch.setattr(
+        publication_module,
+        "show_result",
+        lambda title, lines: captured.append((title, tuple(lines))),
+    )
+
+    publication_module._show_share_preview(
+        activity,
+        MenuSessionContext(),
+    )
+
+    assert len(captured) == 1
+    title, lines = captured[0]
+    rendered = "\n".join(lines)
+    assert title == "Review What Will Be Shared"
+    assert "Scores included: 8" in rendered
+    assert "Current / historical Scores: 6 / 2" in rendered
+    assert "secret/path" not in rendered
+    assert "secret-hash" not in rendered
+    assert "secret-record-set" not in rendered
+
+
+@pytest.mark.parametrize(
+    ("has_head", "expected_superseding"),
+    ((False, False), (True, True)),
+)
+def test_share_results_hides_first_vs_superseding_decision(
+    monkeypatch: pytest.MonkeyPatch,
+    has_head: bool,
+    expected_superseding: bool,
+) -> None:
+    import concord.menu_publication as publication_module
+
+    activity = _activity()
+    calls: list[tuple[bool, bool]] = []
+    state = SimpleNamespace(
+        core_head=(SimpleNamespace(publication_id="pub-1") if has_head else None)
+    )
+    monkeypatch.setattr(publication_module, "_root", lambda: Path("."))
+    monkeypatch.setattr(
+        publication_module,
+        "load_concord_publication_series_status",
+        lambda *_args, **_kwargs: state,
+    )
+    monkeypatch.setattr(
+        publication_module,
+        "_publish",
+        lambda _activity, _session, *, superseding, teacher_facing=False: (
+            calls.append((superseding, teacher_facing))
+        ),
+    )
+
+    publication_module._share_results(activity, MenuSessionContext())
+
+    assert calls == [(expected_superseding, True)]
+
+
+def test_share_navigation_alone_does_not_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import concord.menu_publication as publication_module
+
+    activity = _activity()
+
+    def unexpected(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("opening Share must not mutate publication state")
+
+    for name in (
+        "register_concord_academic_work",
+        "update_academic_work_registration",
+        "generate_academic_result_manifest",
+        "publish_concord_academic_results",
+        "supersede_concord_academic_results",
+        "republish_concord_academic_results_after_withdrawal",
+        "withdraw_concord_academic_result_publication",
+        "rebuild_full_academic_catalog",
+    ):
+        monkeypatch.setattr(publication_module, name, unexpected)
+
+    _inputs(monkeypatch, ["b"])
+    monkeypatch.setattr(publication_module, "clear_screen", lambda: None)
+
+    publication_module.launch_share_results_menu(activity, MenuSessionContext())
+


### PR DESCRIPTION
## Summary

Reorganizes Concord's routine opened-Activity teacher interface around six classroom tasks:

* **Plan**
* **Prepare**
* **Collect**
* **Review**
* **Score**
* **Share**

The existing exact record-oriented workflows remain available through a bounded **Advanced Activity tools** surface.

Closes #66.

## What changed

### Task-oriented opened Activity menu

Replaces the routine record-family Activity menu with:

```text
Plan
Prepare
Collect
Review
Score
Share
Advanced Activity tools
```

This is a presentation/orchestration change over the existing Concord domain services. It does not add persistent task-state records or a parallel Activity workflow model.

### Plan

Plan now provides teacher-facing access to:

* Continue Classroom Setup from #65
* Sessions
* student Groups and GroupPlans
* Roles and Responsibilities
* assessment setup
* Activity editing

Assessment configuration is intentionally separated from actual Score recording.

Criterion Set and Scoring Scale configuration remains under **Plan → Assessment setup** and creates zero Scores.

### Prepare

Prepare now focuses on classroom materials:

* prepare classroom materials;
* inspect prepared materials;
* manage saved materials.

It reuses the #65 saved Packet / Template orchestration and preserves the existing runtime authority:

```text
Template Version
    ->
Packet Version
    ->
Activity-specific Packet preparation
    ->
Artifact / Artifact Page
    ->
Core PDS2 routing
```

Low-level PacketInstance, Artifact/Page, recovery, routing, and reprint operations remain available under Advanced tools.

### Collect and Review

The former broad Artifact menu is split by teacher task.

**Collect** exposes:

* returned work;
* returned Artifact assembly;
* Author confirmation/correction;
* Subject confirmation/correction.

**Review** exposes:

* Artifact Review;
* Moderation.

The implementation preserves the existing distinctions among return state, Author, Subject, Review, Moderation, and Score.

### Score

Routine Score now contains only actual teacher judgment:

* Record a Score
* View Scores
* Revise a Score

The complete existing Scoring administration surface remains available under Advanced tools.

### Share

Adds a teacher-facing Share wrapper over the existing Academic Work Registration, manifest, and Core publication services.

Routine Share provides:

* sharing setup;
* review of what will be shared;
* deliberate result sharing;
* sharing history;
* stopping the current shared result.

The routine interface hides unnecessary manifest paths, hashes, Publication IDs, catalog internals, and first-versus-superseding implementation mechanics.

Existing publication authority and lifecycle semantics remain unchanged.

### Information Density

Carries forward the #65 interface contract:

> Clearing/redrawing the screen is the default. Information remains visible only when the teacher needs it to complete the current action.

Routine task screens remain focused and avoid unnecessary IDs, paths, hashes, revisions, digests, raw JSON, provenance internals, grouping-signal internals, and publication internals.

### Advanced and direct interfaces

The exact record-oriented Activity menu remains available through **Advanced Activity tools** for diagnostics, recovery, troubleshooting, and expert use.

The deterministic direct CLI remains unchanged and noninteractive.

## Documentation and qualification

Adds:

```text
docs/v0.3.0-task-oriented-activity-menus.md
scripts/smoke_test_task_oriented_activity_menu_wheel.py
tests/test_task_oriented_activity_menu_issue66.py
```

The new installed-wheel smoke is integrated into the canonical repository validator and verifies the task-oriented navigation from an isolated installed Concord distribution against released Core 0.6.3.

## Validation

Local canonical qualification passed against:

```text
pds-core 0.6.3
pds-concord 0.3.0.dev0
Python 3.11.9
```

Validated:

* full pytest suite;
* Ruff;
* strict Mypy;
* documentation validation;
* Core compatibility verification;
* package build;
* Twine checks;
* release-artifact validation;
* existing installed-wheel acceptance;
* Activity-copy installed acceptance;
* reusable-preset installed acceptance;
* guided Activity installed acceptance;
* new #66 task-oriented Activity-menu installed acceptance;
* `git diff --check`.

Windows-only filesystem/symlink tests continue to skip where the local account lacks symlink privileges; no #66 qualification failure remains.

## Boundaries preserved

This change does not:

* add persistent task/menu state;
* alter GroupPlan approval semantics;
* create Scores during assessment setup;
* infer Score values;
* calculate Grades or proficiency;
* collapse Author and Subject;
* collapse Review, Moderation, and Score;
* bypass Packet authority;
* create another print/QR/PDS2 path;
* create another scan-routing architecture;
* alter printable layout;
* add a Meridian runtime dependency;
* write directly to Meridian;
* implement #67 attention summaries;
* implement #68 suite integration;
* remove exact Advanced workflows;
* remove or reorganize the deterministic direct CLI.
