### PR TITLE
feat: expose Concord attention and next-action summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Read-only Activity attention and deterministic next-action guidance now derive
+  current `Plan` / `Prepare` / `Collect` / `Review` / `Score` / `Share` work from
+  canonical Concord/Core state without persisting dashboard/task state.
+- Teacher Activity screens expose bounded attention discovery and owner-routed next
+  actions while preserving issue #66 numbering, workflow authority, privacy, and
+  the Information Density clear/redraw contract.
+- Concord now installs a Core v1 `paper_data_suite.module_operations` attention
+  provider with stable codes/count units, partial-versus-unavailable handling,
+  and `readiness_provider=None` for the issue #68 handoff.
+- Issue #67 qualification adds package metadata checks and isolated installed-wheel
+  provider acceptance against released Core v0.6.3 with no Suite/sibling module
+  dependency and a file-fingerprint read-only assertion.
 
 - Opened Activities now use task-oriented `Plan`, `Prepare`, `Collect`, `Review`,
   `Score`, and `Share` teacher navigation with one bounded Advanced escape hatch

--- a/README.md
+++ b/README.md
@@ -201,6 +201,31 @@ complete #66 contract.
 
 [task-activity-menu-doc]: docs/v0.3.0-task-oriented-activity-menus.md
 
+## Activity attention and next actions
+
+Issue #67 adds a read-only attention layer over the same six teacher tasks.
+Opened Activities preserve the existing `1`-through-`7` task numbering and add
+`A. Open next action` only when current canonical state establishes truthful
+attention. Activity Management adds `A. Attention needed` for deterministic
+cross-Activity discovery. These routes enter the existing task menus; attention
+navigation creates no second workflow implementation or persisted task state.
+
+Concord also exposes the same privacy-minimal facts through Core v1:
+
+```text
+paper_data_suite.module_operations
+    concord = concord.pds_operations:get_module_operations_profile
+```
+
+The #67 profile provides attention only. `readiness_provider` remains `None` for
+issue #68, which owns readiness plus suite doctor/launcher/mixed-intake work.
+
+See [Activity attention and next-action documentation][activity-attention-doc]
+for the complete semantic, privacy, count-unit, aggregation, and installed-wheel
+contract.
+
+[activity-attention-doc]: docs/v0.3.0-activity-attention-next-actions.md
+
 ## Direct CLI
 
 Direct commands are deterministic and fully noninteractive. They never clear

--- a/concord/academic_result_share_attention.py
+++ b/concord/academic_result_share_attention.py
@@ -1,0 +1,155 @@
+"""Read-only attention interpretation for Concord academic-result sharing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TypeAlias
+
+from concord.academic_result_manifest import RevisionReason
+from concord.academic_result_manifest_generation import (
+    ConcordManifestGenerationError,
+    GenerateAcademicResultManifestRequest,
+    preview_academic_result_manifest,
+)
+from concord.academic_result_publication import (
+    ConcordAcademicResultPublicationError,
+    load_concord_publication_series_status,
+)
+from concord.academic_work_registration import (
+    ConcordAcademicWorkRegistrationError,
+    load_current_concord_academic_work_registration,
+    load_managed_activity_registration_context,
+)
+from concord.workflows.context import resolve_read_workspace_root
+from concord.workflows.models import WorkflowActor
+
+AcademicResultShareAttentionStatus: TypeAlias = Literal[
+    "inactive",
+    "manifest_needed",
+    "publish_ready",
+    "supersede_ready",
+    "current",
+    "withdrawn",
+    "needs_inspection",
+]
+
+_ATTENTION_ACTOR = WorkflowActor(
+    actor_id="attention_projection",
+    actor_kind="system",
+    owning_system="concord",
+)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class AcademicResultShareAttentionState:
+    """Privacy-minimal current state for one Activity publication series."""
+
+    class_id: str
+    activity_id: str
+    status: AcademicResultShareAttentionStatus
+
+
+def _state(
+    class_id: str,
+    activity_id: str,
+    status: AcademicResultShareAttentionStatus,
+) -> AcademicResultShareAttentionState:
+    return AcademicResultShareAttentionState(
+        class_id=class_id,
+        activity_id=activity_id,
+        status=status,
+    )
+
+
+def inspect_academic_result_share_attention_state(
+    class_id: str,
+    activity_id: str,
+    *,
+    workspace_root: str | Path | None = None,
+) -> AcademicResultShareAttentionState:
+    """Interpret existing Share workflow state without generating or publishing.
+
+    No Academic Work Registration means the teacher has not entered Concord's
+    explicit Share workflow, so publication absence alone is not attention.
+    Once registration exists, this reader reuses the manifest preview and
+    publication-series reconciliation authorities rather than recreating their
+    comparison rules.
+    """
+    root = resolve_read_workspace_root(workspace_root)
+    if root is None:
+        return _state(class_id, activity_id, "inactive")
+
+    try:
+        registration = load_current_concord_academic_work_registration(
+            root,
+            class_id,
+            activity_id,
+        )
+    except ConcordAcademicWorkRegistrationError:
+        return _state(class_id, activity_id, "needs_inspection")
+    if registration is None:
+        return _state(class_id, activity_id, "inactive")
+
+    try:
+        context = load_managed_activity_registration_context(
+            root,
+            class_id,
+            activity_id,
+        )
+        series = load_concord_publication_series_status(
+            class_id,
+            activity_id,
+            workspace_root=root,
+        )
+    except (
+        ConcordAcademicWorkRegistrationError,
+        ConcordAcademicResultPublicationError,
+    ):
+        return _state(class_id, activity_id, "needs_inspection")
+
+    # A structurally current withdrawn head is explicit Share state. Keep that
+    # recovery/review fact distinct from the absence of publication history.
+    if series.core_head_withdrawal is not None:
+        return _state(class_id, activity_id, "withdrawn")
+
+    revision_reason: RevisionReason = (
+        "initial" if series.producer_head is None else "native_state_change"
+    )
+    try:
+        preview = preview_academic_result_manifest(
+            GenerateAcademicResultManifestRequest(
+                class_id=class_id,
+                activity_id=activity_id,
+                expected_snapshot_revision=context.snapshot_revision,
+                actor=_ATTENTION_ACTOR,
+                revision_reason=revision_reason,
+            ),
+            workspace_root=root,
+        )
+    except ConcordManifestGenerationError:
+        # Registration exists, so Share has begun; a state that cannot be
+        # safely previewed requires inspection rather than a fabricated action.
+        return _state(class_id, activity_id, "needs_inspection")
+
+    if preview.disposition == "would_create":
+        return _state(class_id, activity_id, "manifest_needed")
+
+    head = series.core_head
+    if head is None:
+        return _state(class_id, activity_id, "publish_ready")
+    if (
+        preview.revision == head.record_set_revision
+        and preview.sha256 == head.manifest_digest
+    ):
+        return _state(class_id, activity_id, "current")
+    if preview.revision > head.record_set_revision:
+        return _state(class_id, activity_id, "supersede_ready")
+    return _state(class_id, activity_id, "needs_inspection")
+
+
+__all__ = [
+    "AcademicResultShareAttentionState",
+    "AcademicResultShareAttentionStatus",
+    "inspect_academic_result_share_attention_state",
+]

--- a/concord/attention_provider.py
+++ b/concord/attention_provider.py
@@ -1,0 +1,289 @@
+"""Core v1 adapter for Concord's native teacher-attention projection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Final
+
+from pds_core.module_operations import (
+    ModuleAttentionReport,
+    ModuleAttentionSummary,
+    ModuleOperationsNotice,
+    ModuleOperationsRequest,
+    ModuleOwnerActionRef,
+    validate_module_attention_report,
+)
+from pds_core.routing_models import ModuleWorkRef
+from pds_core.workspace import WorkspaceRootError
+
+from concord.pds_contract import CONCORD_MODULE_ID
+from concord.storage import list_activity_work_refs
+from concord.storage_errors import ConcordStorageError
+from concord.workflows.activity_attention import (
+    ActivityAttentionItem,
+    ActivityAttentionSummary,
+    inspect_activity_attention,
+)
+from concord.workflows.context import (
+    list_available_classes,
+    resolve_read_workspace_root,
+)
+from concord.workflows.errors import ConcordWorkflowError
+
+_PARTIAL_NOTICE_CODE: Final = "concord_attention_partial"
+_UNAVAILABLE_NOTICE_CODE: Final = "concord_attention_unavailable"
+
+# Stable aggregation order mirrors the native Plan -> Prepare -> Collect ->
+# Review -> Score -> Share navigation convention. It is not urgency or priority.
+_ATTENTION_CODE_ORDER: Final[tuple[str, ...]] = (
+    "concord_plan_prepare",
+    "concord_plan_unresolved_placements",
+    "concord_plan_approve",
+    "concord_plan_apply",
+    "concord_prepare_materials",
+    "concord_prepare_routes_pending",
+    "concord_prepare_recovery",
+    "concord_collect_assembly",
+    "concord_collect_author_confirmation",
+    "concord_collect_subject_confirmation",
+    "concord_review_first",
+    "concord_review_attention",
+    "concord_review_moderation",
+    "concord_review_post_moderation",
+    "concord_score_ready",
+    "concord_share_inspect",
+    "concord_share_withdrawn",
+    "concord_share_manifest",
+    "concord_share_publish",
+    "concord_share_supersede",
+)
+_ATTENTION_CODE_SET: Final = frozenset(_ATTENTION_CODE_ORDER)
+
+_EXPECTED_SCOPE_ERRORS: Final = (
+    ConcordStorageError,
+    ConcordWorkflowError,
+    WorkspaceRootError,
+    OSError,
+)
+
+
+@dataclass(slots=True)
+class _Aggregate:
+    label: str
+    action_id: str
+    count: int = 0
+    class_ids: set[str] = field(default_factory=set)
+    work_refs: set[ModuleWorkRef] = field(default_factory=set)
+
+    def add(
+        self,
+        item: ActivityAttentionItem,
+        summary: ActivityAttentionSummary,
+    ) -> None:
+        if item.label != self.label or item.action_id != self.action_id:
+            raise RuntimeError(
+                "Concord attention code changed label or action identity during "
+                "one evaluation."
+            )
+        self.count += item.count
+        self.class_ids.add(summary.class_id)
+        self.work_refs.add(
+            ModuleWorkRef(
+                module_id=CONCORD_MODULE_ID,
+                class_id=summary.class_id,
+                work_id=summary.activity_id,
+            )
+        )
+
+
+class _AttentionAccumulator:
+    def __init__(self) -> None:
+        self._aggregates: dict[str, _Aggregate] = {}
+
+    def add_summary(self, summary: ActivityAttentionSummary) -> None:
+        for item in summary.items:
+            if item.code not in _ATTENTION_CODE_SET:
+                raise RuntimeError(
+                    f"Unknown Concord native attention code: {item.code}"
+                )
+            aggregate = self._aggregates.get(item.code)
+            if aggregate is None:
+                aggregate = _Aggregate(
+                    label=item.label,
+                    action_id=item.action_id,
+                )
+                self._aggregates[item.code] = aggregate
+            aggregate.add(item, summary)
+
+    def summaries(
+        self,
+        request: ModuleOperationsRequest,
+    ) -> tuple[ModuleAttentionSummary, ...]:
+        result: list[ModuleAttentionSummary] = []
+        for code in _ATTENTION_CODE_ORDER:
+            aggregate = self._aggregates.get(code)
+            if aggregate is None or aggregate.count <= 0:
+                continue
+            class_id, work_ref = _summary_context(aggregate, request)
+            result.append(
+                ModuleAttentionSummary(
+                    code=code,
+                    label=aggregate.label,
+                    count=aggregate.count,
+                    class_id=class_id,
+                    work_ref=work_ref,
+                    action=ModuleOwnerActionRef(
+                        module_id=CONCORD_MODULE_ID,
+                        action_id=aggregate.action_id,
+                    ),
+                )
+            )
+        return tuple(result)
+
+
+def evaluate_concord_attention(
+    request: ModuleOperationsRequest,
+    /,
+) -> ModuleAttentionReport:
+    """Evaluate current Concord attention without creating or mutating state."""
+    if not isinstance(request, ModuleOperationsRequest):
+        raise TypeError("request must be a ModuleOperationsRequest.")
+
+    if request.workspace_root is None:
+        return _unavailable_report(
+            "Concord attention requires an explicit workspace."
+        )
+
+    try:
+        root = resolve_read_workspace_root(request.workspace_root)
+    except (OSError, WorkspaceRootError):
+        return _unavailable_report(
+            "The supplied workspace cannot be inspected safely for Concord attention."
+        )
+    if root is None:
+        return _unavailable_report(
+            "The supplied workspace is not available for Concord attention."
+        )
+
+    work_refs, discovery_partial = _discover_work_refs(
+        root,
+        requested_class_id=request.class_id,
+    )
+    if work_refs is None:
+        return _unavailable_report(
+            "The requested Concord Activity scope cannot be inspected safely."
+        )
+
+    accumulator = _AttentionAccumulator()
+    partial = discovery_partial
+    for work_ref in work_refs:
+        try:
+            summary = inspect_activity_attention(
+                work_ref.class_id,
+                work_ref.work_id,
+                workspace_root=root,
+            )
+        except _EXPECTED_SCOPE_ERRORS:
+            partial = True
+            continue
+        accumulator.add_summary(summary)
+
+    notices: tuple[ModuleOperationsNotice, ...] = ()
+    if partial:
+        notices = (
+            ModuleOperationsNotice(
+                code=_PARTIAL_NOTICE_CODE,
+                summary=(
+                    "Some Concord attention sources could not be inspected safely; "
+                    "available summaries are partial."
+                ),
+            ),
+        )
+
+    report = ModuleAttentionReport(
+        evaluation="evaluated",
+        summaries=accumulator.summaries(request),
+        notices=notices,
+    )
+    return validate_module_attention_report(
+        report,
+        expected_module_id=CONCORD_MODULE_ID,
+    )
+
+
+def _discover_work_refs(
+    root: Path,
+    *,
+    requested_class_id: str | None,
+) -> tuple[tuple[ModuleWorkRef, ...] | None, bool]:
+    """Discover exact Concord work while isolating independent class failures."""
+    if requested_class_id is not None:
+        try:
+            scoped_refs = list_activity_work_refs(root, requested_class_id)
+        except _EXPECTED_SCOPE_ERRORS:
+            return None, False
+        return scoped_refs, False
+
+    try:
+        classes = list_available_classes(root)
+    except _EXPECTED_SCOPE_ERRORS:
+        return None, False
+
+    discovered_refs: list[ModuleWorkRef] = []
+    partial = False
+    for class_summary in classes:
+        try:
+            discovered_refs.extend(
+                list_activity_work_refs(root, class_summary.class_id)
+            )
+        except _EXPECTED_SCOPE_ERRORS:
+            partial = True
+    return (
+        tuple(
+            sorted(
+                discovered_refs,
+                key=lambda item: (item.class_id, item.work_id),
+            )
+        ),
+        partial,
+    )
+
+
+def _summary_context(
+    aggregate: _Aggregate,
+    request: ModuleOperationsRequest,
+) -> tuple[str | None, ModuleWorkRef | None]:
+    class_id: str | None = None
+    if request.class_id is not None:
+        class_id = request.class_id
+    elif len(aggregate.class_ids) == 1:
+        class_id = next(iter(aggregate.class_ids))
+
+    work_ref: ModuleWorkRef | None = None
+    if len(aggregate.work_refs) == 1:
+        work_ref = next(iter(aggregate.work_refs))
+        if class_id is None:
+            class_id = work_ref.class_id
+
+    return class_id, work_ref
+
+
+def _unavailable_report(summary: str) -> ModuleAttentionReport:
+    report = ModuleAttentionReport(
+        evaluation="unavailable",
+        summaries=(),
+        notices=(
+            ModuleOperationsNotice(
+                code=_UNAVAILABLE_NOTICE_CODE,
+                summary=summary,
+            ),
+        ),
+    )
+    return validate_module_attention_report(
+        report,
+        expected_module_id=CONCORD_MODULE_ID,
+    )
+
+
+__all__ = ["evaluate_concord_attention"]

--- a/concord/menu_activity.py
+++ b/concord/menu_activity.py
@@ -10,6 +10,10 @@ from concord.menu_artifact import (
     launch_collect_work_menu,
     launch_review_work_menu,
 )
+from concord.menu_attention import (
+    launch_activity_attention_discovery,
+    print_activity_attention_summary,
+)
 from concord.menu_context import CancelMenuAction, MenuSessionContext
 from concord.menu_group import launch_group_menu
 from concord.menu_guided_activity import (
@@ -86,6 +90,7 @@ from concord.workflows import (
     show_activity,
     update_activity,
 )
+from concord.workflows.activity_attention import inspect_activity_attention
 from concord.workflows.models import UNSET, OptionalTextUpdate, TextUpdate
 
 _ACTIVITY_TYPES = ("socratic_seminar", "laboratory", "project")
@@ -891,6 +896,30 @@ def launch_share_menu(
     launch_share_results_menu(activity, state)
 
 
+def launch_activity_attention_action(
+    activity: ActivitySummary,
+    state: MenuSessionContext,
+    action_id: str,
+) -> None:
+    """Route one stable Concord attention action into an existing #66 task."""
+    if action_id == "open_activity_plan":
+        launch_plan_menu(activity, state)
+    elif action_id == "open_activity_prepare":
+        launch_prepare_menu(activity, state)
+    elif action_id == "open_activity_collect":
+        launch_collect_menu(activity, state)
+    elif action_id == "open_activity_review":
+        launch_review_task_menu(activity, state)
+    elif action_id == "open_activity_score":
+        launch_score_task_menu(activity, state)
+    elif action_id == "open_activity_share":
+        launch_share_menu(activity, state)
+    else:
+        raise ConcordWorkflowError(
+            f"Unsupported Concord attention action: {action_id}"
+        )
+
+
 def launch_advanced_open_activity_tools_menu(
     activity: ActivitySummary,
     state: MenuSessionContext,
@@ -969,6 +998,18 @@ def launch_activity_context_menu(
             pass
         clear_screen()
         print_menu_header(f"Activity: {activity.title}")
+        try:
+            loaded_attention = inspect_activity_attention(
+                activity.class_id,
+                activity.activity_id,
+            )
+        except Exception:
+            attention = None
+            print("Attention: unavailable")
+            print()
+        else:
+            attention = loaded_attention
+            print_activity_attention_summary(loaded_attention)
         print("1. Plan")
         print("2. Prepare")
         print("3. Collect")
@@ -976,6 +1017,8 @@ def launch_activity_context_menu(
         print("5. Score")
         print("6. Share")
         print("7. Advanced Activity tools")
+        if attention is not None and attention.next_item is not None:
+            print("A. Open next action")
         print_navigation()
         print()
         choice = input("Select an option: ").strip()
@@ -995,6 +1038,16 @@ def launch_activity_context_menu(
             )
         elif navigation is NavigationChoice.BACK:
             return
+        elif (
+            choice.casefold() == "a"
+            and attention is not None
+            and attention.next_item is not None
+        ):
+            launch_activity_attention_action(
+                activity,
+                session_state,
+                attention.next_item.action_id,
+            )
         elif choice == "1":
             launch_plan_menu(activity, session_state)
         elif choice == "2":
@@ -1142,6 +1195,7 @@ def launch_activity_management_menu(
         print("1. Create Classroom Activity")
         print("2. Continue setup for an Activity")
         print("3. Advanced Activity tools")
+        print("A. Attention needed")
         print_navigation()
         print()
         choice = input("Select an option: ").strip()
@@ -1162,6 +1216,11 @@ def launch_activity_management_menu(
             launch_guided_continue_setup(session_state)
         elif choice == "3":
             launch_advanced_activity_tools_menu(session_state)
+        elif choice.casefold() == "a":
+            launch_activity_attention_discovery(
+                session_state,
+                route_action=launch_activity_attention_action,
+            )
         else:
             print(navigation_hint_with_help())
             pause_for_user()

--- a/concord/menu_attention.py
+++ b/concord/menu_attention.py
@@ -1,0 +1,184 @@
+"""Bounded teacher-facing presentation for Concord Activity attention."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from concord.menu_context import MenuSessionContext
+from concord.menu_navigation import (
+    ConcordMenuChoice,
+    NavigationChoice,
+    parse_menu_navigation,
+)
+from concord.menu_ui import (
+    clear_screen,
+    page_count,
+    page_items,
+    pause_for_user,
+    print_menu_header,
+    print_navigation,
+)
+from concord.workflows.activity import show_activity
+from concord.workflows.activity_attention import (
+    ActivityAttentionSummary,
+    list_activity_attention,
+)
+from concord.workflows.models import ActivitySummary
+
+ActivityAttentionActionRouter = Callable[
+    [ActivitySummary, MenuSessionContext, str], None
+]
+
+
+def _task_label(summary: ActivityAttentionSummary) -> str:
+    item = summary.next_item
+    return "-" if item is None else item.task.title()
+
+
+def _next_label(summary: ActivityAttentionSummary) -> str:
+    item = summary.next_item
+    return "No current teacher attention" if item is None else item.label
+
+
+def print_activity_attention_summary(summary: ActivityAttentionSummary) -> None:
+    """Print one compact opened-Activity attention summary.
+
+    Only the deterministic next fact is expanded. Other categories are reported
+    as a category count so the opened Activity screen remains bounded and does
+    not add together heterogeneous count units.
+    """
+    print("Attention")
+    next_item = summary.next_item
+    if next_item is None:
+        print("No current teacher attention.")
+        print()
+        return
+
+    print(
+        f"Next: {next_item.task.title()} - {next_item.label} "
+        f"(count {next_item.count})"
+    )
+    remaining = len(summary.items) - 1
+    if remaining:
+        suffix = "category" if remaining == 1 else "categories"
+        print(f"Also: {remaining} other attention {suffix}")
+    print()
+
+
+def _selection_hint(page_index: int, pages: int) -> str:
+    commands: list[str] = []
+    if page_index + 1 < pages:
+        commands.append("N")
+    if page_index > 0:
+        commands.append("P")
+    commands.extend(("H", "B", "M", "Q"))
+    if len(commands) == 1:
+        suffix = commands[0]
+    elif len(commands) == 2:
+        suffix = f"{commands[0]} or {commands[1]}"
+    else:
+        suffix = ", ".join(commands[:-1]) + f", or {commands[-1]}"
+    return f"Please choose a listed option, {suffix}."
+
+
+def _help() -> None:
+    clear_screen()
+    print_menu_header("Attention Needed Help")
+    print("This screen lists Activities with current mechanically observable")
+    print("teacher attention. It does not rank urgency, students, or Activities.")
+    print("Choosing an Activity opens its deterministic next existing task menu.")
+    print()
+    pause_for_user()
+
+
+def launch_activity_attention_discovery(
+    state: MenuSessionContext,
+    *,
+    route_action: ActivityAttentionActionRouter,
+) -> None:
+    """Browse current Activity attention without creating canonical task state."""
+    page_index = 0
+    while True:
+        try:
+            summaries = tuple(
+                item for item in list_activity_attention() if item.items
+            )
+        except Exception:
+            clear_screen()
+            print_menu_header("Attention Needed")
+            print("Concord attention could not be loaded safely.")
+            print()
+            pause_for_user()
+            return
+
+        if not summaries:
+            clear_screen()
+            print_menu_header("Attention Needed")
+            print("No Concord Activities currently need teacher attention.")
+            print()
+            pause_for_user()
+            return
+
+        pages = page_count(len(summaries))
+        page_index = min(page_index, pages - 1)
+        clear_screen()
+        print_menu_header("Attention Needed")
+        page = page_items(summaries, page_index)
+        for index, summary in enumerate(page, start=1):
+            print(
+                f"{index}. {summary.title} ({summary.class_id}) - "
+                f"{_task_label(summary)}: {_next_label(summary)}"
+            )
+        if pages > 1:
+            print()
+            print(f"Page {page_index + 1} of {pages}")
+            if page_index + 1 < pages:
+                print("N. Next page")
+            if page_index > 0:
+                print("P. Previous page")
+        print_navigation()
+        print()
+
+        choice = input("Select an option: ").strip()
+        navigation = parse_menu_navigation(choice)
+        if navigation is ConcordMenuChoice.HELP:
+            _help()
+            continue
+        if navigation is NavigationChoice.BACK:
+            return
+        normalized = choice.casefold()
+        if normalized == "n" and page_index + 1 < pages:
+            page_index += 1
+            continue
+        if normalized == "p" and page_index > 0:
+            page_index -= 1
+            continue
+        if choice.isdigit():
+            selected = int(choice)
+            if 1 <= selected <= len(page):
+                summary = page[selected - 1]
+                next_item = summary.next_item
+                assert next_item is not None
+                try:
+                    activity = show_activity(
+                        summary.class_id,
+                        summary.activity_id,
+                    ).summary
+                except Exception:
+                    clear_screen()
+                    print_menu_header("Attention Needed")
+                    print("The selected Activity could not be loaded safely.")
+                    print()
+                    pause_for_user()
+                    continue
+                route_action(activity, state, next_item.action_id)
+                continue
+        print(_selection_hint(page_index, pages))
+        pause_for_user()
+
+
+__all__ = [
+    "ActivityAttentionActionRouter",
+    "launch_activity_attention_discovery",
+    "print_activity_attention_summary",
+]

--- a/concord/pds_operations.py
+++ b/concord/pds_operations.py
@@ -1,0 +1,40 @@
+"""Installed Concord module-operations profile for Core v1."""
+
+from __future__ import annotations
+
+from pds_core.module_operations import (
+    MODULE_OPERATIONS_CONTRACT_VERSION,
+    ModuleAttentionReport,
+    ModuleOperationsProfile,
+    ModuleOperationsRequest,
+    validate_module_operations_profile,
+)
+
+from concord.pds_contract import CONCORD_MODULE_ID
+
+
+def evaluate_concord_attention(
+    request: ModuleOperationsRequest,
+    /,
+) -> ModuleAttentionReport:
+    """Lazily evaluate Concord-owned attention for one neutral Core request."""
+    from concord.attention_provider import evaluate_concord_attention as _evaluate
+
+    return _evaluate(request)
+
+
+def get_module_operations_profile() -> ModuleOperationsProfile:
+    """Return Concord's validated Core v1 operations profile for Issue #67."""
+    return validate_module_operations_profile(
+        ModuleOperationsProfile(
+            module_id=CONCORD_MODULE_ID,
+            supported_core_operations_contract_versions=frozenset(
+                {MODULE_OPERATIONS_CONTRACT_VERSION}
+            ),
+            readiness_provider=None,
+            attention_provider=evaluate_concord_attention,
+        )
+    )
+
+
+__all__ = ["evaluate_concord_attention", "get_module_operations_profile"]

--- a/concord/workflows/activity_attention.py
+++ b/concord/workflows/activity_attention.py
@@ -1,0 +1,582 @@
+"""Read-only Concord Activity attention and next-action projection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, Literal, TypeAlias
+
+from concord.academic_result_share_attention import (
+    AcademicResultShareAttentionState,
+    inspect_academic_result_share_attention_state,
+)
+from concord.workflows.activity import list_activities, show_activity
+from concord.workflows.artifact import ArtifactSummary, list_artifacts
+from concord.workflows.artifact_collection import (
+    ArtifactCollectionState,
+    inspect_artifact_collection_state,
+)
+from concord.workflows.artifact_review_attention import (
+    ArtifactReviewAttentionState,
+    inspect_artifact_review_attention_state,
+)
+from concord.workflows.artifact_scoring_attention import (
+    ArtifactScoringAttentionState,
+    inspect_artifact_scoring_attention_state,
+)
+from concord.workflows.group_plan import (
+    GroupPlanSummary,
+    list_group_plans,
+    show_group_plan,
+)
+from concord.workflows.packet_instance import (
+    PacketInstanceSummary,
+    list_packet_instances,
+)
+
+ActivityAttentionTask: TypeAlias = Literal[
+    "plan",
+    "prepare",
+    "collect",
+    "review",
+    "score",
+    "share",
+]
+
+# This is a navigation convention only; it is not urgency or educational priority.
+_TASK_ORDER: Final[dict[ActivityAttentionTask, int]] = {
+    "plan": 0,
+    "prepare": 1,
+    "collect": 2,
+    "review": 3,
+    "score": 4,
+    "share": 5,
+}
+
+_PLAN_ACTIVE_ACTIVITY_STATUSES: Final[frozenset[str]] = frozenset(
+    {"draft", "configured", "active"}
+)
+_SIGNAL_GROUP_PLAN_STRATEGIES: Final[frozenset[str]] = frozenset(
+    {"similar_signal", "mixed_signal"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityAttentionItem:
+    """One privacy-minimal, presentation-neutral Concord attention fact."""
+
+    code: str
+    label: str
+    task: ActivityAttentionTask
+    count: int
+    action_id: str
+
+    def __post_init__(self) -> None:
+        if not self.code or not self.code.strip():
+            raise ValueError("code must be nonempty.")
+        if not self.label or not self.label.strip():
+            raise ValueError("label must be nonempty.")
+        if self.task not in _TASK_ORDER:
+            raise ValueError("task must be a supported Concord attention task.")
+        if (
+            isinstance(self.count, bool)
+            or not isinstance(self.count, int)
+            or self.count <= 0
+        ):
+            raise ValueError("count must be a positive integer.")
+        if not self.action_id or not self.action_id.strip():
+            raise ValueError("action_id must be nonempty.")
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityAttentionSummary:
+    """Current attention picture for one Activity; never persisted as state."""
+
+    class_id: str
+    activity_id: str
+    title: str
+    items: tuple[ActivityAttentionItem, ...] = ()
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "items", tuple(self.items))
+
+    @property
+    def next_item(self) -> ActivityAttentionItem | None:
+        """Return the first truthful item in Concord's deterministic task order."""
+        return self.items[0] if self.items else None
+
+
+@dataclass(frozen=True, slots=True)
+class _AttentionDefinition:
+    code: str
+    label: str
+    task: ActivityAttentionTask
+    action_id: str
+    category_order: int
+
+
+_ATTENTION_DEFINITIONS: Final[tuple[_AttentionDefinition, ...]] = (
+    _AttentionDefinition(
+        code="concord_plan_prepare",
+        label="Group plans still need preparation",
+        task="plan",
+        action_id="open_activity_plan",
+        category_order=0,
+    ),
+    _AttentionDefinition(
+        code="concord_plan_unresolved_placements",
+        label="Student group placements remain unresolved",
+        task="plan",
+        action_id="open_activity_plan",
+        category_order=1,
+    ),
+    _AttentionDefinition(
+        code="concord_plan_approve",
+        label="Group plans are waiting for teacher approval",
+        task="plan",
+        action_id="open_activity_plan",
+        category_order=2,
+    ),
+    _AttentionDefinition(
+        code="concord_plan_apply",
+        label="Approved group plans are ready to apply",
+        task="plan",
+        action_id="open_activity_plan",
+        category_order=3,
+    ),
+    _AttentionDefinition(
+        code="concord_prepare_materials",
+        label="Packet materials still need preparation",
+        task="prepare",
+        action_id="open_activity_prepare",
+        category_order=0,
+    ),
+    _AttentionDefinition(
+        code="concord_prepare_routes_pending",
+        label="Packet routing preparation needs recovery",
+        task="prepare",
+        action_id="open_activity_prepare",
+        category_order=1,
+    ),
+    _AttentionDefinition(
+        code="concord_prepare_recovery",
+        label="Packet generation needs teacher recovery",
+        task="prepare",
+        action_id="open_activity_prepare",
+        category_order=2,
+    ),
+    _AttentionDefinition(
+        code="concord_collect_assembly",
+        label="Returned evidence awaits assembly",
+        task="collect",
+        action_id="open_activity_collect",
+        category_order=0,
+    ),
+    _AttentionDefinition(
+        code="concord_collect_author_confirmation",
+        label="Returned evidence needs author confirmation",
+        task="collect",
+        action_id="open_activity_collect",
+        category_order=1,
+    ),
+    _AttentionDefinition(
+        code="concord_collect_subject_confirmation",
+        label="Returned evidence needs Subject confirmation",
+        task="collect",
+        action_id="open_activity_collect",
+        category_order=2,
+    ),
+    _AttentionDefinition(
+        code="concord_review_first",
+        label="Assembled evidence is ready for Review",
+        task="review",
+        action_id="open_activity_review",
+        category_order=0,
+    ),
+    _AttentionDefinition(
+        code="concord_review_attention",
+        label="Current evidence Review needs teacher attention",
+        task="review",
+        action_id="open_activity_review",
+        category_order=1,
+    ),
+    _AttentionDefinition(
+        code="concord_review_moderation",
+        label="Reviewed evidence requires Moderation",
+        task="review",
+        action_id="open_activity_review",
+        category_order=2,
+    ),
+    _AttentionDefinition(
+        code="concord_review_post_moderation",
+        label="Review needs update after Moderation",
+        task="review",
+        action_id="open_activity_review",
+        category_order=3,
+    ),
+    _AttentionDefinition(
+        code="concord_score_ready",
+        label="Reviewed evidence is ready for scoring",
+        task="score",
+        action_id="open_activity_score",
+        category_order=0,
+    ),
+    _AttentionDefinition(
+        code="concord_share_inspect",
+        label="Sharing state needs teacher inspection",
+        task="share",
+        action_id="open_activity_share",
+        category_order=0,
+    ),
+    _AttentionDefinition(
+        code="concord_share_withdrawn",
+        label="Withdrawn publication needs teacher review",
+        task="share",
+        action_id="open_activity_share",
+        category_order=1,
+    ),
+    _AttentionDefinition(
+        code="concord_share_manifest",
+        label="Current registered result needs a publication manifest",
+        task="share",
+        action_id="open_activity_share",
+        category_order=2,
+    ),
+    _AttentionDefinition(
+        code="concord_share_publish",
+        label="Current result is ready for explicit publication",
+        task="share",
+        action_id="open_activity_share",
+        category_order=3,
+    ),
+    _AttentionDefinition(
+        code="concord_share_supersede",
+        label="Newer current result is ready to supersede publication",
+        task="share",
+        action_id="open_activity_share",
+        category_order=4,
+    ),
+)
+
+_DEFINITION_BY_CODE: Final[dict[str, _AttentionDefinition]] = {
+    definition.code: definition for definition in _ATTENTION_DEFINITIONS
+}
+
+
+def _definition_order(definition: _AttentionDefinition) -> tuple[int, int, str]:
+    return (
+        _TASK_ORDER[definition.task],
+        definition.category_order,
+        definition.code,
+    )
+
+
+def _items_from_counts(counts: dict[str, int]) -> tuple[ActivityAttentionItem, ...]:
+    items: list[ActivityAttentionItem] = []
+    definitions = sorted(_ATTENTION_DEFINITIONS, key=_definition_order)
+    for definition in definitions:
+        count = counts.get(definition.code, 0)
+        if count <= 0:
+            continue
+        items.append(
+            ActivityAttentionItem(
+                code=definition.code,
+                label=definition.label,
+                task=definition.task,
+                count=count,
+                action_id=definition.action_id,
+            )
+        )
+    return tuple(items)
+
+
+def _unresolved_placements_need_attention(
+    summary: GroupPlanSummary,
+    *,
+    workspace_root: str | Path | None,
+) -> bool:
+    """Return whether unresolved placements still require a teacher action."""
+    if summary.unresolved_student_count <= 0:
+        return False
+    if summary.status not in {"draft", "previewed"}:
+        return False
+    if summary.strategy not in _SIGNAL_GROUP_PLAN_STRATEGIES:
+        return True
+
+    detail = show_group_plan(
+        summary.class_id,
+        summary.activity_id,
+        summary.group_plan_id,
+        workspace_root=workspace_root,
+    )
+    return detail.plan.missing_signal_disposition != "leave_unassigned"
+
+
+def _plan_attention_counts(
+    plans: tuple[GroupPlanSummary, ...],
+    *,
+    workspace_root: str | Path | None,
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+
+    def add(code: str) -> None:
+        if code not in _DEFINITION_BY_CODE:
+            raise ValueError(f"Unknown Concord attention code: {code}")
+        counts[code] = counts.get(code, 0) + 1
+
+    for plan in plans:
+        if plan.status == "draft":
+            add("concord_plan_prepare")
+        elif plan.status == "previewed":
+            add("concord_plan_approve")
+        elif plan.status == "approved":
+            add("concord_plan_apply")
+        elif plan.status in {"applied", "cancelled"}:
+            continue
+
+        if _unresolved_placements_need_attention(
+            plan,
+            workspace_root=workspace_root,
+        ):
+            # Count affected plans, not students. This remains safe when several
+            # plan proposals overlap the same roster.
+            add("concord_plan_unresolved_placements")
+
+    return counts
+
+
+def _prepare_attention_counts(
+    packets: tuple[PacketInstanceSummary, ...],
+) -> dict[str, int]:
+    """Count current actionable Packet Instances without exposing target details."""
+    counts: dict[str, int] = {}
+
+    def add(code: str) -> None:
+        if code not in _DEFINITION_BY_CODE:
+            raise ValueError(f"Unknown Concord attention code: {code}")
+        counts[code] = counts.get(code, 0) + 1
+
+    for packet in packets:
+        if packet.generation_status in {"planned", "rendering"}:
+            add("concord_prepare_materials")
+        elif packet.generation_status == "routes_pending":
+            add("concord_prepare_routes_pending")
+        elif packet.generation_status == "failed":
+            add("concord_prepare_recovery")
+        elif packet.generation_status in {"generated", "cancelled"}:
+            continue
+
+    return counts
+
+
+def _collect_attention_counts(
+    artifacts: tuple[ArtifactSummary, ...],
+    *,
+    workspace_root: str | Path | None,
+) -> dict[str, int]:
+    """Count affected Artifacts, never people or association records."""
+    counts: dict[str, int] = {}
+
+    def add(code: str) -> None:
+        if code not in _DEFINITION_BY_CODE:
+            raise ValueError(f"Unknown Concord attention code: {code}")
+        counts[code] = counts.get(code, 0) + 1
+
+    for artifact in artifacts:
+        state: ArtifactCollectionState = inspect_artifact_collection_state(
+            artifact.class_id,
+            artifact.activity_id,
+            artifact.artifact_instance_id,
+            workspace_root=workspace_root,
+        )
+        if state.assembly_state in {
+            "ready",
+            "selection_required",
+            "needs_recovery",
+        }:
+            add("concord_collect_assembly")
+        if state.author_confirmation_pending:
+            add("concord_collect_author_confirmation")
+        if state.subject_confirmation_pending:
+            add("concord_collect_subject_confirmation")
+
+    return counts
+
+
+
+def _review_attention_counts(
+    artifacts: tuple[ArtifactSummary, ...],
+    *,
+    workspace_root: str | Path | None,
+) -> dict[str, int]:
+    """Count affected Artifacts using current Review-head/Moderation authority."""
+    counts: dict[str, int] = {}
+
+    def add(code: str) -> None:
+        if code not in _DEFINITION_BY_CODE:
+            raise ValueError(f"Unknown Concord attention code: {code}")
+        counts[code] = counts.get(code, 0) + 1
+
+    for artifact in artifacts:
+        state: ArtifactReviewAttentionState = (
+            inspect_artifact_review_attention_state(
+                artifact.class_id,
+                artifact.activity_id,
+                artifact.artifact_instance_id,
+                workspace_root=workspace_root,
+            )
+        )
+        if state.first_review_pending:
+            add("concord_review_first")
+        if state.review_attention_pending:
+            add("concord_review_attention")
+        if state.moderation_pending:
+            add("concord_review_moderation")
+        if state.post_moderation_review_pending:
+            add("concord_review_post_moderation")
+
+    return counts
+
+
+def _score_attention_counts(
+    artifacts: tuple[ArtifactSummary, ...],
+    *,
+    workspace_root: str | Path | None,
+) -> dict[str, int]:
+    """Count reviewed Artifacts explicitly ready for scoring.
+
+    The count unit is affected reviewed evidence items. It is not a count of
+    missing Score records, students, targets, criteria, or required judgments.
+    """
+    count = 0
+    for artifact in artifacts:
+        state: ArtifactScoringAttentionState = (
+            inspect_artifact_scoring_attention_state(
+                artifact.class_id,
+                artifact.activity_id,
+                artifact.artifact_instance_id,
+                workspace_root=workspace_root,
+            )
+        )
+        if state.scoring_ready:
+            count += 1
+    return {} if count == 0 else {"concord_score_ready": count}
+
+
+def _share_attention_counts(
+    state: AcademicResultShareAttentionState,
+) -> dict[str, int]:
+    """Map one Activity publication-series state to at most one Share fact."""
+    code_by_status = {
+        "manifest_needed": "concord_share_manifest",
+        "publish_ready": "concord_share_publish",
+        "supersede_ready": "concord_share_supersede",
+        "withdrawn": "concord_share_withdrawn",
+        "needs_inspection": "concord_share_inspect",
+    }
+    code = code_by_status.get(state.status)
+    return {} if code is None else {code: 1}
+
+
+def inspect_activity_attention(
+    class_id: str,
+    activity_id: str,
+    *,
+    workspace_root: str | Path | None = None,
+) -> ActivityAttentionSummary:
+    """Derive current attention for one Activity from authoritative state only."""
+    detail = show_activity(class_id, activity_id, workspace_root=workspace_root)
+
+    counts: dict[str, int] = {}
+    if detail.summary.status in _PLAN_ACTIVE_ACTIVITY_STATUSES:
+        plans = list_group_plans(
+            class_id,
+            activity_id,
+            workspace_root=workspace_root,
+        )
+        counts.update(
+            _plan_attention_counts(plans, workspace_root=workspace_root)
+        )
+
+    packets = list_packet_instances(
+        class_id,
+        activity_id,
+        workspace_root=workspace_root,
+    )
+    counts.update(_prepare_attention_counts(packets))
+
+    artifacts = list_artifacts(
+        class_id,
+        activity_id,
+        workspace_root=workspace_root,
+    )
+    counts.update(
+        _collect_attention_counts(
+            artifacts,
+            workspace_root=workspace_root,
+        )
+    )
+    counts.update(
+        _review_attention_counts(
+            artifacts,
+            workspace_root=workspace_root,
+        )
+    )
+    counts.update(
+        _score_attention_counts(
+            artifacts,
+            workspace_root=workspace_root,
+        )
+    )
+
+    share_state = inspect_academic_result_share_attention_state(
+        class_id,
+        activity_id,
+        workspace_root=workspace_root,
+    )
+    counts.update(_share_attention_counts(share_state))
+
+    return ActivityAttentionSummary(
+        class_id=detail.summary.class_id,
+        activity_id=detail.summary.activity_id,
+        title=detail.summary.title,
+        items=_items_from_counts(counts),
+    )
+
+
+def list_activity_attention(
+    *,
+    workspace_root: str | Path | None = None,
+    class_id: str | None = None,
+) -> tuple[ActivityAttentionSummary, ...]:
+    """List Activity attention in stable ordinary display order."""
+    summaries = [
+        inspect_activity_attention(
+            activity.class_id,
+            activity.activity_id,
+            workspace_root=workspace_root,
+        )
+        for activity in list_activities(
+            workspace_root=workspace_root,
+            class_id=class_id,
+        )
+    ]
+    return tuple(
+        sorted(
+            summaries,
+            key=lambda item: (
+                item.class_id,
+                item.title.casefold(),
+                item.activity_id,
+            ),
+        )
+    )
+
+
+__all__ = [
+    "ActivityAttentionItem",
+    "ActivityAttentionSummary",
+    "ActivityAttentionTask",
+    "inspect_activity_attention",
+    "list_activity_attention",
+]

--- a/concord/workflows/artifact_collection.py
+++ b/concord/workflows/artifact_collection.py
@@ -1,0 +1,173 @@
+"""Read-only collection-stage interpretation for returned Concord Artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, TypeAlias
+
+from concord.model_validation import ConcordRecordGraph
+from concord.models import ArtifactInstance
+from concord.workflows._collaboration import load_graph, work_ref
+from concord.workflows.artifact_assembly import (
+    ArtifactAssemblyAmbiguityError,
+    ArtifactAssemblyError,
+    ArtifactAssemblyIncompleteError,
+    ArtifactAssemblyIntegrityError,
+    _assembly_id,
+    _assembly_paths,
+    _select_lineage,
+    _verify_existing,
+)
+from concord.workflows.artifact_attribution import (
+    list_artifact_authors,
+    list_artifact_subjects,
+)
+from concord.workflows.context import resolve_read_workspace_root
+from concord.workflows.errors import ConcordWorkflowNotFoundError
+
+ArtifactAssemblyState: TypeAlias = Literal[
+    "not_applicable",
+    "not_ready",
+    "ready",
+    "selection_required",
+    "assembled",
+    "needs_recovery",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactCollectionState:
+    """Privacy-minimal current collection state for one Artifact."""
+
+    class_id: str
+    activity_id: str
+    artifact_instance_id: str
+    assembly_state: ArtifactAssemblyState
+    author_confirmation_pending: bool
+    subject_confirmation_pending: bool
+
+
+def _artifact(
+    graph: ConcordRecordGraph,
+    artifact_instance_id: str,
+) -> ArtifactInstance:
+    artifact = next(
+        (
+            item
+            for item in graph.artifact_instances
+            if item.artifact_instance_id == artifact_instance_id
+        ),
+        None,
+    )
+    if artifact is None:
+        raise ConcordWorkflowNotFoundError(
+            f"Artifact is not available: {artifact_instance_id}"
+        )
+    return artifact
+
+
+def _assembly_state(
+    root: Path,
+    class_id: str,
+    activity_id: str,
+    artifact: ArtifactInstance,
+    graph: ConcordRecordGraph,
+) -> ArtifactAssemblyState:
+    """Interpret exact assembly readiness without creating or repairing output."""
+    try:
+        lineage = _select_lineage(artifact, graph, ())
+    except ArtifactAssemblyIncompleteError:
+        # Some or all required paper has not returned yet. Assembly is not a
+        # truthful teacher action until the existing assembly service can act.
+        return "not_ready"
+    except ArtifactAssemblyAmbiguityError:
+        # All required evidence exists, but an exact returned occurrence still
+        # needs teacher selection before assembly can proceed.
+        return "selection_required"
+    except ArtifactAssemblyError:
+        # Includes Artifacts with no return-expected pages.
+        return "not_applicable"
+
+    assembly_id = _assembly_id(artifact.artifact_instance_id, lineage)
+    output_path, manifest_path = _assembly_paths(
+        root,
+        work_ref(class_id, activity_id),
+        artifact.artifact_instance_id,
+        assembly_id,
+    )
+    if not output_path.parent.exists():
+        return "ready"
+    try:
+        _verify_existing(
+            output_path=output_path,
+            manifest_path=manifest_path,
+            work=work_ref(class_id, activity_id),
+            artifact=artifact,
+            assembly_id=assembly_id,
+            lineage=lineage,
+        )
+    except ArtifactAssemblyIntegrityError:
+        return "needs_recovery"
+    return "assembled"
+
+
+def inspect_artifact_collection_state(
+    class_id: str,
+    activity_id: str,
+    artifact_instance_id: str,
+    *,
+    workspace_root: str | Path | None = None,
+) -> ArtifactCollectionState:
+    """Inspect current assembly/confirmation state without mutating workspace data."""
+    root = resolve_read_workspace_root(workspace_root)
+    if root is None:
+        raise ConcordWorkflowNotFoundError(
+            f"Artifact is not available: {artifact_instance_id}"
+        )
+    graph, _, _ = load_graph(root, work_ref(class_id, activity_id))
+    artifact = _artifact(graph, artifact_instance_id)
+    if artifact.activity_id != activity_id:
+        raise ConcordWorkflowNotFoundError(
+            f"Artifact is not available: {artifact_instance_id}"
+        )
+
+    authors = list_artifact_authors(
+        class_id,
+        activity_id,
+        artifact_instance_id=artifact_instance_id,
+        workspace_root=root,
+    )
+    subjects = list_artifact_subjects(
+        class_id,
+        activity_id,
+        artifact_instance_id=artifact_instance_id,
+        workspace_root=root,
+    )
+    return ArtifactCollectionState(
+        class_id=class_id,
+        activity_id=activity_id,
+        artifact_instance_id=artifact_instance_id,
+        assembly_state=_assembly_state(
+            root,
+            class_id,
+            activity_id,
+            artifact,
+            graph,
+        ),
+        author_confirmation_pending=any(
+            item.attribution_status in {"proposed", "disputed"}
+            for item in authors
+        ),
+        subject_confirmation_pending=any(
+            item.confirmation_status in {"proposed", "disputed", "unresolved"}
+            for item in subjects
+        ),
+    )
+
+
+__all__ = [
+    "ArtifactAssemblyState",
+    "ArtifactCollectionState",
+    "inspect_artifact_collection_state",
+]

--- a/concord/workflows/artifact_review_attention.py
+++ b/concord/workflows/artifact_review_attention.py
@@ -1,0 +1,123 @@
+"""Read-only Review and Moderation attention for Concord Artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from concord.models import EvidenceReference
+from concord.workflows.artifact_attribution import list_artifact_subjects
+from concord.workflows.artifact_collection import inspect_artifact_collection_state
+from concord.workflows.artifact_review import current_artifact_review
+from concord.workflows.moderation import assess_moderation_requirement
+
+# These outcomes explicitly leave the current Review in a teacher-actionable
+# administrative state. ``not_suitable_for_scoring`` is deliberately absent:
+# it may be a completed judgment rather than unfinished Review work.
+_ACTIONABLE_REVIEW_OUTCOMES: Final[frozenset[str]] = frozenset(
+    {
+        "incomplete",
+        "unreadable",
+        "misrouted",
+        "duplicate",
+        "awaiting_correction",
+        "awaiting_additional_evidence",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactReviewAttentionState:
+    """Privacy-minimal current Review/Moderation state for one Artifact."""
+
+    class_id: str
+    activity_id: str
+    artifact_instance_id: str
+    first_review_pending: bool
+    review_attention_pending: bool
+    moderation_pending: bool
+    post_moderation_review_pending: bool
+
+
+def inspect_artifact_review_attention_state(
+    class_id: str,
+    activity_id: str,
+    artifact_instance_id: str,
+    *,
+    workspace_root: str | Path | None = None,
+) -> ArtifactReviewAttentionState:
+    """Interpret current Review/Moderation state without writing workspace data."""
+    current = current_artifact_review(
+        class_id,
+        activity_id,
+        artifact_instance_id,
+        workspace_root=workspace_root,
+    )
+    if current is None:
+        collection = inspect_artifact_collection_state(
+            class_id,
+            activity_id,
+            artifact_instance_id,
+            workspace_root=workspace_root,
+        )
+        # A merely existing or expected Artifact is not Review attention. The
+        # exact returned evidence must already have reached a valid assembly.
+        return ArtifactReviewAttentionState(
+            class_id=class_id,
+            activity_id=activity_id,
+            artifact_instance_id=artifact_instance_id,
+            first_review_pending=collection.assembly_state == "assembled",
+            review_attention_pending=False,
+            moderation_pending=False,
+            post_moderation_review_pending=False,
+        )
+
+    review_attention_pending = (
+        current.review_outcome in _ACTIONABLE_REVIEW_OUTCOMES
+    )
+    moderation_pending = False
+    post_moderation_review_pending = False
+    if current.moderation_requirement == "required":
+        subjects = list_artifact_subjects(
+            class_id,
+            activity_id,
+            artifact_instance_id=artifact_instance_id,
+            workspace_root=workspace_root,
+        )
+        subject_context = tuple(item.subject_reference for item in subjects)
+        assessment = assess_moderation_requirement(
+            class_id,
+            activity_id,
+            EvidenceReference(
+                evidence_kind="artifact_instance",
+                owning_system="concord",
+                record_id=artifact_instance_id,
+            ),
+            subject_context=subject_context,
+            workspace_root=workspace_root,
+        )
+        # assess_moderation_requirement already limits these to current records
+        # applicable to the exact evidence + Subject scope. Any such explicit
+        # decision satisfies the *need to moderate*; whether it permits scoring
+        # remains a separate Score concern owned by score_recording.
+        if assessment.applicable_moderation_records:
+            post_moderation_review_pending = True
+        else:
+            moderation_pending = True
+
+    return ArtifactReviewAttentionState(
+        class_id=class_id,
+        activity_id=activity_id,
+        artifact_instance_id=artifact_instance_id,
+        first_review_pending=False,
+        review_attention_pending=review_attention_pending,
+        moderation_pending=moderation_pending,
+        post_moderation_review_pending=post_moderation_review_pending,
+    )
+
+
+__all__ = [
+    "ArtifactReviewAttentionState",
+    "inspect_artifact_review_attention_state",
+]

--- a/concord/workflows/artifact_scoring_attention.py
+++ b/concord/workflows/artifact_scoring_attention.py
@@ -1,0 +1,79 @@
+"""Read-only scoring-readiness attention for Concord Artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from concord.workflows.activity import show_activity
+from concord.workflows.artifact_review import current_artifact_review
+
+_SCORING_READY_OUTCOMES: Final[frozenset[str]] = frozenset(
+    {"ready", "ready_with_qualification"}
+)
+_SCORING_READY_STATES: Final[frozenset[str]] = frozenset(
+    {"ready", "ready_with_qualification"}
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactScoringAttentionState:
+    """Privacy-minimal mechanical Score readiness for one reviewed Artifact."""
+
+    class_id: str
+    activity_id: str
+    artifact_instance_id: str
+    scoring_ready: bool
+
+
+def inspect_artifact_scoring_attention_state(
+    class_id: str,
+    activity_id: str,
+    artifact_instance_id: str,
+    *,
+    workspace_root: str | Path | None = None,
+) -> ArtifactScoringAttentionState:
+    """Return whether explicit current Review state makes evidence score-ready.
+
+    This does not infer that a Score is missing, due, or expected for any target.
+    It also does not inspect Score records as a completion matrix because Concord
+    supports several independent Score target kinds.
+    """
+    activity = show_activity(
+        class_id,
+        activity_id,
+        workspace_root=workspace_root,
+    ).summary
+    if activity.scoring_orientation == "evidence_only":
+        return ArtifactScoringAttentionState(
+            class_id=class_id,
+            activity_id=activity_id,
+            artifact_instance_id=artifact_instance_id,
+            scoring_ready=False,
+        )
+
+    review = current_artifact_review(
+        class_id,
+        activity_id,
+        artifact_instance_id,
+        workspace_root=workspace_root,
+    )
+    ready = bool(
+        review is not None
+        and review.review_outcome in _SCORING_READY_OUTCOMES
+        and review.scoring_readiness in _SCORING_READY_STATES
+        and review.moderation_requirement != "required"
+    )
+    return ArtifactScoringAttentionState(
+        class_id=class_id,
+        activity_id=activity_id,
+        artifact_instance_id=artifact_instance_id,
+        scoring_ready=ready,
+    )
+
+
+__all__ = [
+    "ArtifactScoringAttentionState",
+    "inspect_artifact_scoring_attention_state",
+]

--- a/docs/README.md
+++ b/docs/README.md
@@ -374,6 +374,18 @@ teacher-facing Share wrapper, exact Advanced escape hatch, #65 guided-workflow
 composition, #67/#68 handoffs, direct-CLI preservation, and isolated installed-
 wheel qualification against released Core 0.6.3.
 
+### v0.3.0 Activity attention and next actions
+
+[`v0.3.0-activity-attention-next-actions.md`](v0.3.0-activity-attention-next-actions.md)
+
+Documents issue #67's canonical-state-derived `Plan` / `Prepare` / `Collect` /
+`Review` / `Score` / `Share` attention model, stable codes/count units and
+owner-routed actions, conservative Score and optional Share semantics,
+grouping-signal/privacy exclusions, teacher next-action UI, Core v1
+`paper_data_suite.module_operations` adapter, partial/unavailable distinction,
+read-only guarantees, #68 readiness boundary, and isolated installed-wheel
+qualification against released Core 0.6.3.
+
 ### Future v0.3.0 Group Planning / Template / Packet plan
 
 [`pds-group-planning-interoperability-development-plan.md`](pds-group-planning-interoperability-development-plan.md)

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented through the v0.3.0 task-oriented Activity menu workflow in issue #66.
+Implemented through the v0.3.0 Activity attention and next-action workflow in issue #67.
 
 ## Two interfaces, one service layer
 
@@ -25,6 +25,31 @@ concord --version
 
 Bare `concord` and `concord menu` launch the teacher menu. Help and version are
 direct, read-only operations and never launch the menu.
+
+## Teacher attention navigation
+
+Issue #67 adds read-only attention discovery without changing the direct CLI or
+renumbering issue #66's opened-Activity task menu. When truthful attention exists,
+an opened Activity may show:
+
+```text
+A. Open next action
+```
+
+Activity Management also offers:
+
+```text
+A. Attention needed
+```
+
+These `A` commands are controlled Concord menu choices on those specific screens;
+they do not replace Core-owned H/B/M/Q navigation. A next action routes to the
+existing Plan, Prepare, Collect, Review, Score, or Share menu and performs no
+mutation merely by being selected. Attention screens follow the same
+clear/redraw Information Density contract as the rest of the teacher menu.
+
+The underlying native projection and Core v1 adapter are documented in
+[`v0.3.0-activity-attention-next-actions.md`](v0.3.0-activity-attention-next-actions.md).
 
 ## Direct command inventory
 

--- a/docs/v0.3.0-activity-attention-next-actions.md
+++ b/docs/v0.3.0-activity-attention-next-actions.md
@@ -1,0 +1,416 @@
+# v0.3.0 Activity Attention and Next Actions
+
+**Status:** Implemented for issue #67  
+**Development baseline:** `pds-concord 0.3.0.dev0`  
+**Core compatibility:** `pds-core>=0.6.3,<0.7`
+
+## Purpose
+
+Issue #66 answers:
+
+> Where does the teacher go to do a task?
+
+Issue #67 answers the separate question:
+
+> What currently needs the teacher's attention?
+
+Concord derives one privacy-minimal, read-only attention projection from current
+authoritative Concord/Core state. The same Concord-owned interpretation serves
+both the teacher-facing menu and Core's neutral module-operations contract:
+
+```text
+current Concord/Core state
+    -> ActivityAttentionSummary
+       -> Concord teacher UI
+       -> Core ModuleAttentionReport adapter
+```
+
+The boundary is intentionally strict:
+
+```text
+attention != readiness
+attention != diagnostics
+attention != launchability
+attention != publication authorization
+attention != educational priority
+```
+
+Issue #68 owns readiness and suite doctor/launcher/mixed-intake integration.
+Issue #67 leaves `readiness_provider = None` in the same operations profile that
+#68 will extend.
+
+## Native attention projection
+
+The primary domain model is Concord-native rather than Core-shaped:
+
+```text
+ActivityAttentionItem
+ActivityAttentionSummary
+inspect_activity_attention
+list_activity_attention
+```
+
+An `ActivityAttentionItem` carries only:
+
+```text
+code
+label
+task
+count
+action_id
+```
+
+An `ActivityAttentionSummary` carries one Activity's class/activity/title plus
+its ordered attention items. `next_item` is the first truthful item in Concord's
+fixed workflow ordering.
+
+Concord does not persist `ActivityAttention`, `NextAction`, `TaskStatus`, or a
+second dashboard state. Every query re-derives the answer from current canonical
+records.
+
+## Fundamental rule
+
+Mechanically observable absence is not automatically teacher attention:
+
+```text
+no GroupPlan != group-planning attention
+no Score != missing Score
+no publication != publication attention
+zero Authors != missing attribution
+zero Subjects != missing Subject confirmation
+no PacketInstance != preparation failure
+```
+
+An attention item exists only when an existing workflow has begun, an applicable
+requirement is established, or explicit current state places work at an
+actionable stage.
+
+## Deterministic ordering
+
+Concord's navigation order is:
+
+```text
+Plan -> Prepare -> Collect -> Review -> Score -> Share
+```
+
+Within each task, categories also have a fixed order. This order exists only so
+the interface can choose a deterministic next action. It is not urgency,
+severity, risk, importance, ability, or an educational ranking. Concord does not
+rank students, Activities, or PDS modules by attention.
+
+## Stable attention codes, actions, and count units
+
+The codes below are Concord-owned interoperability vocabulary. Every action ID
+is an opaque owner-routed identifier, never a command, path, URL, import target,
+or serialized context payload.
+
+| Code | Teacher label | Owner action | Count unit |
+| --- | --- | --- | --- |
+| `concord_plan_prepare` | Group plans still need preparation | `open_activity_plan` | affected current GroupPlans |
+| `concord_plan_unresolved_placements` | Student group placements remain unresolved | `open_activity_plan` | affected current GroupPlans, not students |
+| `concord_plan_approve` | Group plans are waiting for teacher approval | `open_activity_plan` | affected current GroupPlans |
+| `concord_plan_apply` | Approved group plans are ready to apply | `open_activity_plan` | affected current GroupPlans |
+| `concord_prepare_materials` | Packet materials still need preparation | `open_activity_prepare` | affected current PacketInstances |
+| `concord_prepare_routes_pending` | Packet routing preparation needs recovery | `open_activity_prepare` | affected current PacketInstances |
+| `concord_prepare_recovery` | Packet generation needs teacher recovery | `open_activity_prepare` | affected current PacketInstances |
+| `concord_collect_assembly` | Returned evidence awaits assembly | `open_activity_collect` | affected Artifacts |
+| `concord_collect_author_confirmation` | Returned evidence needs author confirmation | `open_activity_collect` | affected Artifacts |
+| `concord_collect_subject_confirmation` | Returned evidence needs Subject confirmation | `open_activity_collect` | affected Artifacts |
+| `concord_review_first` | Assembled evidence is ready for Review | `open_activity_review` | affected Artifacts |
+| `concord_review_attention` | Current evidence Review needs teacher attention | `open_activity_review` | affected Artifacts |
+| `concord_review_moderation` | Reviewed evidence requires Moderation | `open_activity_review` | affected Artifacts |
+| `concord_review_post_moderation` | Review needs update after Moderation | `open_activity_review` | affected Artifacts |
+| `concord_score_ready` | Reviewed evidence is ready for scoring | `open_activity_score` | reviewed evidence items ready for scoring |
+| `concord_share_inspect` | Sharing state needs teacher inspection | `open_activity_share` | affected Activities |
+| `concord_share_withdrawn` | Withdrawn publication needs teacher review | `open_activity_share` | affected Activities |
+| `concord_share_manifest` | Current registered result needs a publication manifest | `open_activity_share` | affected Activities |
+| `concord_share_publish` | Current result is ready for explicit publication | `open_activity_share` | affected Activities |
+| `concord_share_supersede` | Newer current result is ready to supersede publication | `open_activity_share` | affected Activities |
+
+The shared Core action always has:
+
+```text
+module_id = concord
+action_id = one stable value above
+```
+
+Exact Activity context belongs in Core's permitted `class_id` and `ModuleWorkRef`
+fields rather than being encoded into the action ID.
+
+## Plan
+
+Plan attention consumes the current GroupPlan lifecycle rather than reconstructing
+one from storage details:
+
+```text
+draft -> preparation attention
+previewed -> approval attention
+approved -> application attention
+applied/cancelled -> no pending lifecycle attention
+```
+
+Unresolved placement is aggregated by affected GroupPlan, not by student. Direct
+Groups do not imply a universal all-roster-members-must-have-Membership rule.
+
+Signal-backed plans may be inspected only as needed by existing GroupPlan
+semantics. Attention does not expose signal values, bands, dimensions, digests,
+student-level missing-signal findings, or Meridian-derived academic information.
+Grouping signals never become attention priority, ability level, Score, or Grade.
+
+## Prepare
+
+Prepare attention reuses PacketInstance generation state:
+
+```text
+planned/rendering -> materials still need preparation
+routes_pending -> routing recovery
+failed -> generation recovery
+generated/cancelled -> no pending preparation attention
+```
+
+No Packet absence creates a requirement. Attention evaluation never instantiates,
+allocates routes/pages, renders, resumes generation, or writes output.
+
+## Collect
+
+Collect attention preserves the existing returned-evidence distinctions:
+
+```text
+expected != returned
+returned != assembled
+Author != Subject
+Membership != authorship
+```
+
+Assembly attention exists only when returned evidence makes assembly applicable.
+Expected-but-not-returned pages are not assembly attention. Author/Subject
+confirmation is based on explicit current association states, not zero-row
+absence. Shared counts are affected Artifacts and never people.
+
+## Review and Moderation
+
+First-Review attention begins only after evidence is actually assembled. Current
+Review-head semantics remain authoritative; historical Reviews do not substitute
+for the current head.
+
+When Review requires Moderation, Concord uses the existing exact evidence and
+Subject-scope applicability service. If no applicable current Moderation exists,
+`concord_review_moderation` is emitted. Once an applicable current Moderation has
+been performed, the moderation action itself is no longer missing; if the Review
+head still says moderation is required, Concord instead emits
+`concord_review_post_moderation` so the Review can be refreshed.
+
+This does not weaken Score authorization. Existing Score workflow semantics still
+decide whether a moderation outcome may support scoring.
+
+## Score
+
+Score attention is deliberately conservative. Concord supports multiple Score
+target kinds, so it does not invent a roster x criteria, Group x criteria, or
+Artifact x criteria completion matrix.
+
+`concord_score_ready` means only that current explicit Review state for a
+non-`evidence_only` Activity says an evidence item is mechanically ready for
+scoring and no required Moderation remains outstanding. It does not mean a Score
+is missing, due, required, correct, or educationally important. Attention never
+creates or infers a Score value or disposition.
+
+## Share
+
+Share attention is optional and state-driven. A never-shared Activity with no
+Academic Work Registration produces no publication nag.
+
+Once the Share workflow has explicit state, Concord reuses the existing read-only
+manifest preview and publication-series reconciliation authorities:
+
+```text
+registered current result needs manifest -> concord_share_manifest
+current manifest, no publication -> concord_share_publish
+newer current manifest than publication -> concord_share_supersede
+already-current publication -> no Share attention
+withdrawn head -> concord_share_withdrawn
+inconsistent existing sharing state -> concord_share_inspect
+```
+
+Attention evaluation performs no Academic Work Registration, manifest generation,
+publication, supersession, withdrawal, republication, or catalog rebuild.
+Attention is not publication authorization.
+
+## Teacher-facing navigation
+
+Issue #67 extends #66 without renumbering the task menu. An opened Activity still
+uses exactly:
+
+```text
+1. Plan
+2. Prepare
+3. Collect
+4. Review
+5. Score
+6. Share
+7. Advanced Activity tools
+```
+
+When attention exists, the same screen adds a compact summary and:
+
+```text
+A. Open next action
+```
+
+The action routes directly into the corresponding existing #66 task menu. There
+is no duplicate task implementation.
+
+Activity Management similarly retains its ordinary numbered choices and adds:
+
+```text
+A. Attention needed
+```
+
+That screen lists only Activities with truthful attention, in deterministic
+class/title/Activity order. Attention screens follow the existing Information
+Density clear/redraw contract and do not expose raw record bodies, private IDs,
+paths, hashes, evidence content, Review notes, Moderation rationale, or Score
+values.
+
+## Core module-operations adapter
+
+Concord installs exactly one Core v1 operations entry point:
+
+```text
+paper_data_suite.module_operations
+    concord = concord.pds_operations:get_module_operations_profile
+```
+
+The validated Issue #67 profile is equivalent to:
+
+```text
+module_id = concord
+supported_core_operations_contract_versions = {1}
+attention_provider = present
+readiness_provider = None
+```
+
+`concord.pds_operations` lazily loads the attention implementation so provider
+metadata remains small and independent from teacher-menu startup.
+
+The Core adapter aggregates matching native codes rather than returning one row
+per student or private record. It carries a `ModuleWorkRef` only when exactly one
+Activity contributes to the aggregate. It carries class context only when that
+context remains exact. Core validates request-context agreement and report bounds.
+
+The neutral `active_school_year` request field does not create a new Concord
+school-year state machine. It is used only if an existing Core/Concord authority
+requires it.
+
+## Partial and unavailable evaluation
+
+These outcomes are deliberately distinct:
+
+```text
+valid scope, no attention
+    evaluation = evaluated
+    summaries = empty
+
+safely isolatable Activity/class failure
+    evaluation = evaluated
+    valid unrelated summaries survive
+    notice = concord_attention_partial
+
+missing or foundationally unsafe requested workspace/scope
+    evaluation = unavailable
+    summaries = empty
+    notice = concord_attention_unavailable
+```
+
+The partial notice is bounded to:
+
+> Some Concord attention sources could not be inspected safely; available summaries are partial.
+
+Private exception text is not copied into the shared report. Unexpected
+programming failures are not flattened into empty or unavailable results; they
+may propagate to Core, which preserves `module_operations.provider_failed` and
+`module_operations.result_invalid` as distinct integration outcomes.
+
+## Privacy boundary
+
+Ordinary shared attention must not contain:
+
+```text
+student names or student IDs
+Group identities
+grouping-signal values/bands/digests
+evidence/work content
+raw scans or PDS2 payloads
+Author or Subject identities
+Review notes or reviewer identity
+Moderation rationale or private evidence references
+Score values, rationales, percentages, or Grades
+Packet/route/generation IDs
+absolute or workspace-relative storage paths
+SHA-256 values
+publication IDs or manifest internals
+urgency, severity, risk, rank, or priority scores
+```
+
+Shared output is limited to Core's bounded code/label/count, optional exact
+class/work context, safe notices, and owner-routed actions.
+
+## Read-only guarantee
+
+Attention evaluation is observational. It must never:
+
+```text
+create or repair a workspace
+write or revise Concord records
+create Groups or Memberships
+instantiate/render/resume Packets
+assemble evidence
+change Author/Subject state
+create Review or Moderation records
+create Scores
+register Academic Work
+generate manifests
+publish/supersede/withdraw results
+rebuild a catalog
+launch a menu
+execute an owner action
+```
+
+The teacher may choose an owner-routed action afterward; that normal task menu
+retains its existing confirmation and mutation semantics.
+
+## Installed qualification
+
+`scripts/smoke_test_attention_provider_wheel.py` installs the candidate Concord
+wheel and exact authenticated Core 0.6.3 wheel into a fresh isolated environment.
+It verifies that:
+
+- Concord and Core import from the isolated environment rather than the source checkout;
+- Paper Data Suite, ScoreForm, Quillan, Meridian, Portia, and Vitrine are absent;
+- routing, publication-producer, and module-operations profiles coexist under the
+  same `concord` module identity and validate through Core provider diagnostics;
+- the operations profile has attention present and readiness absent;
+- Core invocation returns real `concord_plan_prepare` attention from a synthetic
+  draft GroupPlan without exposing its student or GroupPlan identity;
+- missing explicit workspace is reported as unavailable rather than empty success;
+- workspace file fingerprints are identical before and after attention evaluation.
+
+This acceptance uses the installed entry point and Core invocation boundary; it
+does not use an editable install or source-tree `PYTHONPATH` to mask packaging
+defects.
+
+## #68 handoff
+
+Issue #68 must extend the exact same `ModuleOperationsProfile` with readiness.
+It separately owns:
+
+```text
+suite doctor
+suite launcher/readiness presentation
+owner-routed suite handoff
+mixed-module paper intake
+suite Attention Needed aggregation
+```
+
+Issue #67 does not modify those surfaces and does not add a runtime dependency on
+`paper-data-suite`, ScoreForm, Quillan, Meridian, or another sibling module.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,9 @@ concord = "concord.pds_module:get_module_profile"
 [project.entry-points."paper_data_suite.publication_producers"]
 concord = "concord.pds_publication:get_publication_producer_profile"
 
+[project.entry-points."paper_data_suite.module_operations"]
+concord = "concord.pds_operations:get_module_operations_profile"
+
 [project.urls]
 Documentation = "https://github.com/Paper-Data-Suite/pds-concord/tree/main/docs"
 Repository = "https://github.com/Paper-Data-Suite/pds-concord"

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -80,6 +80,9 @@ GUIDED_ACTIVITY_WORKFLOW_DOC = (
 TASK_ORIENTED_ACTIVITY_MENU_DOC = (
     ROOT / "docs" / "v0.3.0-task-oriented-activity-menus.md"
 )
+ACTIVITY_ATTENTION_NEXT_ACTIONS_DOC = (
+    ROOT / "docs" / "v0.3.0-activity-attention-next-actions.md"
+)
 REQUIRED_PACKET_INSTANTIATION_RENDERING_PHRASES = (
     'PacketInstance',
     'PacketTargetContext',
@@ -139,6 +142,25 @@ REQUIRED_TASK_ORIENTED_ACTIVITY_MENU_PHRASES = (
     "publication != downstream ingestion",
     "presentation routing != domain mutation logic",
     "scripts/smoke_test_task_oriented_activity_menu_wheel.py",
+    "pds-core>=0.6.3,<0.7",
+)
+REQUIRED_ACTIVITY_ATTENTION_NEXT_ACTIONS_PHRASES = (
+    "ActivityAttentionItem",
+    "ActivityAttentionSummary",
+    "inspect_activity_attention",
+    "list_activity_attention",
+    "attention != readiness",
+    "Plan -> Prepare -> Collect -> Review -> Score -> Share",
+    "concord_score_ready",
+    "concord_share_publish",
+    "concord_attention_partial",
+    "concord_attention_unavailable",
+    "paper_data_suite.module_operations",
+    "concord.pds_operations:get_module_operations_profile",
+    "readiness_provider = None",
+    "A. Open next action",
+    "A. Attention needed",
+    "scripts/smoke_test_attention_provider_wheel.py",
     "pds-core>=0.6.3,<0.7",
 )
 REQUIRED_REUSABLE_PRESETS_PHRASES = (
@@ -805,6 +827,26 @@ def check_documentation() -> None:
             failures.append(
                 "Documentation index does not link the task-oriented Activity "
                 "menu document."
+            )
+
+    if not ACTIVITY_ATTENTION_NEXT_ACTIONS_DOC.is_file():
+        failures.append(
+            "Current v0.3.0 Activity attention/next-actions document is missing."
+        )
+    else:
+        attention_doc = ACTIVITY_ATTENTION_NEXT_ACTIONS_DOC.read_text(
+            encoding="utf-8"
+        )
+        for phrase in REQUIRED_ACTIVITY_ATTENTION_NEXT_ACTIONS_PHRASES:
+            if phrase not in attention_doc:
+                failures.append(
+                    "Activity attention/next-actions document is missing required "
+                    f"boundary wording {phrase!r}."
+                )
+        if ACTIVITY_ATTENTION_NEXT_ACTIONS_DOC.name not in docs_index:
+            failures.append(
+                "Documentation index does not link the Activity attention/"
+                "next-actions document."
             )
 
     for active_path in (

--- a/scripts/check_package.py
+++ b/scripts/check_package.py
@@ -25,6 +25,7 @@ FORBIDDEN_PREFIXES = (
 )
 FORBIDDEN_PARTS = ("__pycache__", ".pytest_cache", ".mypy_cache", "credentials")
 FORBIDDEN_RUNTIME_DEPENDENCIES = {
+    "paper-data-suite",
     "pds-scoreform",
     "pds-quillan",
     "pds-portia",
@@ -138,10 +139,36 @@ def validate_wheel(path: str | Path) -> None:
         raise PackageValidationError(
             "The Concord publication-producer entry point must occur exactly once."
         )
+    expected_operations = (
+        "[paper_data_suite.module_operations]\n"
+        "concord = concord.pds_operations:get_module_operations_profile"
+    )
+    if expected_operations not in entry_points:
+        raise PackageValidationError(
+            "The Concord module-operations entry point is missing."
+        )
+    if entry_points.count("[paper_data_suite.module_operations]") != 1:
+        raise PackageValidationError(
+            "The module-operations entry-point group must occur exactly once."
+        )
+    if entry_points.count(
+        "concord = concord.pds_operations:get_module_operations_profile"
+    ) != 1:
+        raise PackageValidationError(
+            "The Concord module-operations entry point must occur exactly once."
+        )
     required = {
         "concord/__init__.py",
         "concord/academic_result_artifacts.py",
         "concord/academic_result_reader.py",
+        "concord/academic_result_share_attention.py",
+        "concord/attention_provider.py",
+        "concord/menu_attention.py",
+        "concord/pds_operations.py",
+        "concord/workflows/activity_attention.py",
+        "concord/workflows/artifact_collection.py",
+        "concord/workflows/artifact_review_attention.py",
+        "concord/workflows/artifact_scoring_attention.py",
         "concord/artifact_rendering.py",
         "concord/cli.py",
         "concord/cli_app/handlers/reusable_presets.py",

--- a/scripts/smoke_test_attention_provider_wheel.py
+++ b/scripts/smoke_test_attention_provider_wheel.py
@@ -1,0 +1,321 @@
+"""Install Concord/Core wheels in isolation and smoke-test issue #67 attention."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import tempfile
+import textwrap
+import venv
+from pathlib import Path
+
+
+def _python(venv_root: Path) -> Path:
+    return (
+        venv_root / "Scripts" / "python.exe"
+        if os.name == "nt"
+        else venv_root / "bin" / "python"
+    )
+
+
+def _clean_env() -> dict[str, str]:
+    env = dict(os.environ)
+    env.pop("PYTHONPATH", None)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PYTHONNOUSERSITE"] = "1"
+    env["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
+    return env
+
+
+def _run(command: list[str], cwd: Path) -> None:
+    subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        env=_clean_env(),
+    )
+
+
+def _smoke_code() -> str:
+    return textwrap.dedent(
+        """
+        from __future__ import annotations
+
+        import hashlib
+        import sys
+        import tempfile
+        from datetime import datetime, timezone
+        from importlib import metadata
+        from pathlib import Path
+
+        import concord
+        import pds_core
+        from pds_core.class_metadata import (
+            create_class_metadata,
+            write_class_metadata_for_class,
+        )
+        from pds_core.classes import write_class_roster
+        from pds_core.module_operations import (
+            MODULE_OPERATIONS_ENTRY_POINT_GROUP,
+            ModuleAttentionReport,
+            ModuleOperationsProfile,
+            ModuleOperationsRequest,
+            invoke_module_attention,
+            invoke_module_readiness,
+        )
+        from pds_core.provider_diagnostics import diagnose_core_providers
+        from pds_core.rosters import create_roster
+        from pds_core.workspace import ensure_workspace_root
+
+        from concord.models import PlannedGroup
+        from concord.workflows import (
+            CreateActivityContextRequest,
+            WorkflowActor,
+            create_activity_context,
+        )
+        from concord.workflows.group_plan import (
+            CreateGroupPlanRequest,
+            create_group_plan,
+        )
+
+        assert metadata.version("pds-core") == "0.6.3"
+        assert metadata.version("pds-concord") == "0.3.0.dev0"
+
+        env_root = Path(sys.prefix).resolve()
+        for package in (concord, pds_core):
+            module_path = Path(package.__file__).resolve()
+            module_path.relative_to(env_root)
+            assert "site-packages" in module_path.as_posix().lower(), module_path
+
+        for distribution in (
+            "paper-data-suite",
+            "scoreform",
+            "quillan",
+            "pds-meridian",
+            "pds-portia",
+            "pds-vitrine",
+        ):
+            try:
+                metadata.version(distribution)
+            except metadata.PackageNotFoundError:
+                pass
+            else:
+                raise AssertionError(
+                    f"unexpected sibling distribution installed: {distribution}"
+                )
+
+        operation_entries = tuple(
+            metadata.entry_points(group=MODULE_OPERATIONS_ENTRY_POINT_GROUP)
+        )
+        concord_operation_entries = tuple(
+            entry for entry in operation_entries if entry.name == "concord"
+        )
+        assert len(concord_operation_entries) == 1
+        assert (
+            concord_operation_entries[0].value
+            == "concord.pds_operations:get_module_operations_profile"
+        )
+
+        diagnostics = diagnose_core_providers()
+        concord_diagnostics = tuple(
+            result
+            for result in diagnostics
+            if result.metadata.entry_point_name == "concord"
+        )
+        by_kind = {
+            result.metadata.provider_kind: result
+            for result in concord_diagnostics
+        }
+        assert set(by_kind) == {
+            "routing_module",
+            "publication_producer",
+            "module_operations",
+        }
+        for result in by_kind.values():
+            assert result.code == "provider.valid", result
+            assert result.declared_identity == "concord"
+            assert result.registry_conflict is False
+
+        operations_diagnostic = by_kind["module_operations"]
+        profile = operations_diagnostic.validated_profile
+        assert isinstance(profile, ModuleOperationsProfile)
+        assert profile.module_id == "concord"
+        assert profile.attention_provider is not None
+        assert profile.readiness_provider is None
+
+        def fingerprint(root: Path) -> tuple[tuple[str, str], ...]:
+            rows = []
+            for path in sorted(root.rglob("*"), key=lambda item: item.as_posix()):
+                if path.is_file():
+                    rows.append(
+                        (
+                            path.relative_to(root).as_posix(),
+                            hashlib.sha256(path.read_bytes()).hexdigest(),
+                        )
+                    )
+            return tuple(rows)
+
+        with tempfile.TemporaryDirectory(prefix="concord-attention-installed-") as raw:
+            root = ensure_workspace_root(Path(raw) / "workspace")
+            write_class_metadata_for_class(
+                root,
+                create_class_metadata(
+                    "class-1",
+                    "2026-2027",
+                    created_at=datetime(2026, 8, 28, tzinfo=timezone.utc),
+                ),
+            )
+            write_class_roster(
+                root,
+                create_roster(
+                    "class-1",
+                    (
+                        {
+                            "student_id": "student-1",
+                            "last_name": "PrivateLast",
+                            "first_name": "PrivateFirst",
+                            "period": "1",
+                        },
+                    ),
+                ),
+            )
+            actor = WorkflowActor(
+                actor_id="teacher-private-id",
+                display_label="Private Teacher Label",
+                role_label="teacher",
+            )
+            created = create_activity_context(
+                CreateActivityContextRequest(
+                    class_id="class-1",
+                    activity_id="activity-1",
+                    title="Attention Acceptance Activity",
+                    activity_type="project",
+                    scoring_orientation="evidence_only",
+                    session_id="session-1",
+                    session_label="Day 1",
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            create_group_plan(
+                CreateGroupPlanRequest(
+                    class_id="class-1",
+                    activity_id="activity-1",
+                    group_plan_id="private-plan-1",
+                    strategy="manual",
+                    expected_snapshot_revision=created.commit.snapshot_revision,
+                    actor=actor,
+                    proposed_groups=(
+                        PlannedGroup(
+                            planned_group_key="private-planned-group",
+                            label="Private Group Label",
+                            student_ids=("student-1",),
+                        ),
+                    ),
+                ),
+                workspace_root=root,
+            )
+
+            before = fingerprint(root)
+            request = ModuleOperationsRequest(
+                workspace_root=root,
+                active_school_year="2026-2027",
+                class_id="class-1",
+            )
+            invocation = invoke_module_attention(profile, request)
+            after = fingerprint(root)
+            assert after == before
+
+            assert invocation.code == "module_operations.evaluated"
+            assert invocation.result_validation == "passed"
+            report = invocation.report
+            assert isinstance(report, ModuleAttentionReport)
+            assert report.evaluation == "evaluated"
+            assert report.notices == ()
+            assert len(report.summaries) == 1
+
+            summary = report.summaries[0]
+            assert summary.code == "concord_plan_prepare"
+            assert summary.label == "Group plans still need preparation"
+            assert summary.count == 1
+            assert summary.class_id == "class-1"
+            assert summary.work_ref is not None
+            assert summary.work_ref.module_id == "concord"
+            assert summary.work_ref.class_id == "class-1"
+            assert summary.work_ref.work_id == "activity-1"
+            assert summary.action is not None
+            assert summary.action.module_id == "concord"
+            assert summary.action.action_id == "open_activity_plan"
+
+            rendered = repr(report)
+            for private_value in (
+                "student-1",
+                "PrivateLast",
+                "PrivateFirst",
+                "teacher-private-id",
+                "Private Teacher Label",
+                "private-plan-1",
+                "private-planned-group",
+                "Private Group Label",
+            ):
+                assert private_value not in rendered
+
+            readiness = invoke_module_readiness(profile, request)
+            assert readiness.code == "module_operations.capability_absent"
+            assert readiness.report is None
+            assert fingerprint(root) == before
+
+        unavailable = invoke_module_attention(
+            profile,
+            ModuleOperationsRequest(active_school_year="2026-2027"),
+        )
+        assert unavailable.code == "module_operations.evaluation_unavailable"
+        unavailable_report = unavailable.report
+        assert isinstance(unavailable_report, ModuleAttentionReport)
+        assert unavailable_report.evaluation == "unavailable"
+        assert unavailable_report.summaries == ()
+        assert tuple(notice.code for notice in unavailable_report.notices) == (
+            "concord_attention_unavailable",
+        )
+        """
+    )
+
+
+def smoke(concord_wheel: Path, core_wheel: Path) -> None:
+    if not concord_wheel.is_file():
+        raise FileNotFoundError(concord_wheel)
+    if not core_wheel.is_file():
+        raise FileNotFoundError(core_wheel)
+
+    with tempfile.TemporaryDirectory(prefix="concord-attention-wheel-") as raw:
+        work = Path(raw)
+        env_root = work / "venv"
+        venv.EnvBuilder(with_pip=True).create(env_root)
+        python = _python(env_root)
+        _run(
+            [str(python), "-m", "pip", "install", str(core_wheel.resolve())],
+            work,
+        )
+        _run(
+            [str(python), "-m", "pip", "install", str(concord_wheel.resolve())],
+            work,
+        )
+        _run([str(python), "-m", "pip", "check"], work)
+
+        smoke_path = work / "attention_provider_smoke.py"
+        smoke_path.write_text(_smoke_code(), encoding="utf-8")
+        _run([str(python), "-I", str(smoke_path)], work)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("concord_wheel", type=Path)
+    parser.add_argument("core_wheel", type=Path)
+    args = parser.parse_args()
+    smoke(args.concord_wheel, args.core_wheel)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -117,6 +117,14 @@ def validate(core_wheel: Path, *, allow_dirty: bool) -> None:
                 str(core_wheel),
             ]
         )
+        _run(
+            [
+                python,
+                "scripts/smoke_test_attention_provider_wheel.py",
+                str(wheels[0]),
+                str(core_wheel),
+            ]
+        )
     _run(["git", "diff", "--check"])
     if not allow_dirty:
         result = subprocess.run(

--- a/tests/test_academic_result_share_attention_issue67.py
+++ b/tests/test_academic_result_share_attention_issue67.py
@@ -75,6 +75,11 @@ def _patch_common(
 ) -> None:
     monkeypatch.setattr(
         share,
+        "resolve_read_workspace_root",
+        lambda *_a, **_k: Path("workspace"),
+    )
+    monkeypatch.setattr(
+        share,
         "load_current_concord_academic_work_registration",
         lambda *_a, **_k: _registration(),
     )

--- a/tests/test_academic_result_share_attention_issue67.py
+++ b/tests/test_academic_result_share_attention_issue67.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import concord.academic_result_share_attention as share
+from concord.academic_result_manifest_generation import (
+    ConcordManifestGenerationValidationError,
+)
+from concord.academic_result_publication import (
+    ConcordAcademicResultPublicationIntegrityError,
+)
+from concord.academic_work_registration import (
+    ConcordAcademicWorkRegistrationIntegrityError,
+)
+
+
+def _registration() -> SimpleNamespace:
+    return SimpleNamespace(registration_revision=2)
+
+
+def _context() -> SimpleNamespace:
+    return SimpleNamespace(snapshot_revision=9)
+
+
+def _producer_head(revision: int = 1) -> SimpleNamespace:
+    return SimpleNamespace(revision=revision)
+
+
+def _core_head(
+    revision: int,
+    *,
+    digest: str,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        record_set_revision=revision,
+        manifest_digest=digest,
+    )
+
+
+def _series(
+    *,
+    producer_revision: int | None,
+    core_head: object | None = None,
+    withdrawn: bool = False,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        producer_head=(
+            None if producer_revision is None else _producer_head(producer_revision)
+        ),
+        core_head=core_head,
+        core_head_withdrawal=(object() if withdrawn else None),
+    )
+
+
+def _preview(
+    disposition: str,
+    revision: int,
+    digest: str,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        disposition=disposition,
+        revision=revision,
+        sha256=digest,
+    )
+
+
+def _patch_common(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    series: object,
+    preview: object,
+) -> None:
+    monkeypatch.setattr(
+        share,
+        "load_current_concord_academic_work_registration",
+        lambda *_a, **_k: _registration(),
+    )
+    monkeypatch.setattr(
+        share,
+        "load_managed_activity_registration_context",
+        lambda *_a, **_k: _context(),
+    )
+    monkeypatch.setattr(
+        share,
+        "load_concord_publication_series_status",
+        lambda *_a, **_k: series,
+    )
+    monkeypatch.setattr(
+        share,
+        "preview_academic_result_manifest",
+        lambda *_a, **_k: preview,
+    )
+
+
+def test_no_registration_means_share_workflow_is_inactive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        share,
+        "load_current_concord_academic_work_registration",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        share,
+        "load_concord_publication_series_status",
+        lambda *_a, **_k: pytest.fail("publication state must not be read"),
+    )
+    monkeypatch.setattr(
+        share,
+        "preview_academic_result_manifest",
+        lambda *_a, **_k: pytest.fail("manifest preview must not be built"),
+    )
+    result = share.inspect_academic_result_share_attention_state(
+        "class-1", "activity-1", workspace_root=Path("workspace")
+    )
+    assert result.status == "inactive"
+
+
+def test_registered_changed_result_needs_manifest_before_publication(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_common(
+        monkeypatch,
+        series=_series(producer_revision=1),
+        preview=_preview("would_create", 2, "b" * 64),
+    )
+    result = share.inspect_academic_result_share_attention_state(
+        "class-1", "activity-1"
+    )
+    assert result.status == "manifest_needed"
+
+
+def test_current_manifest_without_publication_is_ready_for_explicit_publish(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    digest = "c" * 64
+    _patch_common(
+        monkeypatch,
+        series=_series(producer_revision=1),
+        preview=_preview("would_reuse", 1, digest),
+    )
+    result = share.inspect_academic_result_share_attention_state(
+        "class-1", "activity-1"
+    )
+    assert result.status == "publish_ready"
+
+
+def test_newer_current_manifest_is_ready_for_explicit_supersession(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_common(
+        monkeypatch,
+        series=_series(
+            producer_revision=2,
+            core_head=_core_head(1, digest="d" * 64),
+        ),
+        preview=_preview("would_reuse", 2, "e" * 64),
+    )
+    result = share.inspect_academic_result_share_attention_state(
+        "class-1", "activity-1"
+    )
+    assert result.status == "supersede_ready"
+
+
+def test_exact_current_publication_produces_no_share_attention_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    digest = "f" * 64
+    _patch_common(
+        monkeypatch,
+        series=_series(
+            producer_revision=3,
+            core_head=_core_head(3, digest=digest),
+        ),
+        preview=_preview("would_reuse", 3, digest),
+    )
+    result = share.inspect_academic_result_share_attention_state(
+        "class-1", "activity-1"
+    )
+    assert result.status == "current"
+
+
+def test_withdrawn_head_is_explicit_recovery_state_without_preview(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_common(
+        monkeypatch,
+        series=_series(
+            producer_revision=1,
+            core_head=_core_head(1, digest="1" * 64),
+            withdrawn=True,
+        ),
+        preview=_preview("would_reuse", 1, "1" * 64),
+    )
+    monkeypatch.setattr(
+        share,
+        "preview_academic_result_manifest",
+        lambda *_a, **_k: pytest.fail("withdrawal state should short-circuit preview"),
+    )
+    result = share.inspect_academic_result_share_attention_state(
+        "class-1", "activity-1"
+    )
+    assert result.status == "withdrawn"
+
+
+@pytest.mark.parametrize(
+    "source",
+    ("registration", "series", "preview"),
+)
+def test_inconsistent_existing_share_state_requires_inspection(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+) -> None:
+    _patch_common(
+        monkeypatch,
+        series=_series(producer_revision=1),
+        preview=_preview("would_reuse", 1, "2" * 64),
+    )
+    if source == "registration":
+        monkeypatch.setattr(
+            share,
+            "load_current_concord_academic_work_registration",
+            lambda *_a, **_k: (_ for _ in ()).throw(
+                ConcordAcademicWorkRegistrationIntegrityError("synthetic")
+            ),
+        )
+    elif source == "series":
+        monkeypatch.setattr(
+            share,
+            "load_concord_publication_series_status",
+            lambda *_a, **_k: (_ for _ in ()).throw(
+                ConcordAcademicResultPublicationIntegrityError("synthetic")
+            ),
+        )
+    else:
+        monkeypatch.setattr(
+            share,
+            "preview_academic_result_manifest",
+            lambda *_a, **_k: (_ for _ in ()).throw(
+                ConcordManifestGenerationValidationError("synthetic")
+            ),
+        )
+    result = share.inspect_academic_result_share_attention_state(
+        "class-1", "activity-1"
+    )
+    assert result.status == "needs_inspection"
+
+
+def test_backward_or_digest_inconsistent_series_requires_inspection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_common(
+        monkeypatch,
+        series=_series(
+            producer_revision=1,
+            core_head=_core_head(2, digest="3" * 64),
+        ),
+        preview=_preview("would_reuse", 1, "4" * 64),
+    )
+    result = share.inspect_academic_result_share_attention_state(
+        "class-1", "activity-1"
+    )
+    assert result.status == "needs_inspection"
+
+
+def test_share_projection_exposes_no_publication_or_manifest_internals(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = "student-secret-publication-id"
+    _patch_common(
+        monkeypatch,
+        series=SimpleNamespace(
+            producer_head=_producer_head(2),
+            core_head=SimpleNamespace(
+                record_set_revision=1,
+                manifest_digest="5" * 64,
+                publication_id=secret,
+            ),
+            core_head_withdrawal=None,
+        ),
+        preview=_preview("would_reuse", 2, "6" * 64),
+    )
+    result = share.inspect_academic_result_share_attention_state(
+        "class-1", "activity-1"
+    )
+    assert result.status == "supersede_ready"
+    assert secret not in repr(result)
+    assert "5" * 64 not in repr(result)
+    assert "6" * 64 not in repr(result)

--- a/tests/test_activity_attention_issue67.py
+++ b/tests/test_activity_attention_issue67.py
@@ -1,0 +1,791 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import concord.workflows.activity_attention as attention
+from concord.academic_result_share_attention import AcademicResultShareAttentionState
+from concord.workflows import ActivitySummary
+from concord.workflows.artifact import ArtifactSummary
+from concord.workflows.artifact_collection import ArtifactCollectionState
+from concord.workflows.artifact_review_attention import ArtifactReviewAttentionState
+from concord.workflows.artifact_scoring_attention import ArtifactScoringAttentionState
+from concord.workflows.group_plan import GroupPlanSummary
+from concord.workflows.packet_instance import PacketInstanceSummary
+
+
+def _activity(
+    activity_id: str = "activity-1",
+    *,
+    class_id: str = "class-1",
+    title: str = "Seminar",
+    status: str = "active",
+    scoring_orientation: str = "evidence_only",
+) -> ActivitySummary:
+    return ActivitySummary(
+        class_id=class_id,
+        activity_id=activity_id,
+        title=title,
+        status=status,
+        scoring_orientation=scoring_orientation,
+        session_count=1,
+        group_count=0,
+        snapshot_revision=1,
+    )
+
+
+def _plan(
+    group_plan_id: str,
+    *,
+    status: str,
+    strategy: str = "manual",
+    unresolved: int = 0,
+) -> GroupPlanSummary:
+    return GroupPlanSummary(
+        class_id="class-1",
+        activity_id="activity-1",
+        group_plan_id=group_plan_id,
+        strategy=strategy,
+        status=status,
+        proposed_group_count=1,
+        assigned_student_count=3,
+        unresolved_student_count=unresolved,
+        target_group_size=None,
+        target_group_count=None,
+        snapshot_revision=1,
+    )
+
+
+def _packet(
+    packet_instance_id: str,
+    *,
+    status: str,
+    target_key: str = "activity:activity-1",
+    output_relative_path: str | None = None,
+    output_sha256: str | None = None,
+) -> PacketInstanceSummary:
+    return PacketInstanceSummary(
+        packet_instance_id=packet_instance_id,
+        generation_id=f"generation-{packet_instance_id}",
+        packet_definition_id="packet-definition-1",
+        packet_version_id="packet-version-1",
+        activity_id="activity-1",
+        session_id="session-1",
+        audience_kind="activity",
+        target_key=target_key,
+        generation_status=status,
+        artifact_count=1,
+        page_count=2,
+        route_count=1,
+        output_relative_path=output_relative_path,
+        output_sha256=output_sha256,
+        created_at="2026-08-28T12:00:00+00:00",
+    )
+
+
+def _artifact(
+    artifact_instance_id: str,
+    *,
+    status: str = "returned",
+    returned: int = 1,
+    required: int = 1,
+    authors: int = 0,
+    subjects: int = 0,
+) -> ArtifactSummary:
+    return ArtifactSummary(
+        class_id="class-1",
+        activity_id="activity-1",
+        artifact_instance_id=artifact_instance_id,
+        artifact_category="student_work",
+        generation_status="completed",
+        expected_return_status="returned_expected",
+        artifact_status=status,
+        required_return_page_count=required,
+        returned_required_page_count=returned,
+        current_author_count=authors,
+        current_subject_count=subjects,
+        snapshot_revision=1,
+    )
+
+
+def _collection_state(
+    artifact_instance_id: str,
+    *,
+    assembly: str = "not_ready",
+    author_pending: bool = False,
+    subject_pending: bool = False,
+) -> ArtifactCollectionState:
+    return ArtifactCollectionState(
+        class_id="class-1",
+        activity_id="activity-1",
+        artifact_instance_id=artifact_instance_id,
+        assembly_state=assembly,  # type: ignore[arg-type]
+        author_confirmation_pending=author_pending,
+        subject_confirmation_pending=subject_pending,
+    )
+
+
+def _patch_activity(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    status: str = "active",
+    plans: tuple[GroupPlanSummary, ...] = (),
+    packets: tuple[PacketInstanceSummary, ...] = (),
+    artifacts: tuple[ArtifactSummary, ...] = (),
+    collection_states: dict[str, ArtifactCollectionState] | None = None,
+    review_states: dict[str, ArtifactReviewAttentionState] | None = None,
+    scoring_states: dict[str, ArtifactScoringAttentionState] | None = None,
+    scoring_orientation: str = "evidence_only",
+    share_status: str = "inactive",
+) -> None:
+    monkeypatch.setattr(
+        attention,
+        "show_activity",
+        lambda *_a, **_k: SimpleNamespace(
+            summary=_activity(
+                status=status,
+                scoring_orientation=scoring_orientation,
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        attention,
+        "list_group_plans",
+        lambda *_a, **_k: plans,
+    )
+    monkeypatch.setattr(
+        attention,
+        "list_packet_instances",
+        lambda *_a, **_k: packets,
+    )
+    monkeypatch.setattr(
+        attention,
+        "list_artifacts",
+        lambda *_a, **_k: artifacts,
+    )
+    states = collection_states or {}
+    monkeypatch.setattr(
+        attention,
+        "inspect_artifact_collection_state",
+        lambda _class_id, _activity_id, artifact_id, **_k: states[artifact_id],
+    )
+    reviews = review_states or {}
+    monkeypatch.setattr(
+        attention,
+        "inspect_artifact_review_attention_state",
+        lambda _class_id, _activity_id, artifact_id, **_k: reviews.get(
+            artifact_id,
+            ArtifactReviewAttentionState(
+                class_id="class-1",
+                activity_id="activity-1",
+                artifact_instance_id=artifact_id,
+                first_review_pending=False,
+                review_attention_pending=False,
+                moderation_pending=False,
+                post_moderation_review_pending=False,
+            ),
+        ),
+    )
+    scoring = scoring_states or {}
+    monkeypatch.setattr(
+        attention,
+        "inspect_artifact_scoring_attention_state",
+        lambda _class_id, _activity_id, artifact_id, **_k: scoring.get(
+            artifact_id,
+            ArtifactScoringAttentionState(
+                class_id="class-1",
+                activity_id="activity-1",
+                artifact_instance_id=artifact_id,
+                scoring_ready=False,
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        attention,
+        "inspect_academic_result_share_attention_state",
+        lambda _class_id, _activity_id, **_k: AcademicResultShareAttentionState(
+            class_id="class-1",
+            activity_id="activity-1",
+            status=share_status,  # type: ignore[arg-type]
+        ),
+    )
+
+
+def test_no_group_plan_does_not_manufacture_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_activity(monkeypatch)
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert result.items == ()
+    assert result.next_item is None
+
+
+def test_group_plan_lifecycle_maps_to_stable_plan_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_activity(
+        monkeypatch,
+        plans=(
+            _plan("plan-draft", status="draft"),
+            _plan("plan-preview", status="previewed"),
+            _plan("plan-approved", status="approved"),
+            _plan("plan-applied", status="applied"),
+            _plan("plan-cancelled", status="cancelled"),
+        ),
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [(item.code, item.count) for item in result.items] == [
+        ("concord_plan_prepare", 1),
+        ("concord_plan_approve", 1),
+        ("concord_plan_apply", 1),
+    ]
+    assert result.next_item == result.items[0]
+    assert all(item.task == "plan" for item in result.items)
+    assert all(item.action_id == "open_activity_plan" for item in result.items)
+
+
+def test_unresolved_placement_attention_counts_plans_not_students(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_activity(
+        monkeypatch,
+        plans=(
+            _plan("plan-a", status="draft", unresolved=7),
+            _plan("plan-b", status="previewed", unresolved=4),
+        ),
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    unresolved = next(
+        item
+        for item in result.items
+        if item.code == "concord_plan_unresolved_placements"
+    )
+    assert unresolved.count == 2
+    assert [item.code for item in result.items] == [
+        "concord_plan_prepare",
+        "concord_plan_unresolved_placements",
+        "concord_plan_approve",
+    ]
+
+
+def test_explicit_leave_unassigned_signal_disposition_is_not_false_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _plan(
+        "plan-signal",
+        status="previewed",
+        strategy="similar_signal",
+        unresolved=5,
+    )
+    _patch_activity(monkeypatch, plans=(plan,))
+    monkeypatch.setattr(
+        attention,
+        "show_group_plan",
+        lambda *_a, **_k: SimpleNamespace(
+            plan=SimpleNamespace(
+                missing_signal_disposition="leave_unassigned",
+                source_signal_set_digest="f" * 64,
+                unresolved_student_ids=("student-secret",),
+            )
+        ),
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [item.code for item in result.items] == ["concord_plan_approve"]
+    rendered = repr(result)
+    assert "student-secret" not in rendered
+    assert "f" * 64 not in rendered
+
+
+def test_signal_plan_without_leave_unassigned_keeps_unresolved_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    plan = _plan(
+        "plan-signal",
+        status="draft",
+        strategy="mixed_signal",
+        unresolved=2,
+    )
+    _patch_activity(monkeypatch, plans=(plan,))
+    monkeypatch.setattr(
+        attention,
+        "show_group_plan",
+        lambda *_a, **_k: SimpleNamespace(
+            plan=SimpleNamespace(missing_signal_disposition="manual")
+        ),
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [item.code for item in result.items] == [
+        "concord_plan_prepare",
+        "concord_plan_unresolved_placements",
+    ]
+
+
+def test_completed_cancelled_and_archived_activities_do_not_emit_plan_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for status in ("completed", "cancelled", "archived"):
+        _patch_activity(
+            monkeypatch,
+            status=status,
+            plans=(_plan("plan-approved", status="approved"),),
+        )
+        result = attention.inspect_activity_attention("class-1", "activity-1")
+        assert result.items == ()
+
+
+def test_activity_attention_list_uses_class_title_identity_display_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    activities = (
+        _activity("activity-z", class_id="class-2", title="Alpha"),
+        _activity("activity-b", class_id="class-1", title="beta"),
+        _activity("activity-a", class_id="class-1", title="Alpha"),
+    )
+    monkeypatch.setattr(attention, "list_activities", lambda **_k: activities)
+
+    def inspect(class_id: str, activity_id: str, **_kwargs: object):
+        activity = next(item for item in activities if item.activity_id == activity_id)
+        return attention.ActivityAttentionSummary(
+            class_id=class_id,
+            activity_id=activity_id,
+            title=activity.title,
+        )
+
+    monkeypatch.setattr(attention, "inspect_activity_attention", inspect)
+    result = attention.list_activity_attention()
+    assert [(item.class_id, item.title, item.activity_id) for item in result] == [
+        ("class-1", "Alpha", "activity-a"),
+        ("class-1", "beta", "activity-b"),
+        ("class-2", "Alpha", "activity-z"),
+    ]
+
+
+def test_attention_item_rejects_nonpositive_counts() -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        attention.ActivityAttentionItem(
+            code="concord_plan_prepare",
+            label="Group plans still need preparation",
+            task="plan",
+            count=0,
+            action_id="open_activity_plan",
+        )
+
+
+def test_packet_lifecycle_maps_only_actionable_prepare_states(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_activity(
+        monkeypatch,
+        packets=(
+            _packet("packet-planned", status="planned"),
+            _packet("packet-rendering", status="rendering"),
+            _packet("packet-routes", status="routes_pending"),
+            _packet("packet-failed", status="failed"),
+            _packet(
+                "packet-generated",
+                status="generated",
+                output_relative_path="rendered/packets/private.pdf",
+                output_sha256="a" * 64,
+            ),
+            _packet("packet-cancelled", status="cancelled"),
+        ),
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [(item.code, item.count) for item in result.items] == [
+        ("concord_prepare_materials", 2),
+        ("concord_prepare_routes_pending", 1),
+        ("concord_prepare_recovery", 1),
+    ]
+    assert all(item.task == "prepare" for item in result.items)
+    assert all(item.action_id == "open_activity_prepare" for item in result.items)
+
+
+def test_generated_and_cancelled_packets_create_no_prepare_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_activity(
+        monkeypatch,
+        packets=(
+            _packet(
+                "packet-generated",
+                status="generated",
+                output_relative_path="rendered/packets/final.pdf",
+                output_sha256="b" * 64,
+            ),
+            _packet("packet-cancelled", status="cancelled"),
+        ),
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert result.items == ()
+
+
+def test_prepare_attention_does_not_leak_packet_target_or_output_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sensitive_target = "participant:student-secret"
+    sensitive_path = "rendered/packets/private-secret.pdf"
+    sensitive_hash = "c" * 64
+    _patch_activity(
+        monkeypatch,
+        packets=(
+            _packet(
+                "packet-secret",
+                status="failed",
+                target_key=sensitive_target,
+            ),
+            _packet(
+                "packet-generated-secret",
+                status="generated",
+                target_key=sensitive_target,
+                output_relative_path=sensitive_path,
+                output_sha256=sensitive_hash,
+            ),
+        ),
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    rendered = repr(result)
+    assert sensitive_target not in rendered
+    assert sensitive_path not in rendered
+    assert sensitive_hash not in rendered
+    assert "packet-secret" not in rendered
+    assert "generation-packet-secret" not in rendered
+
+
+def test_plan_attention_precedes_prepare_attention_for_next_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_activity(
+        monkeypatch,
+        plans=(_plan("plan-draft", status="draft"),),
+        packets=(_packet("packet-failed", status="failed"),),
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [item.task for item in result.items] == ["plan", "prepare"]
+    assert result.next_item is not None
+    assert result.next_item.code == "concord_plan_prepare"
+
+
+
+def test_collect_attention_requires_explicit_actionable_collection_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifacts = (
+        _artifact("artifact-waiting", status="distributed", returned=0, required=2),
+        _artifact("artifact-ready"),
+        _artifact("artifact-assembled"),
+    )
+    _patch_activity(
+        monkeypatch,
+        artifacts=artifacts,
+        collection_states={
+            "artifact-waiting": _collection_state(
+                "artifact-waiting", assembly="not_ready"
+            ),
+            "artifact-ready": _collection_state(
+                "artifact-ready", assembly="ready"
+            ),
+            "artifact-assembled": _collection_state(
+                "artifact-assembled", assembly="assembled"
+            ),
+        },
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [(item.code, item.count) for item in result.items] == [
+        ("concord_collect_assembly", 1)
+    ]
+
+
+def test_collect_confirmation_attention_uses_explicit_association_state_not_absence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifacts = (
+        _artifact("artifact-empty", authors=0, subjects=0),
+        _artifact("artifact-pending", authors=1, subjects=1),
+    )
+    _patch_activity(
+        monkeypatch,
+        artifacts=artifacts,
+        collection_states={
+            "artifact-empty": _collection_state(
+                "artifact-empty", assembly="assembled"
+            ),
+            "artifact-pending": _collection_state(
+                "artifact-pending",
+                assembly="assembled",
+                author_pending=True,
+                subject_pending=True,
+            ),
+        },
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [(item.code, item.count) for item in result.items] == [
+        ("concord_collect_author_confirmation", 1),
+        ("concord_collect_subject_confirmation", 1),
+    ]
+    assert all(item.count == 1 for item in result.items)
+    assert all(item.action_id == "open_activity_collect" for item in result.items)
+
+
+def test_collect_assembly_selection_or_recovery_are_actionable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifacts = (
+        _artifact("artifact-selection"),
+        _artifact("artifact-recovery"),
+    )
+    _patch_activity(
+        monkeypatch,
+        artifacts=artifacts,
+        collection_states={
+            "artifact-selection": _collection_state(
+                "artifact-selection", assembly="selection_required"
+            ),
+            "artifact-recovery": _collection_state(
+                "artifact-recovery", assembly="needs_recovery"
+            ),
+        },
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [(item.code, item.count) for item in result.items] == [
+        ("concord_collect_assembly", 2)
+    ]
+
+
+def test_collect_attention_does_not_leak_artifact_or_identity_details(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret_artifact = "artifact-secret-student-42"
+    _patch_activity(
+        monkeypatch,
+        artifacts=(_artifact(secret_artifact, authors=1, subjects=1),),
+        collection_states={
+            secret_artifact: _collection_state(
+                secret_artifact,
+                assembly="ready",
+                author_pending=True,
+                subject_pending=True,
+            )
+        },
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    rendered = repr(result)
+    assert secret_artifact not in rendered
+    assert [item.code for item in result.items] == [
+        "concord_collect_assembly",
+        "concord_collect_author_confirmation",
+        "concord_collect_subject_confirmation",
+    ]
+
+
+def test_prepare_attention_precedes_collect_attention_for_next_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_activity(
+        monkeypatch,
+        packets=(_packet("packet-failed", status="failed"),),
+        artifacts=(_artifact("artifact-ready"),),
+        collection_states={
+            "artifact-ready": _collection_state("artifact-ready", assembly="ready")
+        },
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [item.task for item in result.items] == ["prepare", "collect"]
+    assert result.next_item is not None
+    assert result.next_item.code == "concord_prepare_recovery"
+
+
+def test_review_and_moderation_attention_use_stable_review_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact("artifact-review")
+    _patch_activity(
+        monkeypatch,
+        artifacts=(artifact,),
+        collection_states={
+            "artifact-review": _collection_state(
+                "artifact-review", assembly="assembled"
+            )
+        },
+        review_states={
+            "artifact-review": ArtifactReviewAttentionState(
+                class_id="class-1",
+                activity_id="activity-1",
+                artifact_instance_id="artifact-review",
+                first_review_pending=True,
+                review_attention_pending=True,
+                moderation_pending=True,
+                post_moderation_review_pending=True,
+            )
+        },
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    review_items = tuple(item for item in result.items if item.task == "review")
+    assert [(item.code, item.count) for item in review_items] == [
+        ("concord_review_first", 1),
+        ("concord_review_attention", 1),
+        ("concord_review_moderation", 1),
+        ("concord_review_post_moderation", 1),
+    ]
+    assert all(item.action_id == "open_activity_review" for item in review_items)
+
+
+def test_collect_attention_precedes_review_attention_for_next_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact("artifact-review")
+    _patch_activity(
+        monkeypatch,
+        artifacts=(artifact,),
+        collection_states={
+            "artifact-review": _collection_state(
+                "artifact-review",
+                assembly="assembled",
+                author_pending=True,
+            )
+        },
+        review_states={
+            "artifact-review": ArtifactReviewAttentionState(
+                class_id="class-1",
+                activity_id="activity-1",
+                artifact_instance_id="artifact-review",
+                first_review_pending=True,
+                review_attention_pending=False,
+                moderation_pending=False,
+                post_moderation_review_pending=False,
+            )
+        },
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [item.code for item in result.items] == [
+        "concord_collect_author_confirmation",
+        "concord_review_first",
+    ]
+    assert result.next_item is not None
+    assert result.next_item.task == "collect"
+
+
+def test_scoring_ready_attention_counts_reviewed_evidence_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifacts = (_artifact("artifact-a"), _artifact("artifact-b"))
+    _patch_activity(
+        monkeypatch,
+        scoring_orientation="local_criteria_only",
+        artifacts=artifacts,
+        collection_states={
+            item.artifact_instance_id: _collection_state(
+                item.artifact_instance_id, assembly="assembled"
+            )
+            for item in artifacts
+        },
+        scoring_states={
+            item.artifact_instance_id: ArtifactScoringAttentionState(
+                class_id="class-1",
+                activity_id="activity-1",
+                artifact_instance_id=item.artifact_instance_id,
+                scoring_ready=True,
+            )
+            for item in artifacts
+        },
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [(item.code, item.count) for item in result.items] == [
+        ("concord_score_ready", 2)
+    ]
+    assert result.items[0].task == "score"
+    assert result.items[0].action_id == "open_activity_score"
+
+
+def test_review_attention_precedes_score_attention_for_next_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact("artifact-score")
+    _patch_activity(
+        monkeypatch,
+        scoring_orientation="mixed",
+        artifacts=(artifact,),
+        collection_states={
+            "artifact-score": _collection_state(
+                "artifact-score", assembly="assembled"
+            )
+        },
+        review_states={
+            "artifact-score": ArtifactReviewAttentionState(
+                class_id="class-1",
+                activity_id="activity-1",
+                artifact_instance_id="artifact-score",
+                first_review_pending=False,
+                review_attention_pending=True,
+                moderation_pending=False,
+                post_moderation_review_pending=False,
+            )
+        },
+        scoring_states={
+            "artifact-score": ArtifactScoringAttentionState(
+                class_id="class-1",
+                activity_id="activity-1",
+                artifact_instance_id="artifact-score",
+                scoring_ready=True,
+            )
+        },
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [item.task for item in result.items] == ["review", "score"]
+    assert result.next_item is not None
+    assert result.next_item.code == "concord_review_attention"
+
+
+@pytest.mark.parametrize(
+    ("share_status", "expected_code"),
+    (
+        ("inactive", None),
+        ("current", None),
+        ("manifest_needed", "concord_share_manifest"),
+        ("publish_ready", "concord_share_publish"),
+        ("supersede_ready", "concord_share_supersede"),
+        ("withdrawn", "concord_share_withdrawn"),
+        ("needs_inspection", "concord_share_inspect"),
+    ),
+)
+def test_share_attention_requires_explicit_share_state(
+    monkeypatch: pytest.MonkeyPatch,
+    share_status: str,
+    expected_code: str | None,
+) -> None:
+    _patch_activity(monkeypatch, share_status=share_status)
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [item.code for item in result.items] == (
+        [] if expected_code is None else [expected_code]
+    )
+    if result.items:
+        assert result.items[0].count == 1
+        assert result.items[0].task == "share"
+        assert result.items[0].action_id == "open_activity_share"
+
+
+def test_score_precedes_share_in_navigation_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    artifact = _artifact("artifact-ready")
+    _patch_activity(
+        monkeypatch,
+        artifacts=(artifact,),
+        collection_states={"artifact-ready": _collection_state("artifact-ready")},
+        scoring_states={
+            "artifact-ready": ArtifactScoringAttentionState(
+                class_id="class-1",
+                activity_id="activity-1",
+                artifact_instance_id="artifact-ready",
+                scoring_ready=True,
+            )
+        },
+        scoring_orientation="standards_based",
+        share_status="publish_ready",
+    )
+    result = attention.inspect_activity_attention("class-1", "activity-1")
+    assert [item.code for item in result.items] == [
+        "concord_score_ready",
+        "concord_share_publish",
+    ]
+    assert result.next_item == result.items[0]

--- a/tests/test_activity_attention_menu_issue67.py
+++ b/tests/test_activity_attention_menu_issue67.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import concord.menu_activity as activity_module
+import concord.menu_attention as attention_menu
+from concord.menu_context import MenuSessionContext
+from concord.menu_navigation import ReturnToMainMenu
+from concord.workflows.activity_attention import (
+    ActivityAttentionItem,
+    ActivityAttentionSummary,
+)
+from concord.workflows.models import ActivitySummary
+
+
+def _activity() -> ActivitySummary:
+    return ActivitySummary(
+        class_id="class-1",
+        activity_id="activity-1",
+        title="Macbeth Seminar",
+        status="active",
+        scoring_orientation="mixed",
+        session_count=1,
+        group_count=0,
+        snapshot_revision=7,
+    )
+
+
+def _summary(*items: ActivityAttentionItem) -> ActivityAttentionSummary:
+    return ActivityAttentionSummary(
+        class_id="class-1",
+        activity_id="activity-1",
+        title="Macbeth Seminar",
+        items=items,
+    )
+
+
+def _item(
+    *,
+    task: str = "score",
+    code: str = "concord_score_ready",
+    label: str = "Reviewed evidence is ready for scoring",
+    count: int = 2,
+    action_id: str = "open_activity_score",
+) -> ActivityAttentionItem:
+    return ActivityAttentionItem(
+        code=code,
+        label=label,
+        task=task,  # type: ignore[arg-type]
+        count=count,
+        action_id=action_id,
+    )
+
+
+def _stable_activity(monkeypatch: pytest.MonkeyPatch) -> ActivitySummary:
+    activity = _activity()
+    monkeypatch.setattr(
+        activity_module,
+        "show_activity",
+        lambda *_args, **_kwargs: SimpleNamespace(summary=activity),
+    )
+    return activity
+
+
+def test_opened_activity_shows_bounded_next_action_without_renumbering(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    activity = _stable_activity(monkeypatch)
+    summary = _summary(
+        _item(),
+        _item(
+            task="share",
+            code="concord_share_publish",
+            label="Current result is ready for explicit publication",
+            count=1,
+            action_id="open_activity_share",
+        ),
+    )
+    monkeypatch.setattr(
+        activity_module,
+        "inspect_activity_attention",
+        lambda *_args, **_kwargs: summary,
+    )
+    routed: list[str] = []
+    monkeypatch.setattr(
+        activity_module,
+        "launch_activity_attention_action",
+        lambda _activity, _state, action_id: routed.append(action_id),
+    )
+    answers = iter(("a", "b"))
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr(activity_module, "clear_screen", lambda: None)
+
+    activity_module.launch_activity_context_menu(activity, MenuSessionContext())
+
+    output = capsys.readouterr().out
+    assert "1. Plan" in output
+    assert "2. Prepare" in output
+    assert "3. Collect" in output
+    assert "4. Review" in output
+    assert "5. Score" in output
+    assert "6. Share" in output
+    assert "7. Advanced Activity tools" in output
+    assert "A. Open next action" in output
+    assert "Next: Score - Reviewed evidence is ready for scoring (count 2)" in output
+    assert "Also: 1 other attention category" in output
+    assert routed == ["open_activity_score"]
+
+
+@pytest.mark.parametrize(
+    ("action_id", "target_name"),
+    (
+        ("open_activity_plan", "launch_plan_menu"),
+        ("open_activity_prepare", "launch_prepare_menu"),
+        ("open_activity_collect", "launch_collect_menu"),
+        ("open_activity_review", "launch_review_task_menu"),
+        ("open_activity_score", "launch_score_task_menu"),
+        ("open_activity_share", "launch_share_menu"),
+    ),
+)
+def test_owner_action_ids_route_to_existing_issue66_task_menus(
+    monkeypatch: pytest.MonkeyPatch,
+    action_id: str,
+    target_name: str,
+) -> None:
+    activity = _activity()
+    state = MenuSessionContext()
+    calls: list[tuple[str, object]] = []
+    monkeypatch.setattr(
+        activity_module,
+        target_name,
+        lambda selected, selected_state: calls.append(
+            (selected.activity_id, selected_state)
+        ),
+    )
+
+    activity_module.launch_activity_attention_action(activity, state, action_id)
+
+    assert calls == [("activity-1", state)]
+
+
+def test_unknown_owner_action_is_rejected_without_fallback() -> None:
+    with pytest.raises(Exception, match="Unsupported Concord attention action"):
+        activity_module.launch_activity_attention_action(
+            _activity(), MenuSessionContext(), "open_student_secret"
+        )
+
+
+def test_attention_failure_is_generic_and_does_not_leak_exception_text(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    activity = _stable_activity(monkeypatch)
+
+    def _fail(*_args: object, **_kwargs: object) -> ActivityAttentionSummary:
+        raise RuntimeError("student-secret grouping-signal=high")
+
+    monkeypatch.setattr(activity_module, "inspect_activity_attention", _fail)
+    monkeypatch.setattr(activity_module, "clear_screen", lambda: None)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "b")
+
+    activity_module.launch_activity_context_menu(activity)
+
+    output = capsys.readouterr().out
+    assert "Attention: unavailable" in output
+    assert "student-secret" not in output
+    assert "grouping-signal" not in output
+
+
+def test_activity_management_adds_attention_discovery_without_renumbering(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    calls: list[object] = []
+    monkeypatch.setattr(
+        activity_module,
+        "launch_activity_attention_discovery",
+        lambda state, **_kwargs: calls.append(state),
+    )
+    answers = iter(("a", "b"))
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    monkeypatch.setattr(activity_module, "clear_screen", lambda: None)
+    state = MenuSessionContext()
+
+    activity_module.launch_activity_management_menu(state)
+
+    output = capsys.readouterr().out
+    assert "1. Create Classroom Activity" in output
+    assert "2. Continue setup for an Activity" in output
+    assert "3. Advanced Activity tools" in output
+    assert "A. Attention needed" in output
+    assert calls == [state]
+
+
+def test_cross_activity_discovery_routes_only_the_selected_next_action(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    summary = _summary(_item(task="review", action_id="open_activity_review"))
+    monkeypatch.setattr(
+        attention_menu,
+        "list_activity_attention",
+        lambda: (summary,),
+    )
+    monkeypatch.setattr(
+        attention_menu,
+        "show_activity",
+        lambda *_args, **_kwargs: SimpleNamespace(summary=_activity()),
+    )
+    monkeypatch.setattr(attention_menu, "clear_screen", lambda: None)
+    answers = iter(("1", "b"))
+    monkeypatch.setattr("builtins.input", lambda _prompt="": next(answers))
+    calls: list[str] = []
+
+    attention_menu.launch_activity_attention_discovery(
+        MenuSessionContext(),
+        route_action=lambda _activity, _state, action_id: calls.append(action_id),
+    )
+
+    output = capsys.readouterr().out
+    assert "Attention Needed" in output
+    assert "Macbeth Seminar (class-1)" in output
+    assert "Review: Reviewed evidence is ready for scoring" in output
+    assert calls == ["open_activity_review"]
+
+
+def test_cross_activity_discovery_preserves_main_menu_unwind(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    summary = _summary(_item())
+    monkeypatch.setattr(
+        attention_menu,
+        "list_activity_attention",
+        lambda: (summary,),
+    )
+    monkeypatch.setattr(
+        attention_menu,
+        "show_activity",
+        lambda *_args, **_kwargs: SimpleNamespace(summary=_activity()),
+    )
+    monkeypatch.setattr(attention_menu, "clear_screen", lambda: None)
+    monkeypatch.setattr("builtins.input", lambda _prompt="": "1")
+
+    def _route(*_args: object) -> None:
+        raise ReturnToMainMenu
+
+    with pytest.raises(ReturnToMainMenu):
+        attention_menu.launch_activity_attention_discovery(
+            MenuSessionContext(),
+            route_action=_route,
+        )
+
+
+def test_opened_summary_does_not_sum_heterogeneous_attention_counts(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    attention_menu.print_activity_attention_summary(
+        _summary(
+            _item(count=4),
+            _item(
+                task="share",
+                code="concord_share_publish",
+                label="Current result is ready for explicit publication",
+                count=1,
+                action_id="open_activity_share",
+            ),
+        )
+    )
+
+    output = capsys.readouterr().out
+    assert "count 4" in output
+    assert "5" not in output
+    assert "1 other attention category" in output

--- a/tests/test_artifact_collection_issue67.py
+++ b/tests/test_artifact_collection_issue67.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import concord.workflows.artifact_collection as collection
+from concord.workflows.artifact_assembly import (
+    ArtifactAssemblyAmbiguityError,
+    ArtifactAssemblyIncompleteError,
+    ArtifactAssemblyIntegrityError,
+    AssemblyAmbiguity,
+)
+
+
+def _artifact() -> SimpleNamespace:
+    return SimpleNamespace(
+        artifact_instance_id="artifact-1",
+        activity_id="activity-1",
+    )
+
+
+def _graph() -> SimpleNamespace:
+    return SimpleNamespace(artifact_instances=(_artifact(),))
+
+
+def test_assembly_state_waits_until_all_required_evidence_can_be_assembled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def incomplete(*_args: object, **_kwargs: object) -> object:
+        raise ArtifactAssemblyIncompleteError(((2, "page-2"),))
+
+    monkeypatch.setattr(collection, "_select_lineage", incomplete)
+    assert collection._assembly_state(
+        tmp_path,
+        "class-1",
+        "activity-1",
+        _artifact(),  # type: ignore[arg-type]
+        _graph(),  # type: ignore[arg-type]
+    ) == "not_ready"
+
+
+def test_assembly_state_marks_ambiguous_complete_returns_as_actionable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ambiguity = AssemblyAmbiguity(
+        artifact_page_id="page-1",
+        logical_page_number=1,
+        scan_reference_ids=("scan-a", "scan-b"),
+    )
+
+    def ambiguous(*_args: object, **_kwargs: object) -> object:
+        raise ArtifactAssemblyAmbiguityError((ambiguity,))
+
+    monkeypatch.setattr(collection, "_select_lineage", ambiguous)
+    assert collection._assembly_state(
+        tmp_path,
+        "class-1",
+        "activity-1",
+        _artifact(),  # type: ignore[arg-type]
+        _graph(),  # type: ignore[arg-type]
+    ) == "selection_required"
+
+
+def test_assembly_state_distinguishes_ready_current_and_recovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    lineage = (SimpleNamespace(),)
+    output = tmp_path / "assemblies" / "assembly-1" / "artifact.pdf"
+    manifest = output.with_name("manifest.json")
+    monkeypatch.setattr(collection, "_select_lineage", lambda *_a, **_k: lineage)
+    monkeypatch.setattr(collection, "_assembly_id", lambda *_a, **_k: "assembly-1")
+    monkeypatch.setattr(
+        collection,
+        "_assembly_paths",
+        lambda *_a, **_k: (output, manifest),
+    )
+
+    assert collection._assembly_state(
+        tmp_path,
+        "class-1",
+        "activity-1",
+        _artifact(),  # type: ignore[arg-type]
+        _graph(),  # type: ignore[arg-type]
+    ) == "ready"
+
+    output.parent.mkdir(parents=True)
+    monkeypatch.setattr(collection, "_verify_existing", lambda **_k: "a" * 64)
+    assert collection._assembly_state(
+        tmp_path,
+        "class-1",
+        "activity-1",
+        _artifact(),  # type: ignore[arg-type]
+        _graph(),  # type: ignore[arg-type]
+    ) == "assembled"
+
+    def invalid(**_kwargs: object) -> str:
+        raise ArtifactAssemblyIntegrityError("invalid exact assembly")
+
+    monkeypatch.setattr(collection, "_verify_existing", invalid)
+    assert collection._assembly_state(
+        tmp_path,
+        "class-1",
+        "activity-1",
+        _artifact(),  # type: ignore[arg-type]
+        _graph(),  # type: ignore[arg-type]
+    ) == "needs_recovery"
+
+
+def test_confirmation_attention_requires_explicit_current_pending_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        collection,
+        "resolve_read_workspace_root",
+        lambda _root: tmp_path,
+    )
+    monkeypatch.setattr(collection, "load_graph", lambda *_a, **_k: (_graph(), 1, "x"))
+    monkeypatch.setattr(collection, "_assembly_state", lambda *_a, **_k: "assembled")
+    monkeypatch.setattr(
+        collection,
+        "list_artifact_authors",
+        lambda *_a, **_k: (
+            SimpleNamespace(attribution_status="confirmed"),
+            SimpleNamespace(attribution_status="unknown"),
+        ),
+    )
+    monkeypatch.setattr(
+        collection,
+        "list_artifact_subjects",
+        lambda *_a, **_k: (SimpleNamespace(confirmation_status="confirmed"),),
+    )
+    state = collection.inspect_artifact_collection_state(
+        "class-1",
+        "activity-1",
+        "artifact-1",
+        workspace_root=tmp_path,
+    )
+    assert not state.author_confirmation_pending
+    assert not state.subject_confirmation_pending
+
+    monkeypatch.setattr(
+        collection,
+        "list_artifact_authors",
+        lambda *_a, **_k: (SimpleNamespace(attribution_status="proposed"),),
+    )
+    monkeypatch.setattr(
+        collection,
+        "list_artifact_subjects",
+        lambda *_a, **_k: (SimpleNamespace(confirmation_status="unresolved"),),
+    )
+    state = collection.inspect_artifact_collection_state(
+        "class-1",
+        "activity-1",
+        "artifact-1",
+        workspace_root=tmp_path,
+    )
+    assert state.author_confirmation_pending
+    assert state.subject_confirmation_pending
+
+
+def test_zero_author_and_subject_records_do_not_manufacture_confirmation_attention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        collection,
+        "resolve_read_workspace_root",
+        lambda _root: tmp_path,
+    )
+    monkeypatch.setattr(collection, "load_graph", lambda *_a, **_k: (_graph(), 1, "x"))
+    monkeypatch.setattr(collection, "_assembly_state", lambda *_a, **_k: "not_ready")
+    monkeypatch.setattr(collection, "list_artifact_authors", lambda *_a, **_k: ())
+    monkeypatch.setattr(collection, "list_artifact_subjects", lambda *_a, **_k: ())
+    state = collection.inspect_artifact_collection_state(
+        "class-1",
+        "activity-1",
+        "artifact-1",
+        workspace_root=tmp_path,
+    )
+    assert not state.author_confirmation_pending
+    assert not state.subject_confirmation_pending

--- a/tests/test_artifact_review_attention_issue67.py
+++ b/tests/test_artifact_review_attention_issue67.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import concord.workflows.artifact_review_attention as review_attention
+from concord.workflows.artifact_collection import ArtifactCollectionState
+
+
+def _collection(assembly: str) -> ArtifactCollectionState:
+    return ArtifactCollectionState(
+        class_id="class-1",
+        activity_id="activity-1",
+        artifact_instance_id="artifact-1",
+        assembly_state=assembly,  # type: ignore[arg-type]
+        author_confirmation_pending=False,
+        subject_confirmation_pending=False,
+    )
+
+
+def _review(
+    *,
+    outcome: str = "ready",
+    moderation: str = "not_required",
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        review_outcome=outcome,
+        moderation_requirement=moderation,
+    )
+
+
+def test_first_review_requires_completed_exact_assembly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        review_attention,
+        "current_artifact_review",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        review_attention,
+        "inspect_artifact_collection_state",
+        lambda *_a, **_k: _collection("not_ready"),
+    )
+    state = review_attention.inspect_artifact_review_attention_state(
+        "class-1", "activity-1", "artifact-1", workspace_root=tmp_path
+    )
+    assert not state.first_review_pending
+
+    monkeypatch.setattr(
+        review_attention,
+        "inspect_artifact_collection_state",
+        lambda *_a, **_k: _collection("assembled"),
+    )
+    state = review_attention.inspect_artifact_review_attention_state(
+        "class-1", "activity-1", "artifact-1", workspace_root=tmp_path
+    )
+    assert state.first_review_pending
+    assert not state.review_attention_pending
+
+
+def test_current_ready_or_terminal_not_suitable_review_is_not_false_attention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for outcome in ("ready", "ready_with_qualification", "not_suitable_for_scoring"):
+        monkeypatch.setattr(
+            review_attention,
+            "current_artifact_review",
+            lambda *_a, _outcome=outcome, **_k: _review(outcome=_outcome),
+        )
+        state = review_attention.inspect_artifact_review_attention_state(
+            "class-1", "activity-1", "artifact-1", workspace_root=tmp_path
+        )
+        assert not state.review_attention_pending
+        assert not state.moderation_pending
+
+
+def test_explicit_blocking_review_outcomes_create_review_attention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outcomes = (
+        "incomplete",
+        "unreadable",
+        "misrouted",
+        "duplicate",
+        "awaiting_correction",
+        "awaiting_additional_evidence",
+    )
+    for outcome in outcomes:
+        monkeypatch.setattr(
+            review_attention,
+            "current_artifact_review",
+            lambda *_a, _outcome=outcome, **_k: _review(outcome=_outcome),
+        )
+        state = review_attention.inspect_artifact_review_attention_state(
+            "class-1", "activity-1", "artifact-1", workspace_root=tmp_path
+        )
+        assert state.review_attention_pending
+
+
+def test_required_moderation_without_applicable_current_decision_is_attention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        review_attention,
+        "current_artifact_review",
+        lambda *_a, **_k: _review(
+            outcome="moderation_required",
+            moderation="required",
+        ),
+    )
+    monkeypatch.setattr(
+        review_attention,
+        "list_artifact_subjects",
+        lambda *_a, **_k: (
+            SimpleNamespace(subject_reference=SimpleNamespace(subject_id="private")),
+        ),
+    )
+    seen: list[tuple[object, ...]] = []
+
+    def assess(*args: object, **kwargs: object) -> SimpleNamespace:
+        seen.append((args, kwargs))
+        return SimpleNamespace(applicable_moderation_records=())
+
+    monkeypatch.setattr(review_attention, "assess_moderation_requirement", assess)
+    state = review_attention.inspect_artifact_review_attention_state(
+        "class-1", "activity-1", "artifact-1", workspace_root=tmp_path
+    )
+    assert state.moderation_pending
+    assert not state.post_moderation_review_pending
+    assert len(seen) == 1
+
+
+def test_exact_applicable_current_moderation_moves_attention_to_review_update(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        review_attention,
+        "current_artifact_review",
+        lambda *_a, **_k: _review(
+            outcome="moderation_required",
+            moderation="required",
+        ),
+    )
+    monkeypatch.setattr(
+        review_attention,
+        "list_artifact_subjects",
+        lambda *_a, **_k: (),
+    )
+    monkeypatch.setattr(
+        review_attention,
+        "assess_moderation_requirement",
+        lambda *_a, **_k: SimpleNamespace(
+            applicable_moderation_records=(
+                SimpleNamespace(
+                    moderation_record_id="private-id",
+                    status="rejected",
+                    rationale="private rationale",
+                ),
+            )
+        ),
+    )
+    state = review_attention.inspect_artifact_review_attention_state(
+        "class-1", "activity-1", "artifact-1", workspace_root=tmp_path
+    )
+    assert not state.moderation_pending
+    assert state.post_moderation_review_pending
+    rendered = repr(state)
+    assert "private-id" not in rendered
+    assert "private rationale" not in rendered

--- a/tests/test_artifact_scoring_attention_issue67.py
+++ b/tests/test_artifact_scoring_attention_issue67.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import concord.workflows.artifact_scoring_attention as scoring_attention
+
+
+def _activity(orientation: str) -> object:
+    return SimpleNamespace(
+        summary=SimpleNamespace(scoring_orientation=orientation)
+    )
+
+
+def _review(
+    *,
+    outcome: str = "ready",
+    readiness: str = "ready",
+    moderation: str = "not_required",
+) -> object:
+    return SimpleNamespace(
+        review_outcome=outcome,
+        scoring_readiness=readiness,
+        moderation_requirement=moderation,
+        notes="private teacher note",
+        reviewer_display_label="Private Teacher",
+    )
+
+
+def test_evidence_only_activity_never_gets_routine_score_attention(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        scoring_attention,
+        "show_activity",
+        lambda *_a, **_k: _activity("evidence_only"),
+    )
+    seen: list[str] = []
+
+    def _review_reader(*_args: object, **_kwargs: object) -> object:
+        seen.append("review")
+        return _review()
+
+    monkeypatch.setattr(
+        scoring_attention,
+        "current_artifact_review",
+        _review_reader,
+    )
+    result = scoring_attention.inspect_artifact_scoring_attention_state(
+        "class-1", "activity-1", "artifact-1"
+    )
+    assert not result.scoring_ready
+    assert seen == []
+
+
+@pytest.mark.parametrize(
+    ("orientation", "outcome", "readiness", "moderation"),
+    (
+        ("local_criteria_only", "ready", "ready", "not_required"),
+        (
+            "standards_based",
+            "ready_with_qualification",
+            "ready_with_qualification",
+            "not_required",
+        ),
+        ("mixed", "ready", "ready", "completed"),
+    ),
+)
+def test_explicit_current_review_can_establish_mechanical_scoring_readiness(
+    monkeypatch: pytest.MonkeyPatch,
+    orientation: str,
+    outcome: str,
+    readiness: str,
+    moderation: str,
+) -> None:
+    monkeypatch.setattr(
+        scoring_attention,
+        "show_activity",
+        lambda *_a, **_k: _activity(orientation),
+    )
+    monkeypatch.setattr(
+        scoring_attention,
+        "current_artifact_review",
+        lambda *_a, **_k: _review(
+            outcome=outcome,
+            readiness=readiness,
+            moderation=moderation,
+        ),
+    )
+    result = scoring_attention.inspect_artifact_scoring_attention_state(
+        "class-1", "activity-1", "artifact-private-id"
+    )
+    assert result.scoring_ready
+    rendered = repr(result)
+    assert "private teacher note" not in rendered
+    assert "Private Teacher" not in rendered
+
+
+@pytest.mark.parametrize(
+    ("review",),
+    (
+        (None,),
+        (_review(outcome="incomplete", readiness="not_ready"),),
+        (
+            _review(
+                outcome="moderation_required",
+                readiness="not_ready",
+                moderation="required",
+            ),
+        ),
+        (
+            _review(
+                outcome="not_suitable_for_scoring",
+                readiness="not_ready",
+            ),
+        ),
+    ),
+)
+def test_absence_or_nonready_review_does_not_infer_missing_score(
+    monkeypatch: pytest.MonkeyPatch,
+    review: object | None,
+) -> None:
+    monkeypatch.setattr(
+        scoring_attention,
+        "show_activity",
+        lambda *_a, **_k: _activity("mixed"),
+    )
+    monkeypatch.setattr(
+        scoring_attention,
+        "current_artifact_review",
+        lambda *_a, **_k: review,
+    )
+    result = scoring_attention.inspect_artifact_scoring_attention_state(
+        "class-1", "activity-1", "artifact-1"
+    )
+    assert not result.scoring_ready

--- a/tests/test_attention_provider_issue67.py
+++ b/tests/test_attention_provider_issue67.py
@@ -1,0 +1,350 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from pds_core.module_operations import ModuleOperationsRequest
+from pds_core.routing_models import ModuleWorkRef
+
+import concord.attention_provider as provider
+from concord.storage_errors import ConcordStorageIntegrityError
+from concord.workflows.activity_attention import (
+    ActivityAttentionItem,
+    ActivityAttentionSummary,
+)
+
+
+def _work(class_id: str, activity_id: str) -> ModuleWorkRef:
+    return ModuleWorkRef(
+        module_id="concord",
+        class_id=class_id,
+        work_id=activity_id,
+    )
+
+
+def _summary(
+    class_id: str,
+    activity_id: str,
+    *,
+    code: str = "concord_plan_approve",
+    label: str = "Group plans are waiting for teacher approval",
+    count: int = 1,
+    action_id: str = "open_activity_plan",
+) -> ActivityAttentionSummary:
+    return ActivityAttentionSummary(
+        class_id=class_id,
+        activity_id=activity_id,
+        title=f"Activity {activity_id}",
+        items=(
+            ActivityAttentionItem(
+                code=code,
+                label=label,
+                task="plan",
+                count=count,
+                action_id=action_id,
+            ),
+        ),
+    )
+
+
+def _resolved_root(monkeypatch: pytest.MonkeyPatch, root: Path) -> None:
+    monkeypatch.setattr(
+        provider,
+        "resolve_read_workspace_root",
+        lambda _root: root,
+    )
+
+
+def test_missing_explicit_workspace_is_unavailable() -> None:
+    report = provider.evaluate_concord_attention(ModuleOperationsRequest())
+    assert report.evaluation == "unavailable"
+    assert report.summaries == ()
+    assert [notice.code for notice in report.notices] == [
+        "concord_attention_unavailable"
+    ]
+
+
+def test_valid_scope_with_no_activities_is_evaluated_empty(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _resolved_root(monkeypatch, tmp_path)
+    monkeypatch.setattr(provider, "list_activity_work_refs", lambda *_args: ())
+
+    report = provider.evaluate_concord_attention(
+        ModuleOperationsRequest(
+            workspace_root=tmp_path,
+            class_id="class-1",
+        )
+    )
+
+    assert report.evaluation == "evaluated"
+    assert report.summaries == ()
+    assert report.notices == ()
+
+
+def test_exact_class_filter_is_used_for_discovery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _resolved_root(monkeypatch, tmp_path)
+    seen: list[str] = []
+
+    def _refs(_root: Path, class_id: str) -> tuple[ModuleWorkRef, ...]:
+        seen.append(class_id)
+        return ()
+
+    monkeypatch.setattr(provider, "list_activity_work_refs", _refs)
+
+    provider.evaluate_concord_attention(
+        ModuleOperationsRequest(
+            workspace_root=tmp_path,
+            class_id="class-exact",
+        )
+    )
+
+    assert seen == ["class-exact"]
+
+
+def test_aggregate_preserves_single_work_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _resolved_root(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        provider,
+        "list_activity_work_refs",
+        lambda *_args: (_work("class-1", "activity-1"),),
+    )
+    monkeypatch.setattr(
+        provider,
+        "inspect_activity_attention",
+        lambda *_args, **_kwargs: _summary("class-1", "activity-1", count=3),
+    )
+
+    report = provider.evaluate_concord_attention(
+        ModuleOperationsRequest(
+            workspace_root=tmp_path,
+            class_id="class-1",
+        )
+    )
+
+    assert len(report.summaries) == 1
+    summary = report.summaries[0]
+    assert summary.code == "concord_plan_approve"
+    assert summary.count == 3
+    assert summary.class_id == "class-1"
+    assert summary.work_ref == _work("class-1", "activity-1")
+    assert summary.action is not None
+    assert summary.action.module_id == "concord"
+    assert summary.action.action_id == "open_activity_plan"
+
+
+def test_multi_activity_aggregate_omits_ambiguous_work_ref(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _resolved_root(monkeypatch, tmp_path)
+    works = (
+        _work("class-1", "activity-a"),
+        _work("class-1", "activity-b"),
+    )
+    monkeypatch.setattr(provider, "list_activity_work_refs", lambda *_args: works)
+    monkeypatch.setattr(
+        provider,
+        "inspect_activity_attention",
+        lambda class_id, activity_id, **_kwargs: _summary(
+            class_id,
+            activity_id,
+            count=2,
+        ),
+    )
+
+    report = provider.evaluate_concord_attention(
+        ModuleOperationsRequest(
+            workspace_root=tmp_path,
+            class_id="class-1",
+        )
+    )
+
+    summary = report.summaries[0]
+    assert summary.count == 4
+    assert summary.class_id == "class-1"
+    assert summary.work_ref is None
+
+
+def test_workspace_aggregate_omits_ambiguous_class_and_work_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _resolved_root(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        provider,
+        "list_available_classes",
+        lambda _root: (
+            SimpleNamespace(class_id="class-a"),
+            SimpleNamespace(class_id="class-b"),
+        ),
+    )
+    monkeypatch.setattr(
+        provider,
+        "list_activity_work_refs",
+        lambda _root, class_id: (_work(class_id, f"{class_id}-activity"),),
+    )
+    monkeypatch.setattr(
+        provider,
+        "inspect_activity_attention",
+        lambda class_id, activity_id, **_kwargs: _summary(class_id, activity_id),
+    )
+
+    report = provider.evaluate_concord_attention(
+        ModuleOperationsRequest(workspace_root=tmp_path)
+    )
+
+    summary = report.summaries[0]
+    assert summary.count == 2
+    assert summary.class_id is None
+    assert summary.work_ref is None
+
+
+def test_partial_activity_failure_preserves_unrelated_attention(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _resolved_root(monkeypatch, tmp_path)
+    works = (
+        _work("class-1", "good"),
+        _work("class-1", "bad"),
+    )
+    monkeypatch.setattr(provider, "list_activity_work_refs", lambda *_args: works)
+
+    def _inspect(
+        class_id: str,
+        activity_id: str,
+        **_kwargs: object,
+    ) -> ActivityAttentionSummary:
+        if activity_id == "bad":
+            raise ConcordStorageIntegrityError("private corrupt path detail")
+        return _summary(class_id, activity_id)
+
+    monkeypatch.setattr(provider, "inspect_activity_attention", _inspect)
+
+    report = provider.evaluate_concord_attention(
+        ModuleOperationsRequest(
+            workspace_root=tmp_path,
+            class_id="class-1",
+        )
+    )
+
+    assert report.evaluation == "evaluated"
+    assert len(report.summaries) == 1
+    assert report.summaries[0].count == 1
+    assert [notice.code for notice in report.notices] == [
+        "concord_attention_partial"
+    ]
+    assert "private corrupt path detail" not in repr(report)
+
+
+def test_foundational_requested_scope_failure_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _resolved_root(monkeypatch, tmp_path)
+
+    def _broken(*_args: object) -> tuple[ModuleWorkRef, ...]:
+        raise ConcordStorageIntegrityError("unsafe class work collection")
+
+    monkeypatch.setattr(provider, "list_activity_work_refs", _broken)
+
+    report = provider.evaluate_concord_attention(
+        ModuleOperationsRequest(
+            workspace_root=tmp_path,
+            class_id="class-1",
+        )
+    )
+
+    assert report.evaluation == "unavailable"
+    assert report.summaries == ()
+    assert report.notices[0].code == "concord_attention_unavailable"
+    assert "unsafe class work collection" not in repr(report)
+
+
+def test_unrequested_class_discovery_failure_is_partial(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _resolved_root(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        provider,
+        "list_available_classes",
+        lambda _root: (
+            SimpleNamespace(class_id="good-class"),
+            SimpleNamespace(class_id="bad-class"),
+        ),
+    )
+
+    def _refs(_root: Path, class_id: str) -> tuple[ModuleWorkRef, ...]:
+        if class_id == "bad-class":
+            raise ConcordStorageIntegrityError("unsafe")
+        return (_work(class_id, "activity-1"),)
+
+    monkeypatch.setattr(provider, "list_activity_work_refs", _refs)
+    monkeypatch.setattr(
+        provider,
+        "inspect_activity_attention",
+        lambda class_id, activity_id, **_kwargs: _summary(class_id, activity_id),
+    )
+
+    report = provider.evaluate_concord_attention(
+        ModuleOperationsRequest(workspace_root=tmp_path)
+    )
+
+    assert report.evaluation == "evaluated"
+    assert len(report.summaries) == 1
+    assert report.summaries[0].class_id == "good-class"
+    assert report.notices[0].code == "concord_attention_partial"
+
+
+def test_unexpected_provider_failure_is_not_flattened(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _resolved_root(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        provider,
+        "list_activity_work_refs",
+        lambda *_args: (_work("class-1", "activity-1"),),
+    )
+
+    def _bug(*_args: object, **_kwargs: object) -> ActivityAttentionSummary:
+        raise RuntimeError("synthetic programming failure")
+
+    monkeypatch.setattr(provider, "inspect_activity_attention", _bug)
+
+    with pytest.raises(RuntimeError, match="synthetic programming failure"):
+        provider.evaluate_concord_attention(
+            ModuleOperationsRequest(
+                workspace_root=tmp_path,
+                class_id="class-1",
+            )
+        )
+
+
+def test_active_school_year_does_not_invent_attention_semantics(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _resolved_root(monkeypatch, tmp_path)
+    monkeypatch.setattr(provider, "list_activity_work_refs", lambda *_args: ())
+
+    report = provider.evaluate_concord_attention(
+        ModuleOperationsRequest(
+            workspace_root=tmp_path,
+            active_school_year="2026-2027",
+            class_id="class-1",
+        )
+    )
+
+    assert report.evaluation == "evaluated"
+    assert report.summaries == ()

--- a/tests/test_attention_qualification_issue67.py
+++ b/tests/test_attention_qualification_issue67.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "v0.3.0-activity-attention-next-actions.md"
+SMOKE = ROOT / "scripts" / "smoke_test_attention_provider_wheel.py"
+
+
+def test_normative_attention_document_records_issue67_boundaries() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    required = (
+        "ActivityAttentionItem",
+        "ActivityAttentionSummary",
+        "inspect_activity_attention",
+        "list_activity_attention",
+        "attention != readiness",
+        "Plan -> Prepare -> Collect -> Review -> Score -> Share",
+        "concord_score_ready",
+        "concord_share_publish",
+        "concord_attention_partial",
+        "concord_attention_unavailable",
+        "paper_data_suite.module_operations",
+        "concord.pds_operations:get_module_operations_profile",
+        "readiness_provider = None",
+        "A. Open next action",
+        "A. Attention needed",
+        "scripts/smoke_test_attention_provider_wheel.py",
+        "pds-core>=0.6.3,<0.7",
+    )
+    for phrase in required:
+        assert phrase in text
+
+
+def test_package_declares_exact_module_operations_entry_point() -> None:
+    data = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    groups = data["project"]["entry-points"]
+    assert groups["paper_data_suite.module_operations"] == {
+        "concord": "concord.pds_operations:get_module_operations_profile"
+    }
+
+
+def test_package_checker_requires_operations_provider_and_files() -> None:
+    text = (ROOT / "scripts" / "check_package.py").read_text(encoding="utf-8")
+    assert "[paper_data_suite.module_operations]" in text
+    assert "concord = concord.pds_operations:get_module_operations_profile" in text
+    assert "The Concord module-operations entry point must occur exactly once." in text
+    assert '"paper-data-suite"' in text
+    for path in (
+        "concord/attention_provider.py",
+        "concord/pds_operations.py",
+        "concord/workflows/activity_attention.py",
+        "concord/academic_result_share_attention.py",
+    ):
+        assert path in text
+
+
+def test_repository_validation_runs_installed_attention_smoke() -> None:
+    text = (ROOT / "scripts" / "validate_repository.py").read_text(
+        encoding="utf-8"
+    )
+    assert "scripts/smoke_test_attention_provider_wheel.py" in text
+
+
+def test_installed_smoke_isolated_and_uses_core_invocation() -> None:
+    text = SMOKE.read_text(encoding="utf-8")
+    required = (
+        'env.pop("PYTHONPATH", None)',
+        'env["PYTHONNOUSERSITE"] = "1"',
+        '"-I"',
+        "diagnose_core_providers",
+        "invoke_module_attention",
+        "invoke_module_readiness",
+        '"module_operations.capability_absent"',
+        '"module_operations.evaluated"',
+        '"module_operations.evaluation_unavailable"',
+        '"concord_plan_prepare"',
+        '"concord_attention_unavailable"',
+        "fingerprint(root)",
+        "assert after == before",
+        '"paper-data-suite"',
+        '"quillan"',
+        '"pds-meridian"',
+    )
+    for phrase in required:
+        assert phrase in text
+
+
+def test_documentation_validation_requires_attention_document() -> None:
+    text = (ROOT / "scripts" / "check_documentation.py").read_text(
+        encoding="utf-8"
+    )
+    assert "ACTIVITY_ATTENTION_NEXT_ACTIONS_DOC" in text
+    assert "REQUIRED_ACTIVITY_ATTENTION_NEXT_ACTIONS_PHRASES" in text
+    assert "v0.3.0-activity-attention-next-actions.md" in text
+
+
+def test_active_docs_expose_attention_navigation_and_issue68_boundary() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    docs_index = (ROOT / "docs" / "README.md").read_text(encoding="utf-8")
+    cli = (ROOT / "docs" / "cli-contract.md").read_text(encoding="utf-8")
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    assert "v0.3.0-activity-attention-next-actions.md" in readme
+    assert "v0.3.0-activity-attention-next-actions.md" in docs_index
+    assert "A. Open next action" in cli
+    assert "A. Attention needed" in cli
+    assert "readiness_provider=None" in changelog

--- a/tests/test_pds_operations_issue67.py
+++ b/tests/test_pds_operations_issue67.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pds_core.module_operations import (
+    MODULE_OPERATIONS_CONTRACT_VERSION,
+    ModuleOperationsRequest,
+    invoke_module_attention,
+    invoke_module_readiness,
+    validate_module_operations_profile,
+)
+
+from concord.pds_operations import get_module_operations_profile
+
+
+def test_profile_exposes_attention_only_for_issue67() -> None:
+    profile = get_module_operations_profile()
+    assert validate_module_operations_profile(profile) is profile
+    assert profile.module_id == "concord"
+    assert profile.supported_core_operations_contract_versions == frozenset(
+        {MODULE_OPERATIONS_CONTRACT_VERSION}
+    )
+    assert profile.attention_provider is not None
+    assert profile.readiness_provider is None
+
+
+def test_core_invocation_preserves_absent_readiness_and_unavailable_attention() -> None:
+    profile = get_module_operations_profile()
+    request = ModuleOperationsRequest()
+
+    readiness = invoke_module_readiness(profile, request)
+    attention = invoke_module_attention(profile, request)
+
+    assert readiness.code == "module_operations.capability_absent"
+    assert readiness.report is None
+    assert attention.code == "module_operations.evaluation_unavailable"
+    assert attention.report is not None
+    assert attention.report.evaluation == "unavailable"
+
+
+def test_pyproject_registers_exact_concord_operations_entry_point() -> None:
+    text = Path("pyproject.toml").read_text(encoding="utf-8")
+    assert '[project.entry-points."paper_data_suite.module_operations"]' in text
+    assert (
+        'concord = "concord.pds_operations:get_module_operations_profile"'
+        in text
+    )
+    assert text.count(
+        '[project.entry-points."paper_data_suite.module_operations"]'
+    ) == 1


### PR DESCRIPTION
## Summary

Implements #67 by adding a Concord-owned, read-only teacher-attention projection over current Activity state, integrating bounded next-action guidance into the teacher UI, and exposing the same attention facts through Core's released v1 `paper_data_suite.module_operations` contract.

This completes the distinction introduced by #66:

```text
#66: Where does the teacher go to do a task?
#67: What currently needs the teacher's attention?
```

The implementation preserves:

```text
attention
!=
readiness
!=
diagnostics
!=
launchability
!=
publication authorization
!=
educational priority
```

Readiness remains deliberately deferred to #68.

## What changed

### Concord-native attention projection

Adds a presentation-neutral native attention model and read-only services for current Activities.

Attention is derived from authoritative Concord/Core state and is never persisted as a second source of truth.

The fixed operational order is:

```text
Plan
Prepare
Collect
Review
Score
Share
```

The first truthful item in that order becomes the Activity's next action.

This ordering is navigation only; it does not represent urgency, severity, student risk, educational priority, or cross-module ranking.

### Plan attention

Adds deterministic attention for current GroupPlan states including:

* draft plans still needing preparation;
* unresolved placements;
* previewed plans awaiting teacher approval;
* approved plans ready to apply.

No GroupPlan means no automatic planning attention.

Signal-backed planning remains privacy-minimized: grouping-signal values, dimensions, bands, digests, and student-level findings are not exposed.

### Prepare attention

Adds attention for current PacketInstance preparation states including:

* materials still being prepared;
* routing preparation requiring recovery;
* failed generation requiring teacher recovery.

Generated and cancelled Packet Instances are not treated as pending.

Attention inspection performs no rendering, recovery, resume, routing, or other canonical write.

### Collect attention

Adds a pure Artifact collection projection covering:

* returned evidence awaiting assembly;
* returned/assembled evidence with pending Author confirmation;
* returned/assembled evidence with pending Subject confirmation.

The implementation preserves:

```text
Author != Subject
Membership != authorship
Author != automatic Subject
```

Expected-but-not-returned pages are not incorrectly surfaced as assembly attention.

### Review and Moderation attention

Adds current-head Review attention for:

* assembled evidence ready for first Review;
* current Review states needing teacher attention;
* evidence requiring Moderation;
* Reviews that need updating after an applicable Moderation decision.

Moderation completion and Score eligibility remain separate concepts. An applicable Moderation decision satisfies the need to perform Moderation even if the decision does not authorize Score use.

Historical or incorrectly scoped Review/Moderation records do not satisfy current state.

### Score attention

Adds conservative Score guidance:

```text
Reviewed evidence is ready for scoring
```

This is emitted only for non-`evidence_only` Activities when current explicit Review state is mechanically scoring-ready and required Moderation is satisfied.

The implementation deliberately does not infer:

```text
no Score record == missing Score
```

and does not create an expected Score matrix across students, Groups, Sessions, Activities, or Artifacts.

### Share attention

Adds read-only publication/share attention for:

* registered current results needing a manifest;
* current results ready for explicit first publication;
* newer current results ready for supersession;
* withdrawn publication requiring teacher review;
* inconsistent sharing state requiring inspection.

A never-shared Activity does not receive an automatic publication nag, and an already-current publication produces no Share attention.

Manifest inspection uses the existing read-only preview/reconciliation authorities and performs zero publication writes.

## Teacher-facing integration

Opened Activities retain the exact #66 numbering:

```text
1. Plan
2. Prepare
3. Collect
4. Review
5. Score
6. Share
7. Advanced Activity tools
```

When attention exists, the Activity screen adds a bounded:

```text
A. Open next action
```

option.

The next action routes back into the existing #66 task menu rather than duplicating workflow implementation.

Stable owner-action IDs are:

```text
open_activity_plan
open_activity_prepare
open_activity_collect
open_activity_review
open_activity_score
open_activity_share
```

Activity Management also gains:

```text
A. Attention needed
```

for deterministic cross-Activity discovery.

The attention screens follow the existing low-information-density clear/redraw contract and do not expose raw record internals.

## Core `module_operations` integration

Adds:

```toml
[project.entry-points."paper_data_suite.module_operations"]
concord = "concord.pds_operations:get_module_operations_profile"
```

The Concord operations profile is equivalent to:

```python
ModuleOperationsProfile(
    module_id="concord",
    supported_core_operations_contract_versions=frozenset({"1"}),
    attention_provider=evaluate_concord_attention,
    readiness_provider=None,
)
```

`concord.pds_operations` remains thin and lazy-loads the heavier attention implementation.

The Core-facing adapter:

* maps native Concord attention into bounded `ModuleAttentionReport` values;
* aggregates by stable Concord attention code;
* uses opaque `ModuleOwnerActionRef` values for owner routing;
* preserves exact class/work context only when unambiguous;
* avoids student identity, evidence content, grouping signals, scores, paths, hashes, publication IDs, Packet IDs, raw payloads, and teacher rationale;
* distinguishes partial evaluation from foundational unavailability;
* does not introduce priority/risk/severity fields.

Concord's routing, publication-producer, and module-operations profiles continue to coexist independently under the same `concord` module identity.

## Installed qualification and packaging

Adds dedicated isolated-wheel acceptance:

```text
scripts/smoke_test_attention_provider_wheel.py
```

and integrates it with the canonical repository validator.

The installed smoke proves that:

* the candidate Concord wheel works with exact `pds-core` 0.6.3;
* no `paper-data-suite`, ScoreForm, Quillan, Meridian, Portia, or Vitrine installation is required;
* the installed `paper_data_suite.module_operations` entry point is discoverable;
* the profile validates through Core;
* routing, publication, and operations providers coexist;
* attention can be invoked through Core;
* a real draft GroupPlan produces bounded native/Core attention;
* shared attention does not leak student/group/private identities;
* attention evaluation leaves the workspace byte-for-byte unchanged;
* readiness remains absent for the #68 handoff;
* a missing workspace reports evaluation unavailable rather than false success.

Package validation now also requires exactly one Concord module-operations entry point and rejects an accidental `paper-data-suite` runtime dependency.

## Documentation

Adds:

```text
docs/v0.3.0-activity-attention-next-actions.md
```

and updates the active README, documentation index, CLI/menu contract, changelog, and documentation validator.

The normative document records:

* all stable attention codes;
* labels and count units;
* stable owner-action IDs;
* Plan → Share ordering;
* privacy boundaries;
* Score conservatism;
* Share optionality;
* partial/unavailable semantics;
* the Core adapter contract;
* the explicit #68 readiness boundary.

## Validation

Final repository qualification completed successfully against:

```text
pds-core 0.6.3
pds-concord 0.3.0.dev0
Python 3.11.9
```

Qualification included:

* full pytest suite;
* Ruff;
* mypy;
* documentation validation;
* release-compatibility validation;
* wheel and sdist build;
* `twine check`;
* package validation;
* release-artifact validation;
* existing isolated installed-wheel smoke suites;
* new isolated installed attention-provider acceptance;
* `git diff --check`.

The candidate wheel and sdist built successfully, package validation passed, and the installed attention-provider smoke completed successfully against exact Core 0.6.3.

## Boundaries preserved

This PR does **not**:

* add readiness evaluation;
* modify the suite shell;
* modify `pds doctor`;
* modify suite launcher policy;
* implement mixed-module paper intake;
* implement suite-level Attention Needed aggregation;
* add a `paper-data-suite` runtime dependency;
* add a ScoreForm, Quillan, Meridian, Portia, or other sibling-module dependency;
* persist attention or next-action state;
* infer student risk, urgency, educational priority, Grade, or proficiency;
* change publication authorization semantics.

Issue #68 can now extend the same `ModuleOperationsProfile` by adding a readiness provider without introducing a second operations-provider family.

Closes #67
