### PR TITLE
93 optimize validation performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        python: ["3.11", "3.12", "3.13", "3.14"]
+        include:
+          - os: ubuntu-latest
+            python: "3.11"
+            complete: true
+          - os: ubuntu-latest
+            python: "3.12"
+            complete: false
+          - os: ubuntu-latest
+            python: "3.13"
+            complete: false
+          - os: ubuntu-latest
+            python: "3.14"
+            complete: false
+          - os: windows-latest
+            python: "3.11"
+            complete: false
+          - os: windows-latest
+            python: "3.12"
+            complete: false
+          - os: windows-latest
+            python: "3.13"
+            complete: false
+          - os: windows-latest
+            python: "3.14"
+            complete: true
 
     runs-on: ${{ matrix.os }}
 
@@ -44,22 +67,13 @@ jobs:
             $coreDirectory `
             "pds-core-0.6.1-grouping-signal-fixtures.zip"
 
-          $ruffCache = Join-Path $env:RUNNER_TEMP "ruff-cache"
-          $mypyCache = Join-Path $env:RUNNER_TEMP "mypy-cache"
-
           "PDS_CORE_WHEEL=$coreWheel" |
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
           "PDS_CORE_GROUPING_FIXTURES=$coreGroupingFixtures" |
             Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
-          "RUFF_CACHE_DIR=$ruffCache" |
-            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-          "MYPY_CACHE_DIR=$mypyCache" |
-            Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-
-      - name: Download official Core release wheel
+      - name: Download official Core release inputs
         shell: pwsh
         run: |
           Invoke-WebRequest `
@@ -76,15 +90,22 @@ jobs:
             -OutFile $env:PDS_CORE_GROUPING_FIXTURES `
             -ErrorAction Stop
 
-          if (-not (Test-Path -LiteralPath $env:PDS_CORE_GROUPING_FIXTURES -PathType Leaf)) {
-            throw "Core grouping fixture download did not create $env:PDS_CORE_GROUPING_FIXTURES."
+          if (
+            -not (
+              Test-Path `
+                -LiteralPath $env:PDS_CORE_GROUPING_FIXTURES `
+                -PathType Leaf
+            )
+          ) {
+            throw "Core grouping fixture download did not create the expected file."
           }
 
       - name: Authenticate and install Core
         shell: pwsh
         run: |
           python scripts/verify_core_wheel.py "$env:PDS_CORE_WHEEL"
-          python scripts/verify_core_grouping_fixtures.py "$env:PDS_CORE_GROUPING_FIXTURES"
+          python scripts/verify_core_grouping_fixtures.py `
+            "$env:PDS_CORE_GROUPING_FIXTURES"
           python -m pip install "$env:PDS_CORE_WHEEL"
 
       - name: Install Concord development dependencies
@@ -103,70 +124,28 @@ jobs:
             }
           }
 
-      - name: Verify installed dependency boundary
+      - name: Run compatibility validation
+        if: ${{ matrix.complete == false }}
         shell: pwsh
         run: |
           python scripts/verify_core_wheel.py --installed
           python -m pip check
-
-      - name: Test
-        shell: pwsh
-        run: >-
-          python -m pytest
-          --basetemp "${{ runner.temp }}/pytest"
-          -o cache_dir="${{ runner.temp }}/pytest-cache"
-
-      - name: Lint and type-check
-        shell: pwsh
-        run: |
-          python -m ruff check .
-          python -m mypy --cache-dir "$env:MYPY_CACHE_DIR"
-
-      - name: Check documentation
-        run: python scripts/check_documentation.py
-
-      - name: Verify release compatibility
-        run: python scripts/verify_release_compatibility.py
-
-      - name: Build and validate distributions
-        shell: pwsh
-        run: |
-          $dist = Join-Path $env:RUNNER_TEMP "dist"
-
-          python -m build --outdir $dist
-          python -m twine check "$dist/*"
-
-          $wheels = @(
-            Get-ChildItem `
-              -LiteralPath $dist `
-              -Filter "*.whl" `
-              -File
-          )
-
-          if ($wheels.Count -ne 1) {
-            throw "Expected exactly one Concord wheel; found $($wheels.Count)."
-          }
-
-          $concordWheel = $wheels[0].FullName
-
-          python scripts/check_package.py "$concordWheel"
-          python scripts/verify_release_artifacts.py "$dist"
-          python scripts/smoke_test_wheel.py `
-            "$concordWheel" `
-            "$env:PDS_CORE_WHEEL"
-
-          python scripts/smoke_test_activity_copying_wheel.py `
-            "$concordWheel" `
-            "$env:PDS_CORE_WHEEL"
-
-      - name: Verify repository hygiene
-        shell: pwsh
-        run: |
+          python -c "import concord"
+          python -m pytest `
+            --basetemp "${{ runner.temp }}/pytest" `
+            -o cache_dir="${{ runner.temp }}/pytest-cache" `
+            --durations=25
           git diff --check
 
           $residue = git status --porcelain --untracked-files=all
-
           if ($residue) {
             $residue
-            throw "Validation left tracked or untracked repository residue."
+            throw "Compatibility validation left repository residue."
           }
+
+      - name: Run complete repository qualification
+        if: ${{ matrix.complete == true }}
+        shell: pwsh
+        run: |
+          python scripts/validate_repository.py `
+            --core-wheel "$env:PDS_CORE_WHEEL"

--- a/concord/storage.py
+++ b/concord/storage.py
@@ -257,10 +257,11 @@ def list_record_revisions(
     return tuple(sorted(result))
 
 
-def list_record_identities(
-    workspace_root: str | Path, work: ModuleWorkRef
-) -> tuple[tuple[str, str], ...]:
-    result: list[tuple[str, str]] = []
+def _list_record_history(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+) -> dict[tuple[str, str], tuple[int, ...]]:
+    result: dict[tuple[str, str], tuple[int, ...]] = {}
     for kind_path in _visible(records_path(workspace_root, work), "record kinds"):
         descriptor_for_kind(kind_path.name)
         if kind_path.is_symlink() or not kind_path.is_dir():
@@ -277,11 +278,20 @@ def list_record_identities(
                 raise ConcordStorageIntegrityError(
                     f"unexpected record identity contents: {identity_path}"
                 )
-            list_record_revisions(
-                workspace_root, work, kind_path.name, identity_path.name
+            identity = (kind_path.name, identity_path.name)
+            result[identity] = list_record_revisions(
+                workspace_root,
+                work,
+                identity[0],
+                identity[1],
             )
-            result.append((kind_path.name, identity_path.name))
-    return tuple(sorted(result))
+    return result
+
+
+def list_record_identities(
+    workspace_root: str | Path, work: ModuleWorkRef
+) -> tuple[tuple[str, str], ...]:
+    return tuple(sorted(_list_record_history(workspace_root, work)))
 
 
 def _load_snapshot_chain(
@@ -400,7 +410,7 @@ def load_record_graph_at_snapshot(
 def list_work_snapshots(
     workspace_root: str | Path, work: ModuleWorkRef
 ) -> tuple[int, ...]:
-    result: list[int] = []
+    entries: list[tuple[int, Path]] = []
     for path in _visible(snapshots_path(workspace_root, work), "snapshots"):
         if (
             path.is_symlink()
@@ -410,33 +420,60 @@ def list_work_snapshots(
             or path.stem.startswith("0")
         ):
             raise ConcordStorageIntegrityError(f"unexpected snapshot entry: {path}")
-        revision = int(path.stem)
-        load_work_snapshot(workspace_root, work, revision)
+        entries.append((int(path.stem), path))
+
+    entries.sort(key=lambda item: item[0])
+    previous_bytes: bytes | None = None
+    result: list[int] = []
+    for expected_revision, (revision, path) in enumerate(entries, start=1):
+        if revision != expected_revision:
+            raise ConcordStorageIntegrityError(
+                "snapshot history is noncontiguous or contains orphan revisions."
+            )
+        snapshot, snapshot_bytes = _parse(
+            path,
+            snapshot_from_dict,
+            missing=True,
+        )
+        if snapshot.work != work or snapshot.snapshot_revision != revision:
+            raise ConcordStorageIntegrityError(
+                "snapshot identity disagrees with its canonical path."
+            )
+        if revision > 1:
+            assert previous_bytes is not None
+            if snapshot.previous_snapshot_revision != revision - 1:
+                raise ConcordStorageIntegrityError(
+                    "snapshot predecessor revision mismatch."
+                )
+            if snapshot.previous_snapshot_sha256 != _sha(previous_bytes):
+                raise ConcordStorageIntegrityError(
+                    "snapshot predecessor digest mismatch."
+                )
+        _validated_snapshot_graph(workspace_root, work, snapshot)
+        previous_bytes = snapshot_bytes
         result.append(revision)
-    return tuple(sorted(result))
+    return tuple(result)
 
 
-def load_current_snapshot(
-    workspace_root: str | Path, work: ModuleWorkRef
-) -> ConcordCurrentSnapshot:
-    value, _ = _parse(
-        current_snapshot_path(workspace_root, work), current_from_dict, missing=True
+def _load_current_snapshot_state(
+    workspace_root: str | Path,
+    work: ModuleWorkRef,
+) -> tuple[
+    ConcordCurrentSnapshot,
+    ConcordWorkSnapshot,
+    str,
+    ConcordRecordGraph,
+]:
+    """Load and verify the current pointer, snapshot chain, and selected graph once."""
+    current, _ = _parse(
+        current_snapshot_path(workspace_root, work),
+        current_from_dict,
+        missing=True,
     )
-    if value.work != work:
+    if current.work != work:
         raise ConcordStorageIntegrityError(
             "current pointer work disagrees with canonical path."
         )
-    _, digest = load_work_snapshot(workspace_root, work, value.snapshot_revision)
-    if digest != value.snapshot_sha256:
-        raise ConcordStorageIntegrityError("current pointer snapshot digest mismatch.")
-    return value
-
-
-def load_current_record_graph(
-    workspace_root: str | Path, work: ModuleWorkRef, *, standards_library: Any = None
-) -> ConcordLoadedRecordGraph:
-    load_work_marker(workspace_root, work)
-    current = load_current_snapshot(workspace_root, work)
     snapshot, snapshot_bytes = _load_snapshot_chain(
         workspace_root,
         work,
@@ -448,8 +485,21 @@ def load_current_record_graph(
             "current pointer snapshot digest mismatch."
         )
     graph = _validated_snapshot_graph(workspace_root, work, snapshot)
+    return current, snapshot, snapshot_sha256, graph
+
+
+def load_current_snapshot(
+    workspace_root: str | Path, work: ModuleWorkRef
+) -> ConcordCurrentSnapshot:
+    current, _, _, _ = _load_current_snapshot_state(workspace_root, work)
+    return current
+
+
+def _validate_loaded_graph_standards(
+    graph: ConcordRecordGraph,
+    standards_library: Any,
+) -> None:
     try:
-        validate_record_graph(graph)
         requires_standards = (
             graph.activities[0].scoring_orientation in {"standards_based", "mixed"}
             or any(item.criterion_kind == "standard_backed" for item in graph.criteria)
@@ -471,6 +521,17 @@ def load_current_record_graph(
         raise ConcordStorageIntegrityError(
             f"current graph is invalid: {error}"
         ) from error
+
+
+def load_current_record_graph(
+    workspace_root: str | Path, work: ModuleWorkRef, *, standards_library: Any = None
+) -> ConcordLoadedRecordGraph:
+    load_work_marker(workspace_root, work)
+    current, _, snapshot_sha256, graph = _load_current_snapshot_state(
+        workspace_root,
+        work,
+    )
+    _validate_loaded_graph_standards(graph, standards_library)
     return ConcordLoadedRecordGraph(
         graph,
         current.snapshot_revision,
@@ -550,7 +611,8 @@ def _validate_canonical_write_history(
 ) -> None:
     try:
         snapshot_revisions = list_work_snapshots(workspace_root, work)
-        record_identities = list_record_identities(workspace_root, work)
+        record_history = _list_record_history(workspace_root, work)
+        record_identities = tuple(sorted(record_history))
     except ConcordStorageIntegrityError:
         raise
     except ConcordStorageError as error:
@@ -581,12 +643,7 @@ def _validate_canonical_write_history(
         )
 
     for identity, reference in sorted(selected.items()):
-        revisions = list_record_revisions(
-            workspace_root,
-            work,
-            identity[0],
-            identity[1],
-        )
+        revisions = record_history[identity]
         expected_revisions = tuple(range(1, reference.record_revision + 1))
         if revisions != expected_revisions:
             raise ConcordStorageIntegrityError(
@@ -854,13 +911,20 @@ def commit_record_batch(
                 "marker/current presence is contradictory."
             )
         if current_exists:
-            loaded = load_current_record_graph(
-                status.root, work, standards_library=standards_library
+            load_work_marker(status.root, work)
+            (
+                current,
+                current_snapshot,
+                current_snapshot_sha256,
+                current_graph,
+            ) = _load_current_snapshot_state(status.root, work)
+            _validate_loaded_graph_standards(current_graph, standards_library)
+            loaded = ConcordLoadedRecordGraph(
+                current_graph,
+                current.snapshot_revision,
+                current_snapshot_sha256,
             )
             current_revision = loaded.snapshot_revision
-            current_snapshot, _ = load_work_snapshot(
-                status.root, work, current_revision
-            )
             _validate_canonical_write_history(
                 status.root,
                 work,
@@ -969,9 +1033,7 @@ def commit_record_batch(
             raise ConcordStorageIntegrityError(
                 "orphan/colliding snapshot blocks commit."
             )
-        previous_digest = None
-        if current_revision:
-            _, previous_digest = load_work_snapshot(status.root, work, current_revision)
+        previous_digest = loaded.snapshot_sha256 if current_revision else None
         snapshot = ConcordWorkSnapshot(
             CONCORD_STORAGE_SCHEMA_VERSION,
             "concord_work_snapshot",

--- a/docs/README.md
+++ b/docs/README.md
@@ -386,6 +386,19 @@ grouping-signal/privacy exclusions, teacher next-action UI, Core v1
 read-only guarantees, #68 readiness boundary, and isolated installed-wheel
 qualification against released Core 0.6.3.
 
+
+### v0.3.0 validation and CI performance
+
+[`development/validation-performance.md`](development/validation-performance.md)
+
+Documents issue #93's measured validation baseline, stable timing diagnostics,
+installed-wheel environment de-duplication, in-operation immutable-history
+reuse, linear snapshot validation, single-pass record-history inspection,
+candidate release-wheel reuse, opt-in external Ruff/Mypy caches, factored
+eight-cell compatibility versus two-cell complete CI qualification, storage
+microbenchmark evidence, preserved fail-closed invariants, and measured
+before/after results.
+
 ### Future v0.3.0 Group Planning / Template / Packet plan
 
 [`pds-group-planning-interoperability-development-plan.md`](pds-group-planning-interoperability-development-plan.md)

--- a/docs/development/validation-performance.md
+++ b/docs/development/validation-performance.md
@@ -1,7 +1,7 @@
 # Concord validation and CI performance
 
-**Status:** Implemented for issue #93  
-**Applies to:** Concord `0.3.0.dev0` development validation  
+**Status:** Implemented for issue #93
+**Applies to:** Concord `0.3.0.dev0` development validation
 **Released Core baseline:** `pds-core` `0.6.3` / `pds-core>=0.6.3,<0.7`
 
 Issue #93 reduces Concord validation and CI cost without reducing substantive

--- a/docs/development/validation-performance.md
+++ b/docs/development/validation-performance.md
@@ -1,0 +1,493 @@
+# Concord validation and CI performance
+
+**Status:** Implemented for issue #93  
+**Applies to:** Concord `0.3.0.dev0` development validation  
+**Released Core baseline:** `pds-core` `0.6.3` / `pds-core>=0.6.3,<0.7`
+
+Issue #93 reduces Concord validation and CI cost without reducing substantive
+runtime, storage-integrity, packaging, installed-wheel, or cross-platform
+coverage.
+
+The governing rule is:
+
+```text
+faster validation != weaker validation
+```
+
+This work follows the sequence:
+
+```text
+measure
+    ->
+de-duplicate harness work
+    ->
+profile remaining runtime
+    ->
+optimize demonstrated hot paths
+    ->
+factor CI
+    ->
+remeasure
+```
+
+## Authoritative complete qualification
+
+The authoritative local complete repository gate remains:
+
+```powershell
+python scripts\validate_repository.py `
+  --core-wheel "<path-to-pds_core-0.6.3-py3-none-any.whl>"
+```
+
+For development on a dirty issue branch:
+
+```powershell
+python scripts\validate_repository.py `
+  --core-wheel "<path-to-pds_core-0.6.3-py3-none-any.whl>" `
+  --allow-dirty
+```
+
+The complete gate still establishes all of the following:
+
+- authenticated released Core compatibility;
+- Core grouping-fixture compatibility;
+- `pip check`;
+- full pytest;
+- Ruff;
+- strict Mypy;
+- documentation validation;
+- release-compatibility validation;
+- clean source-tree wheel and sdist construction;
+- Twine validation;
+- package-content policy;
+- release-artifact policy;
+- base installed candidate-wheel acceptance;
+- Activity-copying installed acceptance;
+- reusable-presets installed acceptance;
+- guided-Activity installed acceptance;
+- task-oriented-menu installed acceptance;
+- module-operations / readiness / attention installed acceptance;
+- `git diff --check`; and
+- repository-residue rejection unless `--allow-dirty` is explicitly used.
+
+Timing diagnostics are observational only. No validation phase has a wall-clock
+pass/fail threshold.
+
+## Measurement baseline
+
+The authoritative pre-optimization baseline was captured on Windows with Python
+3.11.9 using released Core `0.6.3`.
+
+```text
+Core wheel verification:                    0.184 s
+Core grouping fixtures:                     0.187 s
+pip check:                                  1.162 s
+pytest:                                   286.730 s
+Ruff:                                       0.238 s
+Mypy:                                       6.614 s
+documentation validation:                   0.200 s
+release compatibility:                      1.596 s
+source tree copy:                            0.378 s
+package build:                              23.430 s
+Twine:                                      0.607 s
+package content:                             0.166 s
+release artifacts:                           0.193 s
+installed-wheel smoke: base:                57.247 s
+installed-wheel smoke: Activity copying:    21.453 s
+installed-wheel smoke: reusable presets:    21.671 s
+installed-wheel smoke: guided Activity:     21.588 s
+installed-wheel smoke: task-oriented menu:  19.576 s
+installed-wheel smoke: module operations:   20.524 s
+git diff check:                              0.104 s
+TOTAL:                                     487.916 s
+```
+
+The preliminary approximately-909-second pytest observation that motivated
+issue #93 is not used as the comparison baseline because it came from a
+different run context.
+
+## Measured integration result
+
+After the main optimization tranche, a comparable complete validator
+integration run on the same Windows / Python 3.11.9 development environment reported:
+
+```text
+Core wheel verification:                             0.224 s
+Core grouping fixtures:                              0.076 s
+pip check:                                           0.329 s
+source tree copy:                                     0.271 s
+package build:                                       20.447 s
+pytest:                                             220.944 s
+Ruff:                                                0.182 s
+Mypy:                                                2.884 s
+documentation validation:                            0.205 s
+release compatibility:                               1.334 s
+Twine:                                               0.375 s
+package content:                                      0.123 s
+release artifacts:                                    0.166 s
+installed-wheel smoke: base:                         44.637 s
+installed-wheel smoke: shared feature scenarios:     21.962 s
+installed-wheel smoke: module operations:            19.037 s
+git diff check:                                       0.047 s
+TOTAL:                                              336.195 s
+```
+
+That run completed with validator exit code `0`.
+
+### Before / after summary
+
+| Measure | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Full pytest inside complete validation | 286.730 s | 220.944 s | -22.9% |
+| Four feature installed smokes | 84.288 s | 21.962 s | -73.9% |
+| All installed-wheel qualification | 162.059 s | 85.636 s | -47.2% |
+| Complete repository validation | 487.916 s | 336.195 s | -31.1% |
+
+The complete validator therefore saved `151.721 s` in the measured comparison
+while retaining the complete qualification boundary.
+
+A separate post-storage full pytest profile completed `1,315` tests with `11`
+expected platform skips in `216.31 s`. The later complete-validator run,
+after additional issue #93 tests were added and the candidate Core wheel was
+supplied, completed `1,318` tests with `10` expected skips in `220.54 s`
+(`220.944 s` validator phase time).
+
+## What changed
+
+### 1. Stable phase timing
+
+`scripts/validate_repository.py` now records each major phase with
+`time.perf_counter()` and prints a stable summary even when a later phase
+fails.
+
+Pytest runs with `--durations=25` so the slowest tests remain visible during
+complete qualification.
+
+### 2. Installed-wheel environment de-duplication
+
+The following installed feature scenarios still exist as independently
+runnable smoke scripts:
+
+```text
+scripts/smoke_test_activity_copying_wheel.py
+scripts/smoke_test_reusable_presets_wheel.py
+scripts/smoke_test_guided_activity_wheel.py
+scripts/smoke_test_task_oriented_activity_menu_wheel.py
+```
+
+Complete validation now executes those scenarios through:
+
+```text
+scripts/smoke_test_feature_wheels.py
+```
+
+That harness creates one fresh installed candidate-wheel environment, installs
+released Core and Concord once, runs `pip check` once, and then executes each
+feature scenario independently. Each scenario still creates its own fresh
+workspace and retains its own assertions and failure identity.
+
+The base installed producer acceptance and module-operations acceptance remain
+separate because they establish distinct qualification boundaries.
+
+### 3. Current graph read reuse
+
+Within one `load_current_record_graph()` operation, Concord now reuses the exact
+current pointer, verified snapshot chain, snapshot digest, and materialized graph
+instead of reconstructing the same immutable state more than once.
+
+There is no persistent canonical-state cache.
+
+### 4. Commit-state reuse
+
+`commit_record_batch()` now reuses already verified immutable current state
+during its pre-publication work rather than invoking equivalent public reads
+again.
+
+The final post-pointer `load_current_record_graph()` verification remains in
+place.
+
+### 5. Linear snapshot-history validation
+
+`list_work_snapshots()` now validates a snapshot history in one chronological
+pass.
+
+The old pattern validated each revision independently, repeatedly walking
+overlapping predecessor chains. The new traversal still verifies:
+
+- contiguous revisions;
+- canonical snapshot identity;
+- predecessor revision;
+- predecessor SHA-256;
+- every selected record digest and graph; and
+- the same corruption / orphan failure modes.
+
+Direct exact historical snapshot loads retain their full predecessor-chain
+validation.
+
+### 6. Single-pass record-history inspection
+
+Canonical write-history validation now obtains verified record revision history
+once per record identity and reuses those immutable results inside the same
+operation.
+
+Public `list_record_identities()` still validates the revisions behind each
+identity; validation has not been converted into an unverified directory
+listing.
+
+### 7. Candidate release wheel reuse inside pytest
+
+Complete validation now constructs the candidate release artifacts before
+pytest and supplies the exact candidate wheel through:
+
+```text
+PDS_CONCORD_TEST_WHEEL
+```
+
+The package-metadata pytest fixture validates that supplied wheel rather than
+building an equivalent second wheel.
+
+Ordinary standalone `python -m pytest` remains self-contained: when
+`PDS_CONCORD_TEST_WHEEL` is absent, the fixture still performs its own isolated
+wheel build.
+
+### 8. Opt-in reusable static-analysis caches
+
+Cold, disposable static-analysis caches remain the default.
+
+Developers may explicitly request reusable Ruff and Mypy caches:
+
+```powershell
+python scripts\validate_repository.py `
+  --core-wheel "<path-to-Core-wheel>" `
+  --allow-dirty `
+  --reuse-static-caches
+```
+
+The optional cache root is controlled by:
+
+```text
+PDS_CONCORD_VALIDATION_CACHE_ROOT
+```
+
+If not configured, a persistent directory under the operating system temporary
+area is used.
+
+The cache:
+
+- affects speed only;
+- is not canonical authority;
+- may be deleted at any time;
+- is rejected if it resolves inside the repository; and
+- does not alter validation coverage or pass/fail semantics.
+
+CI does not use `--reuse-static-caches`; complete CI qualification remains cold
+with respect to this development option.
+
+## Final cold qualification
+
+After all issue #93 implementation, CI factoring, cache-option, benchmark, and
+documentation changes were present, the default cold authoritative validator
+was run again without `--reuse-static-caches`.
+
+The final Windows / Python 3.11.9 qualification reported:
+
+```text
+Core wheel verification:                             0.116 s
+Core grouping fixtures:                              0.133 s
+pip check:                                           0.421 s
+source tree copy:                                     0.255 s
+package build:                                       19.696 s
+pytest:                                             197.694 s
+Ruff:                                                0.225 s
+Mypy:                                                5.112 s
+documentation validation:                            0.250 s
+release compatibility:                               1.724 s
+Twine:                                               0.573 s
+package content:                                      0.160 s
+release artifacts:                                    0.244 s
+installed-wheel smoke: base:                         51.630 s
+installed-wheel smoke: shared feature scenarios:     22.219 s
+installed-wheel smoke: module operations:            19.199 s
+git diff check:                                       0.043 s
+TOTAL:                                              322.901 s
+```
+
+That run completed with validator exit code `0`, with `1,330` tests passed and
+`10` expected platform skips.
+
+### Final before / after summary
+
+| Measure | Before | Final cold run | Change |
+| --- | ---: | ---: | ---: |
+| Full pytest inside complete validation | 286.730 s | 197.694 s | -31.1% |
+| Four feature installed smokes | 84.288 s | 22.219 s | -73.6% |
+| All installed-wheel qualification | 162.059 s | 93.048 s | -42.6% |
+| Complete repository validation | 487.916 s | 322.901 s | -33.8% |
+
+The final cold complete validator therefore saved `165.015 s` versus the
+authoritative pre-optimization baseline while retaining the complete
+qualification boundary.
+
+The earlier `336.195 s` run remains useful integration evidence showing the
+same optimization direction before the final documentation and benchmark
+coverage were added.
+
+## Canonical-storage benchmark
+
+Because issue #93 changed immutable-history traversal, the repository includes
+the diagnostic benchmark at
+`scripts/benchmark_storage_performance_issue93.py`:
+
+```powershell
+python scripts\benchmark_storage_performance_issue93.py `
+  --snapshots 12 `
+  --repetitions 5
+```
+
+The benchmark reconstructs the pre-#93 read patterns against the same synthetic
+canonical history and compares them with the optimized paths. It uses median
+`time.perf_counter()` measurements and defines no performance threshold.
+
+Measured Windows / Python 3.11.9 results:
+
+```text
+Issue #93 storage benchmark: 12 snapshots, 5 median repetitions
+list_work_snapshots:
+    legacy=0.078408 s
+    optimized=0.035175 s
+    55.1% faster
+
+load_current_record_graph:
+    legacy=0.022176 s
+    optimized=0.012696 s
+    42.7% faster
+
+record-history enumeration:
+    legacy=0.034541 s
+    optimized=0.017584 s
+    49.1% faster
+```
+
+These results are diagnostic evidence, not contractual timing guarantees.
+
+## Storage integrity preserved
+
+The optimization does not weaken Concord's fail-closed storage contract.
+Regression coverage specifically preserves:
+
+```text
+immutable record revisions
+snapshot predecessor revision verification
+snapshot predecessor SHA-256 verification
+current pointer digest verification
+record digest verification
+canonical identity/path agreement
+append-only semantics
+expected snapshot revision conflicts
+record graph validation
+Core standards validation
+work/class identity validation
+symlink/path-security protections
+pre-pointer failure semantics
+post-pointer verification
+partial-success boundaries
+orphan/corruption detection
+```
+
+Optimized history traversal continues to reject corruption in predecessor
+state, not only corruption at the current head.
+
+## CI factoring
+
+Supported runtime coverage remains:
+
+```text
+Ubuntu  x Python 3.11, 3.12, 3.13, 3.14
+Windows x Python 3.11, 3.12, 3.13, 3.14
+```
+
+All eight cells remain compatibility cells and prove:
+
+- authenticated Core release inputs;
+- Core install;
+- installed dependency boundary / `pip check`;
+- Concord import;
+- full pytest; and
+- repository hygiene / `git diff --check`.
+
+Complete qualification additionally runs on:
+
+```text
+Ubuntu / Python 3.11
+Windows / Python 3.14
+```
+
+Those reference cells delegate to the authoritative
+`scripts/validate_repository.py` gate and therefore add:
+
+- Ruff;
+- strict Mypy;
+- documentation;
+- release compatibility;
+- clean wheel + sdist construction;
+- Twine;
+- package-content validation;
+- release-artifact validation; and
+- every required installed-wheel acceptance scenario.
+
+This preserves both supported operating systems and spans the supported Python
+range while avoiding eight repetitions of platform-independent release
+qualification.
+
+The structural change reduces complete-qualification execution from eight CI
+cells to two, a 75% reduction in the number of cells performing that expensive
+tier. This is not presented as a 75% aggregate CI-time reduction: exact GitHub
+runner-time improvement must be taken from actual CI runs after the branch is
+pushed.
+
+## Remaining measured hotspots
+
+After the optimization tranche, the two slowest application-level pytest calls
+in the complete run were the starter-template install-all scenarios at
+approximately five seconds each:
+
+```text
+test_starter_install_all_installs_only_missing
+test_install_all_installs_thirty_and_replays_idempotently
+```
+
+They exercise real repeated canonical Template creation and idempotent replay.
+They were not optimized further in issue #93 because the measured remaining
+cost did not justify another storage-contract change after the larger duplicate
+history and qualification costs had been removed.
+
+Other individual slow tests were approximately one to three seconds and spread
+across Packet, publication, scoring, Artifact, and GroupPlan workflows rather
+than revealing another single dominant algorithmic hotspot.
+
+`pytest-xdist` was not introduced.
+
+## Development guidance
+
+For focused iteration, run the narrow affected tests plus Ruff/Mypy rather than
+repeated complete qualification.
+
+Use the complete validator at meaningful integration boundaries and before
+merge.
+
+Use `--reuse-static-caches` only as a local development acceleration. A clean
+default complete run remains the reference qualification result.
+
+When future validation cost increases materially, repeat the same method:
+
+```text
+measure first
+    ->
+identify duplicate proof or demonstrated hot path
+    ->
+optimize without changing authority
+    ->
+retain regression coverage
+    ->
+remeasure
+```

--- a/scripts/benchmark_storage_performance_issue93.py
+++ b/scripts/benchmark_storage_performance_issue93.py
@@ -1,0 +1,252 @@
+"""Benchmark issue #93 canonical-read optimizations without setting thresholds."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import tempfile
+import time
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable, TypeVar
+
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.workspace import ensure_workspace_root
+
+from concord import storage
+from concord.model_conversion import record_from_dict
+from concord.model_validation import validate_record_graph
+from concord.models import Activity, Session
+from concord.storage import commit_record_batch
+from concord.storage_errors import ConcordStorageIntegrityError
+from concord.storage_models import ConcordLoadedRecordGraph
+from concord.storage_paths import snapshots_path
+
+ROOT = Path(__file__).resolve().parents[1]
+FIXTURE = (
+    ROOT / "tests" / "fixtures" / "native_records" / "evidence_only_activity.json"
+)
+T = TypeVar("T")
+
+
+def _seed_history(
+    workspace_root: Path,
+    *,
+    snapshots: int,
+) -> tuple[Activity, Session]:
+    root = ensure_workspace_root(workspace_root)
+    metadata = create_class_metadata(
+        "class-1",
+        "2026-2027",
+        created_at=datetime(2026, 8, 29, tzinfo=timezone.utc),
+    )
+    write_class_metadata_for_class(root, metadata)
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    activity = record_from_dict("activity", fixture["records"][0]["body"])
+    session = record_from_dict("session", fixture["records"][1]["body"])
+    if not isinstance(activity, Activity) or not isinstance(session, Session):
+        raise RuntimeError("benchmark fixture did not produce Activity and Session")
+
+    committed = commit_record_batch(
+        root,
+        activity.work_reference,
+        (activity, session),
+        expected_snapshot_revision=None,
+    )
+    for revision in range(2, snapshots + 1):
+        committed = commit_record_batch(
+            root,
+            activity.work_reference,
+            (replace(session, notes=f"Benchmark revision {revision}."),),
+            expected_snapshot_revision=committed.snapshot_revision,
+        )
+    if committed.snapshot_revision != snapshots:
+        raise RuntimeError("benchmark history did not reach requested revision")
+    return activity, session
+
+
+def _legacy_list_work_snapshots(
+    workspace_root: Path,
+    activity: Activity,
+) -> tuple[int, ...]:
+    revisions: list[int] = []
+    for path in storage._visible(
+        snapshots_path(workspace_root, activity.work_reference),
+        "snapshots",
+    ):
+        if (
+            path.is_symlink()
+            or not path.is_file()
+            or not path.name.endswith(".json")
+            or not path.stem.isdigit()
+            or path.stem.startswith("0")
+        ):
+            raise ConcordStorageIntegrityError(
+                f"unexpected snapshot entry: {path}"
+            )
+        revision = int(path.stem)
+        storage.load_work_snapshot(
+            workspace_root,
+            activity.work_reference,
+            revision,
+        )
+        revisions.append(revision)
+    return tuple(sorted(revisions))
+
+
+def _legacy_load_current_record_graph(
+    workspace_root: Path,
+    activity: Activity,
+) -> ConcordLoadedRecordGraph:
+    storage.load_work_marker(workspace_root, activity.work_reference)
+    current = storage.load_current_snapshot(workspace_root, activity.work_reference)
+    snapshot, snapshot_bytes = storage._load_snapshot_chain(
+        workspace_root,
+        activity.work_reference,
+        current.snapshot_revision,
+    )
+    snapshot_sha256 = storage._sha(snapshot_bytes)
+    if snapshot_sha256 != current.snapshot_sha256:
+        raise ConcordStorageIntegrityError(
+            "current pointer snapshot digest mismatch."
+        )
+    graph = storage._validated_snapshot_graph(
+        workspace_root,
+        activity.work_reference,
+        snapshot,
+    )
+    validate_record_graph(graph)
+    return ConcordLoadedRecordGraph(
+        graph,
+        current.snapshot_revision,
+        snapshot_sha256,
+    )
+
+
+def _legacy_record_history_pass(
+    workspace_root: Path,
+    activity: Activity,
+) -> tuple[tuple[str, str], ...]:
+    identities = storage.list_record_identities(
+        workspace_root,
+        activity.work_reference,
+    )
+    for record_kind, record_id in identities:
+        storage.list_record_revisions(
+            workspace_root,
+            activity.work_reference,
+            record_kind,
+            record_id,
+        )
+    return identities
+
+
+def _current_record_history_pass(
+    workspace_root: Path,
+    activity: Activity,
+) -> tuple[tuple[str, str], ...]:
+    history = storage._list_record_history(
+        workspace_root,
+        activity.work_reference,
+    )
+    return tuple(sorted(history))
+
+
+def _time_call(
+    function: Callable[[], T],
+    *,
+    repetitions: int,
+) -> tuple[float, T]:
+    elapsed: list[float] = []
+    result: T | None = None
+    for _ in range(repetitions):
+        started = time.perf_counter()
+        result = function()
+        elapsed.append(time.perf_counter() - started)
+    assert result is not None
+    return statistics.median(elapsed), result
+
+
+def _format_change(before: float, after: float) -> str:
+    if before <= 0:
+        return "n/a"
+    reduction = (before - after) / before * 100
+    return f"{reduction:.1f}% faster"
+
+
+def benchmark(*, snapshots: int, repetitions: int) -> None:
+    with tempfile.TemporaryDirectory(prefix="pds-concord-issue93-benchmark-") as raw:
+        workspace = Path(raw) / "workspace"
+        activity, _ = _seed_history(workspace, snapshots=snapshots)
+
+        comparisons: tuple[
+            tuple[str, Callable[[], object], Callable[[], object]], ...
+        ] = (
+            (
+                "list_work_snapshots",
+                lambda: _legacy_list_work_snapshots(workspace, activity),
+                lambda: storage.list_work_snapshots(
+                    workspace,
+                    activity.work_reference,
+                ),
+            ),
+            (
+                "load_current_record_graph",
+                lambda: _legacy_load_current_record_graph(workspace, activity),
+                lambda: storage.load_current_record_graph(
+                    workspace,
+                    activity.work_reference,
+                ),
+            ),
+            (
+                "record-history enumeration",
+                lambda: _legacy_record_history_pass(workspace, activity),
+                lambda: _current_record_history_pass(workspace, activity),
+            ),
+        )
+
+        print(
+            f"Issue #93 storage benchmark: {snapshots} snapshots, "
+            f"{repetitions} median repetitions"
+        )
+        for label, legacy, current in comparisons:
+            before, legacy_result = _time_call(
+                legacy,
+                repetitions=repetitions,
+            )
+            after, current_result = _time_call(
+                current,
+                repetitions=repetitions,
+            )
+            if legacy_result != current_result:
+                raise RuntimeError(f"{label} benchmark paths disagree")
+            print(
+                f"{label}: legacy={before:.6f}s "
+                f"optimized={after:.6f}s "
+                f"({_format_change(before, after)})"
+            )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--snapshots", type=int, default=12)
+    parser.add_argument("--repetitions", type=int, default=5)
+    args = parser.parse_args()
+    if args.snapshots < 2:
+        parser.error("--snapshots must be at least 2")
+    if args.repetitions < 1:
+        parser.error("--repetitions must be positive")
+    benchmark(
+        snapshots=args.snapshots,
+        repetitions=args.repetitions,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_test_feature_wheels.py
+++ b/scripts/smoke_test_feature_wheels.py
@@ -1,0 +1,110 @@
+"""Run Concord feature smoke scenarios in one isolated installed-wheel environment."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import runpy
+import subprocess
+import tempfile
+import venv
+from collections.abc import Callable
+from pathlib import Path
+from typing import cast
+
+ROOT = Path(__file__).resolve().parents[1]
+SmokeSource = Callable[[], str]
+
+SCENARIOS: tuple[tuple[str, str, str], ...] = (
+    (
+        "Activity copying",
+        "activity_copying_smoke.py",
+        "scripts/smoke_test_activity_copying_wheel.py",
+    ),
+    (
+        "reusable presets",
+        "reusable_presets_smoke.py",
+        "scripts/smoke_test_reusable_presets_wheel.py",
+    ),
+    (
+        "guided Activity",
+        "guided_activity_smoke.py",
+        "scripts/smoke_test_guided_activity_wheel.py",
+    ),
+    (
+        "task-oriented menu",
+        "task_oriented_activity_menu_smoke.py",
+        "scripts/smoke_test_task_oriented_activity_menu_wheel.py",
+    ),
+)
+
+
+def _python(venv_root: Path) -> Path:
+    return (
+        venv_root / "Scripts" / "python.exe"
+        if os.name == "nt"
+        else venv_root / "bin" / "python"
+    )
+
+
+def _run(command: list[str], cwd: Path) -> None:
+    subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    )
+
+
+def _load_smoke_source(script_path: str) -> SmokeSource:
+    """Load one existing smoke scenario source without importing script modules."""
+    namespace = runpy.run_path(str(ROOT / script_path), run_name="__pds_smoke_source__")
+    source = namespace.get("_smoke_code")
+    if not callable(source):
+        raise RuntimeError(f"{script_path} does not expose callable _smoke_code().")
+    return cast(SmokeSource, source)
+
+
+def smoke(concord_wheel: Path, core_wheel: Path) -> None:
+    """Run all retained feature scenarios against one fresh installed environment."""
+    if not concord_wheel.is_file():
+        raise FileNotFoundError(concord_wheel)
+    if not core_wheel.is_file():
+        raise FileNotFoundError(core_wheel)
+
+    with tempfile.TemporaryDirectory(prefix="concord-feature-wheel-") as raw:
+        work = Path(raw)
+        env_root = work / "venv"
+        venv.EnvBuilder(with_pip=True).create(env_root)
+        python = _python(env_root)
+
+        _run(
+            [str(python), "-m", "pip", "install", str(core_wheel.resolve())],
+            work,
+        )
+        _run(
+            [str(python), "-m", "pip", "install", str(concord_wheel.resolve())],
+            work,
+        )
+        _run([str(python), "-m", "pip", "check"], work)
+
+        for label, filename, script_path in SCENARIOS:
+            print(f"Running installed feature smoke: {label}", flush=True)
+            source = _load_smoke_source(script_path)
+            smoke_path = work / filename
+            smoke_path.write_text(source(), encoding="utf-8")
+            _run([str(python), "-I", str(smoke_path)], work)
+            print(f"PASSED installed feature smoke: {label}", flush=True)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("concord_wheel", type=Path)
+    parser.add_argument("core_wheel", type=Path)
+    args = parser.parse_args()
+    smoke(args.concord_wheel, args.core_wheel)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -8,61 +8,62 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
+from time import perf_counter
 
 ROOT = Path(__file__).resolve().parents[1]
+STATIC_CACHE_ROOT_ENV = "PDS_CONCORD_VALIDATION_CACHE_ROOT"
 
 
-def _run(command: list[str], *, cwd: Path = ROOT) -> None:
+@dataclass(frozen=True, slots=True)
+class PhaseTiming:
+    """Elapsed time for one repository-validation phase."""
+
+    phase: str
+    elapsed_seconds: float
+
+
+def _run(
+    command: list[str],
+    *,
+    phase: str,
+    timings: list[PhaseTiming],
+    cwd: Path = ROOT,
+    env: dict[str, str] | None = None,
+) -> None:
+    """Run one validation command and record elapsed time even on failure."""
     print("+", subprocess.list2cmdline(command), flush=True)
-    subprocess.run(
-        command,
-        cwd=cwd,
-        check=True,
-        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
-    )
+    started = perf_counter()
+    try:
+        subprocess.run(
+            command,
+            cwd=cwd,
+            check=True,
+            env=(
+                env
+                if env is not None
+                else {**os.environ, "PYTHONDONTWRITEBYTECODE": "1"}
+            ),
+        )
+    finally:
+        elapsed = perf_counter() - started
+        timings.append(PhaseTiming(phase=phase, elapsed_seconds=elapsed))
+        print(f"TIMING {phase}: {elapsed:.3f}s", flush=True)
 
 
-def validate(core_wheel: Path, *, allow_dirty: bool) -> None:
-    """Run tests, static checks, builds, package checks, and smoke validation."""
-    python = sys.executable
-    _run([python, "scripts/verify_core_wheel.py", str(core_wheel), "--installed"])
-    _run([python, "scripts/verify_core_grouping_fixtures.py"])
-    _run([python, "-m", "pip", "check"])
-    with tempfile.TemporaryDirectory(prefix="pds-concord-validation-") as raw_temp:
-        temp = Path(raw_temp)
-        env = {
-            **os.environ,
-            "TMP": str(temp),
-            "TEMP": str(temp),
-            "PDS_CORE_WHEEL": str(core_wheel.resolve()),
-            "PYTHONDONTWRITEBYTECODE": "1",
-            "RUFF_CACHE_DIR": str(temp / "ruff-cache"),
-            "MYPY_CACHE_DIR": str(temp / "mypy-cache"),
-        }
-        commands = [
-            [
-                python,
-                "-m",
-                "pytest",
-                "--basetemp",
-                str(temp / "pytest"),
-                "-o",
-                f"cache_dir={temp / 'pytest-cache'}",
-            ],
-            [python, "-m", "ruff", "check", "."],
-            [python, "-m", "mypy"],
-            [python, "scripts/check_documentation.py"],
-            [python, "scripts/verify_release_compatibility.py"],
-        ]
-        for command in commands:
-            print("+", subprocess.list2cmdline(command), flush=True)
-            subprocess.run(command, cwd=ROOT, check=True, env=env)
-        dist = temp / "dist"
-        source = temp / "source"
+def _copy_build_source(
+    source_root: Path,
+    destination: Path,
+    *,
+    timings: list[PhaseTiming],
+) -> None:
+    """Copy the clean build source while recording its standalone cost."""
+    started = perf_counter()
+    try:
         shutil.copytree(
-            ROOT,
-            source,
+            source_root,
+            destination,
             ignore=shutil.ignore_patterns(
                 ".git",
                 ".venv",
@@ -75,69 +76,213 @@ def validate(core_wheel: Path, *, allow_dirty: bool) -> None:
                 ".ruff_cache",
             ),
         )
-        _run([python, "-m", "build", "--outdir", str(dist)], cwd=source)
-        artifacts = sorted(dist.iterdir())
-        _run([python, "-m", "twine", "check", *map(str, artifacts)])
-        wheels = list(dist.glob("*.whl"))
-        if len(wheels) != 1:
-            raise RuntimeError("Expected exactly one built Concord wheel.")
-        _run([python, "scripts/check_package.py", str(wheels[0])])
-        _run([python, "scripts/verify_release_artifacts.py", str(dist)])
-        _run([python, "scripts/smoke_test_wheel.py", str(wheels[0]), str(core_wheel)])
-        _run(
-            [
-                python,
-                "scripts/smoke_test_activity_copying_wheel.py",
-                str(wheels[0]),
-                str(core_wheel),
-            ]
+    finally:
+        elapsed = perf_counter() - started
+        timings.append(
+            PhaseTiming(
+                phase="source tree copy",
+                elapsed_seconds=elapsed,
+            )
         )
-        _run(
-            [
-                python,
-                "scripts/smoke_test_reusable_presets_wheel.py",
-                str(wheels[0]),
-                str(core_wheel),
-            ]
-        )
-        _run(
-            [
-                python,
-                "scripts/smoke_test_guided_activity_wheel.py",
-                str(wheels[0]),
-                str(core_wheel),
-            ]
+        print(f"TIMING source tree copy: {elapsed:.3f}s", flush=True)
+
+
+def _print_timing_summary(
+    timings: list[PhaseTiming],
+    total_seconds: float,
+) -> None:
+    """Print stable diagnostic timing output for completed validation phases."""
+    print("", flush=True)
+    print("Validation timing summary:", flush=True)
+    for timing in timings:
+        print(f"  {timing.phase}: {timing.elapsed_seconds:.3f}s", flush=True)
+    print(f"  TOTAL: {total_seconds:.3f}s", flush=True)
+
+
+def _static_cache_directories(
+    temp: Path,
+    *,
+    reuse_static_caches: bool,
+) -> tuple[Path, Path]:
+    """Resolve disposable or opt-in persistent Ruff and Mypy cache directories."""
+    if not reuse_static_caches:
+        return temp / "ruff-cache", temp / "mypy-cache"
+
+    configured = os.environ.get(STATIC_CACHE_ROOT_ENV)
+    cache_root = (
+        Path(configured).expanduser()
+        if configured
+        else Path(tempfile.gettempdir()) / "pds-concord-validation-cache"
+    ).resolve()
+    repository_root = ROOT.resolve()
+    if cache_root == repository_root or cache_root.is_relative_to(repository_root):
+        raise RuntimeError(
+            f"{STATIC_CACHE_ROOT_ENV} must resolve outside the repository."
         )
 
+    ruff_cache = cache_root / "ruff"
+    mypy_cache = cache_root / "mypy"
+    ruff_cache.mkdir(parents=True, exist_ok=True)
+    mypy_cache.mkdir(parents=True, exist_ok=True)
+    print(f"Reusing static-analysis caches from {cache_root}", flush=True)
+    return ruff_cache, mypy_cache
+
+
+def validate(
+    core_wheel: Path,
+    *,
+    allow_dirty: bool,
+    reuse_static_caches: bool = False,
+) -> None:
+    """Run tests, static checks, builds, package checks, and smoke validation."""
+    python = sys.executable
+    timings: list[PhaseTiming] = []
+    validation_started = perf_counter()
+    try:
         _run(
-            [
-                python,
-                "scripts/smoke_test_task_oriented_activity_menu_wheel.py",
-                str(wheels[0]),
-                str(core_wheel),
-            ]
+            [python, "scripts/verify_core_wheel.py", str(core_wheel), "--installed"],
+            phase="Core wheel verification",
+            timings=timings,
         )
         _run(
-            [
-                python,
-                "scripts/smoke_test_attention_provider_wheel.py",
-                str(wheels[0]),
-                str(core_wheel),
-            ]
+            [python, "scripts/verify_core_grouping_fixtures.py"],
+            phase="Core grouping fixtures",
+            timings=timings,
         )
-    _run(["git", "diff", "--check"])
-    if not allow_dirty:
-        result = subprocess.run(
-            ["git", "status", "--porcelain"],
-            cwd=ROOT,
-            check=True,
-            capture_output=True,
-            text=True,
+        _run(
+            [python, "-m", "pip", "check"],
+            phase="pip check",
+            timings=timings,
         )
-        if result.stdout:
-            raise RuntimeError(
-                "Repository validation left or found working-tree residue."
+        with tempfile.TemporaryDirectory(
+            prefix="pds-concord-validation-"
+        ) as raw_temp:
+            temp = Path(raw_temp)
+            ruff_cache, mypy_cache = _static_cache_directories(
+                temp,
+                reuse_static_caches=reuse_static_caches,
             )
+            env = {
+                **os.environ,
+                "TMP": str(temp),
+                "TEMP": str(temp),
+                "PDS_CORE_WHEEL": str(core_wheel.resolve()),
+                "PYTHONDONTWRITEBYTECODE": "1",
+                "RUFF_CACHE_DIR": str(ruff_cache),
+                "MYPY_CACHE_DIR": str(mypy_cache),
+            }
+
+            dist = temp / "dist"
+            source = temp / "source"
+            _copy_build_source(ROOT, source, timings=timings)
+
+            _run(
+                [python, "-m", "build", "--outdir", str(dist)],
+                phase="package build",
+                timings=timings,
+                cwd=source,
+            )
+            artifacts = sorted(dist.iterdir())
+            wheels = list(dist.glob("*.whl"))
+            if len(wheels) != 1:
+                raise RuntimeError("Expected exactly one built Concord wheel.")
+            env["PDS_CONCORD_TEST_WHEEL"] = str(wheels[0].resolve())
+
+            commands = (
+                (
+                    "pytest",
+                    [
+                        python,
+                        "-m",
+                        "pytest",
+                        "--basetemp",
+                        str(temp / "pytest"),
+                        "-o",
+                        f"cache_dir={temp / 'pytest-cache'}",
+                        "--durations=25",
+                    ],
+                ),
+                ("Ruff", [python, "-m", "ruff", "check", "."]),
+                ("Mypy", [python, "-m", "mypy"]),
+                (
+                    "documentation validation",
+                    [python, "scripts/check_documentation.py"],
+                ),
+                (
+                    "release compatibility",
+                    [python, "scripts/verify_release_compatibility.py"],
+                ),
+            )
+            for phase, command in commands:
+                _run(
+                    command,
+                    phase=phase,
+                    timings=timings,
+                    cwd=ROOT,
+                    env=env,
+                )
+
+            _run(
+                [python, "-m", "twine", "check", *map(str, artifacts)],
+                phase="Twine",
+                timings=timings,
+            )
+
+            wheel = str(wheels[0])
+            core = str(core_wheel)
+            _run(
+                [python, "scripts/check_package.py", wheel],
+                phase="package content",
+                timings=timings,
+            )
+            _run(
+                [python, "scripts/verify_release_artifacts.py", str(dist)],
+                phase="release artifacts",
+                timings=timings,
+            )
+            _run(
+                [python, "scripts/smoke_test_wheel.py", wheel, core],
+                phase="installed-wheel smoke: base",
+                timings=timings,
+            )
+            _run(
+                [python, "scripts/smoke_test_feature_wheels.py", wheel, core],
+                phase="installed-wheel smoke: shared feature scenarios",
+                timings=timings,
+            )
+            _run(
+                [
+                    python,
+                    "scripts/smoke_test_attention_provider_wheel.py",
+                    wheel,
+                    core,
+                ],
+                phase="installed-wheel smoke: module operations",
+                timings=timings,
+            )
+
+        _run(
+            ["git", "diff", "--check"],
+            phase="git diff check",
+            timings=timings,
+        )
+        if not allow_dirty:
+            result = subprocess.run(
+                ["git", "status", "--porcelain"],
+                cwd=ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            if result.stdout:
+                raise RuntimeError(
+                    "Repository validation left or found working-tree residue."
+                )
+    finally:
+        _print_timing_summary(
+            timings,
+            perf_counter() - validation_started,
+        )
 
 
 def main() -> int:
@@ -145,8 +290,20 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--core-wheel", required=True, type=Path)
     parser.add_argument("--allow-dirty", action="store_true")
+    parser.add_argument(
+        "--reuse-static-caches",
+        action="store_true",
+        help=(
+            "Reuse Ruff and Mypy caches outside the repository. "
+            "This affects speed only and does not change qualification coverage."
+        ),
+    )
     args = parser.parse_args()
-    validate(args.core_wheel, allow_dirty=args.allow_dirty)
+    validate(
+        args.core_wheel,
+        allow_dirty=args.allow_dirty,
+        reuse_static_caches=args.reuse_static_caches,
+    )
     return 0
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -73,7 +74,18 @@ def built_dist(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 
 @pytest.fixture(scope="session")
-def built_wheel(built_dist: Path) -> Path:
+def built_wheel(request: pytest.FixtureRequest) -> Path:
+    supplied = os.environ.get("PDS_CONCORD_TEST_WHEEL")
+    if supplied is not None:
+        wheel = Path(supplied)
+        assert wheel.is_file(), f"supplied Concord test wheel is missing: {wheel}"
+        assert wheel.suffix == ".whl", (
+            f"supplied Concord test wheel is not a wheel: {wheel}"
+        )
+        return wheel
+
+    built_dist = request.getfixturevalue("built_dist")
+    assert isinstance(built_dist, Path)
     wheels = list(built_dist.glob("*.whl"))
     assert len(wheels) == 1
     return wheels[0]

--- a/tests/test_ci_performance_issue93.py
+++ b/tests/test_ci_performance_issue93.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def test_ci_retains_all_supported_os_python_cells() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    for os_name in ("ubuntu-latest", "windows-latest"):
+        for python in ("3.11", "3.12", "3.13", "3.14"):
+            assert f"- os: {os_name}\n            python: \"{python}\"" in text
+
+    assert text.count("          - os: ") == 8
+
+
+def test_ci_complete_qualification_spans_os_and_python_range() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert (
+        '- os: ubuntu-latest\n            python: "3.11"\n            complete: true'
+        in text
+    )
+    assert (
+        '- os: windows-latest\n            python: "3.14"\n            complete: true'
+        in text
+    )
+    assert text.count("            complete: true") == 2
+    assert text.count("            complete: false") == 6
+
+
+def test_ci_compatibility_cells_keep_runtime_pytest_and_hygiene() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Run compatibility validation" in text
+    assert "matrix.complete == false" in text
+    assert "python scripts/verify_core_wheel.py --installed" in text
+    assert "python -m pip check" in text
+    assert 'python -c "import concord"' in text
+    assert "python -m pytest" in text
+    assert "--durations=25" in text
+    assert "git diff --check" in text
+    assert "git status --porcelain --untracked-files=all" in text
+
+
+def test_ci_complete_cells_delegate_to_authoritative_validator() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Run complete repository qualification" in text
+    assert "matrix.complete == true" in text
+    assert "python scripts/validate_repository.py" in text
+    assert '--core-wheel "$env:PDS_CORE_WHEEL"' in text
+
+    for duplicated_command in (
+        "python -m ruff check .",
+        "python -m mypy",
+        "python -m build --outdir",
+        "python -m twine check",
+        "scripts/smoke_test_wheel.py",
+        "scripts/smoke_test_activity_copying_wheel.py",
+    ):
+        assert duplicated_command not in text

--- a/tests/test_guided_activity_qualification_issue65.py
+++ b/tests/test_guided_activity_qualification_issue65.py
@@ -59,10 +59,12 @@ def test_guided_menu_source_keeps_teacher_language_and_refresh_calls() -> None:
 
 def test_repository_qualification_wires_guided_installed_smoke_and_package() -> None:
     validator = _text("scripts/validate_repository.py")
+    feature_smokes = _text("scripts/smoke_test_feature_wheels.py")
     package = _text("scripts/check_package.py")
     documentation = _text("scripts/check_documentation.py")
 
-    assert "scripts/smoke_test_guided_activity_wheel.py" in validator
+    assert "scripts/smoke_test_feature_wheels.py" in validator
+    assert "scripts/smoke_test_guided_activity_wheel.py" in feature_smokes
     assert '"concord/menu_guided_activity.py"' in package
     assert '"concord/workflows/guided_activity_setup.py"' in package
     assert "GUIDED_ACTIVITY_WORKFLOW_DOC" in documentation

--- a/tests/test_installed_smoke_performance_issue93.py
+++ b/tests/test_installed_smoke_performance_issue93.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import smoke_test_feature_wheels as feature_smokes
+
+
+def test_issue93_shared_feature_smoke_reuses_existing_scenario_sources() -> None:
+    assert tuple(label for label, _, _ in feature_smokes.SCENARIOS) == (
+        "Activity copying",
+        "reusable presets",
+        "guided Activity",
+        "task-oriented menu",
+    )
+    assert tuple(filename for _, filename, _ in feature_smokes.SCENARIOS) == (
+        "activity_copying_smoke.py",
+        "reusable_presets_smoke.py",
+        "guided_activity_smoke.py",
+        "task_oriented_activity_menu_smoke.py",
+    )
+    assert tuple(script for _, _, script in feature_smokes.SCENARIOS) == (
+        "scripts/smoke_test_activity_copying_wheel.py",
+        "scripts/smoke_test_reusable_presets_wheel.py",
+        "scripts/smoke_test_guided_activity_wheel.py",
+        "scripts/smoke_test_task_oriented_activity_menu_wheel.py",
+    )
+
+
+def test_issue93_shared_feature_smoke_has_one_environment_install_boundary() -> None:
+    source = Path(feature_smokes.__file__).read_text(encoding="utf-8")
+    assert source.count("venv.EnvBuilder(with_pip=True).create(env_root)") == 1
+    assert source.count('"pip", "install"') == 2
+    assert source.count('"pip", "check"') == 1
+    assert '[str(python), "-I", str(smoke_path)]' in source
+    assert "runpy.run_path" in source
+
+
+def test_issue93_repository_validator_batches_only_feature_smokes() -> None:
+    source = Path("scripts/validate_repository.py").read_text(encoding="utf-8")
+    assert "scripts/smoke_test_feature_wheels.py" in source
+    assert "installed-wheel smoke: shared feature scenarios" in source
+
+    for removed_direct_call in (
+        "scripts/smoke_test_activity_copying_wheel.py",
+        "scripts/smoke_test_reusable_presets_wheel.py",
+        "scripts/smoke_test_guided_activity_wheel.py",
+        "scripts/smoke_test_task_oriented_activity_menu_wheel.py",
+    ):
+        assert removed_direct_call not in source
+
+    # These retain separate isolation because they qualify additional boundaries.
+    assert "scripts/smoke_test_wheel.py" in source
+    assert "scripts/smoke_test_attention_provider_wheel.py" in source

--- a/tests/test_package_build_reuse_issue93.py
+++ b/tests/test_package_build_reuse_issue93.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_package_fixture_accepts_validator_supplied_wheel_without_build_dependency(
+) -> None:
+    source = (ROOT / "tests" / "conftest.py").read_text(encoding="utf-8")
+
+    assert 'os.environ.get("PDS_CONCORD_TEST_WHEEL")' in source
+    assert "def built_wheel(request: pytest.FixtureRequest)" in source
+    assert 'request.getfixturevalue("built_dist")' in source
+    assert "def built_wheel(built_dist: Path)" not in source
+
+
+def test_complete_validator_builds_once_before_pytest_and_supplies_exact_wheel(
+) -> None:
+    source = (ROOT / "scripts" / "validate_repository.py").read_text(
+        encoding="utf-8"
+    )
+
+    build_marker = 'phase="package build"'
+    pytest_marker = '"pytest",'
+    supplied_marker = (
+        'env["PDS_CONCORD_TEST_WHEEL"] = str(wheels[0].resolve())'
+    )
+
+    assert source.count(build_marker) == 1
+    assert supplied_marker in source
+    assert source.index(build_marker) < source.index(pytest_marker)
+    assert source.index(supplied_marker) < source.index(pytest_marker)

--- a/tests/test_record_history_performance_issue93.py
+++ b/tests/test_record_history_performance_issue93.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.workspace import ensure_workspace_root
+
+import concord.storage as storage_module
+from concord.model_conversion import record_from_dict
+from concord.models import Activity, Session
+from concord.storage import commit_record_batch, list_record_identities
+from concord.storage_errors import ConcordStorageReadError
+from concord.storage_paths import record_revision_path
+
+FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "native_records"
+    / "evidence_only_activity.json"
+)
+
+
+@pytest.fixture
+def storage_case(tmp_path: Path) -> tuple[Path, Activity, Session]:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    metadata = create_class_metadata(
+        "class-1",
+        "2026-2027",
+        created_at=datetime(2026, 8, 29, tzinfo=timezone.utc),
+    )
+    write_class_metadata_for_class(root, metadata)
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    activity = record_from_dict("activity", fixture["records"][0]["body"])
+    session = record_from_dict("session", fixture["records"][1]["body"])
+    assert isinstance(activity, Activity)
+    assert isinstance(session, Session)
+    return root, activity, session
+
+
+def _three_snapshots(root: Path, activity: Activity, session: Session) -> None:
+    result = commit_record_batch(
+        root,
+        activity.work_reference,
+        (activity, session),
+        expected_snapshot_revision=None,
+    )
+    for revision in range(2, 4):
+        result = commit_record_batch(
+            root,
+            activity.work_reference,
+            (replace(session, notes=f"Synthetic revision {revision}."),),
+            expected_snapshot_revision=result.snapshot_revision,
+        )
+    assert result.snapshot_revision == 3
+
+
+def test_write_history_loads_each_record_revision_once(
+    storage_case: tuple[Path, Activity, Session],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, activity, session = storage_case
+    _three_snapshots(root, activity, session)
+    _, current_snapshot, _, _ = storage_module._load_current_snapshot_state(
+        root,
+        activity.work_reference,
+    )
+
+    original = storage_module.load_record_revision
+    calls: list[tuple[str, str, int]] = []
+
+    def counted(
+        workspace_root: str | Path,
+        work: Any,
+        record_kind: str,
+        record_id: str,
+        record_revision: int,
+    ) -> Any:
+        calls.append((record_kind, record_id, record_revision))
+        return original(
+            workspace_root,
+            work,
+            record_kind,
+            record_id,
+            record_revision,
+        )
+
+    monkeypatch.setattr(storage_module, "load_record_revision", counted)
+
+    storage_module._validate_canonical_write_history(
+        root,
+        activity.work_reference,
+        current_snapshot,
+    )
+
+    expected = {
+        ("activity", activity.activity_id, 1),
+        ("session", session.session_id, 1),
+        ("session", session.session_id, 2),
+        ("session", session.session_id, 3),
+    }
+    assert set(calls) == expected
+    assert Counter(calls) == Counter({item: 1 for item in expected})
+
+
+def test_public_record_identity_listing_preserves_validation(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    _three_snapshots(root, activity, session)
+
+    assert list_record_identities(root, activity.work_reference) == (
+        ("activity", activity.activity_id),
+        ("session", session.session_id),
+    )
+
+    historical = record_revision_path(
+        root,
+        activity.work_reference,
+        "session",
+        session.session_id,
+        1,
+    )
+    historical.write_bytes(b"{not-json")
+
+    with pytest.raises(ConcordStorageReadError):
+        list_record_identities(root, activity.work_reference)

--- a/tests/test_reusable_presets_qualification_issue64.py
+++ b/tests/test_reusable_presets_qualification_issue64.py
@@ -133,6 +133,9 @@ def test_repository_qualification_requires_preset_docs_package_and_wheel_smoke(
     validator = (root / "scripts" / "validate_repository.py").read_text(
         encoding="utf-8"
     )
+    feature_smokes = (root / "scripts" / "smoke_test_feature_wheels.py").read_text(
+        encoding="utf-8"
+    )
     package_check = (root / "scripts" / "check_package.py").read_text(
         encoding="utf-8"
     )
@@ -141,7 +144,8 @@ def test_repository_qualification_requires_preset_docs_package_and_wheel_smoke(
     )
     docs_index = (root / "docs" / "README.md").read_text(encoding="utf-8")
 
-    assert "scripts/smoke_test_reusable_presets_wheel.py" in validator
+    assert "scripts/smoke_test_feature_wheels.py" in validator
+    assert "scripts/smoke_test_reusable_presets_wheel.py" in feature_smokes
     assert '"concord/cli_app/handlers/reusable_presets.py"' in package_check
     assert '"concord/menu_presets.py"' in package_check
     assert '"concord/reusable_preset_storage.py"' in package_check

--- a/tests/test_static_cache_performance_issue93.py
+++ b/tests/test_static_cache_performance_issue93.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts import validate_repository as validator
+
+
+def test_default_static_caches_remain_disposable(tmp_path: Path) -> None:
+    ruff_cache, mypy_cache = validator._static_cache_directories(
+        tmp_path,
+        reuse_static_caches=False,
+    )
+
+    assert ruff_cache == tmp_path / "ruff-cache"
+    assert mypy_cache == tmp_path / "mypy-cache"
+    assert not ruff_cache.exists()
+    assert not mypy_cache.exists()
+
+
+def test_reusable_static_caches_use_explicit_external_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cache_root = tmp_path / "persistent"
+    monkeypatch.setenv(
+        validator.STATIC_CACHE_ROOT_ENV,
+        str(cache_root),
+    )
+
+    ruff_cache, mypy_cache = validator._static_cache_directories(
+        tmp_path / "disposable",
+        reuse_static_caches=True,
+    )
+
+    assert ruff_cache == cache_root.resolve() / "ruff"
+    assert mypy_cache == cache_root.resolve() / "mypy"
+    assert ruff_cache.is_dir()
+    assert mypy_cache.is_dir()
+
+
+def test_reusable_static_cache_root_cannot_live_in_repository(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(
+        validator.STATIC_CACHE_ROOT_ENV,
+        str(validator.ROOT / ".validation-cache"),
+    )
+
+    with pytest.raises(RuntimeError, match="outside the repository"):
+        validator._static_cache_directories(
+            validator.ROOT / "ignored",
+            reuse_static_caches=True,
+        )
+
+
+def test_validator_cli_exposes_opt_in_cache_reuse() -> None:
+    source = Path(validator.__file__).read_text(encoding="utf-8")
+
+    assert '"--reuse-static-caches"' in source
+    assert '"PDS_CONCORD_VALIDATION_CACHE_ROOT"' in source
+    assert "reuse_static_caches=args.reuse_static_caches" in source
+    assert "This affects speed only" in source

--- a/tests/test_storage_benchmark_issue93.py
+++ b/tests/test_storage_benchmark_issue93.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import benchmark_storage_performance_issue93 as benchmark
+
+
+def test_storage_benchmark_formats_improvement_without_thresholds() -> None:
+    assert benchmark._format_change(2.0, 1.0) == "50.0% faster"
+    assert benchmark._format_change(0.0, 1.0) == "n/a"
+
+
+def test_storage_benchmark_source_keeps_comparisons_diagnostic_only() -> None:
+    source = Path(benchmark.__file__).read_text(encoding="utf-8")
+
+    assert "time.perf_counter()" in source
+    assert "statistics.median" in source
+    assert "_legacy_list_work_snapshots" in source
+    assert "_legacy_load_current_record_graph" in source
+    assert "_legacy_record_history_pass" in source
+    assert "pytest" not in source
+    assert "pass/fail" not in source.casefold()

--- a/tests/test_storage_commit_performance_issue93.py
+++ b/tests/test_storage_commit_performance_issue93.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.workspace import ensure_workspace_root
+
+import concord.storage as storage_module
+from concord.model_conversion import record_from_dict
+from concord.models import Activity, Session
+from concord.storage import commit_record_batch, load_current_record_graph
+
+FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "native_records"
+    / "evidence_only_activity.json"
+)
+
+
+@pytest.fixture
+def storage_case(tmp_path: Path) -> tuple[Path, Activity, Session]:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    metadata = create_class_metadata(
+        "class-1",
+        "2026-2027",
+        created_at=datetime(2026, 8, 29, tzinfo=timezone.utc),
+    )
+    write_class_metadata_for_class(root, metadata)
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    activity = record_from_dict("activity", fixture["records"][0]["body"])
+    session = record_from_dict("session", fixture["records"][1]["body"])
+    assert isinstance(activity, Activity)
+    assert isinstance(session, Session)
+    return root, activity, session
+
+
+def test_update_commit_does_not_reload_current_snapshot_for_refs_or_digest(
+    storage_case: tuple[Path, Activity, Session],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, activity, session = storage_case
+    first = commit_record_batch(
+        root,
+        activity.work_reference,
+        (activity, session),
+        expected_snapshot_revision=None,
+    )
+
+    original = storage_module.load_work_snapshot
+    calls: list[int] = []
+
+    def counted(
+        workspace_root: str | Path,
+        work: Any,
+        snapshot_revision: int,
+    ) -> Any:
+        calls.append(snapshot_revision)
+        return original(workspace_root, work, snapshot_revision)
+
+    monkeypatch.setattr(storage_module, "load_work_snapshot", counted)
+
+    updated = commit_record_batch(
+        root,
+        activity.work_reference,
+        (replace(session, notes="Second revision."),),
+        expected_snapshot_revision=first.snapshot_revision,
+    )
+
+    assert updated.snapshot_revision == 2
+    # Slice 5 validates existing snapshot history directly in one linear pass,
+    # so load_work_snapshot() is now needed only to verify the newly written
+    # revision-2 snapshot. Current refs and predecessor digest still reuse the
+    # state already verified by _load_current_snapshot_state().
+    assert calls == [2]
+
+
+def test_update_commit_retains_final_post_publication_graph_verification(
+    storage_case: tuple[Path, Activity, Session],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, activity, session = storage_case
+    first = commit_record_batch(
+        root,
+        activity.work_reference,
+        (activity, session),
+        expected_snapshot_revision=None,
+    )
+
+    original = storage_module.load_current_record_graph
+    calls = 0
+
+    def counted(*args: Any, **kwargs: Any) -> Any:
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(storage_module, "load_current_record_graph", counted)
+
+    result = commit_record_batch(
+        root,
+        activity.work_reference,
+        (replace(session, notes="Verified after publication."),),
+        expected_snapshot_revision=first.snapshot_revision,
+    )
+
+    assert result.snapshot_revision == 2
+    assert calls == 1
+    loaded = load_current_record_graph(root, activity.work_reference)
+    assert loaded.snapshot_revision == 2

--- a/tests/test_storage_history_performance_issue93.py
+++ b/tests/test_storage_history_performance_issue93.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.workspace import ensure_workspace_root
+
+import concord.storage as storage_module
+from concord.model_conversion import record_from_dict
+from concord.models import Activity, Session
+from concord.storage import commit_record_batch, list_work_snapshots
+from concord.storage_errors import ConcordStorageIntegrityError
+from concord.storage_paths import snapshot_path
+
+FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "native_records"
+    / "evidence_only_activity.json"
+)
+
+
+@pytest.fixture
+def storage_case(tmp_path: Path) -> tuple[Path, Activity, Session]:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    metadata = create_class_metadata(
+        "class-1",
+        "2026-2027",
+        created_at=datetime(2026, 8, 29, tzinfo=timezone.utc),
+    )
+    write_class_metadata_for_class(root, metadata)
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    activity = record_from_dict("activity", fixture["records"][0]["body"])
+    session = record_from_dict("session", fixture["records"][1]["body"])
+    assert isinstance(activity, Activity)
+    assert isinstance(session, Session)
+    return root, activity, session
+
+
+def _five_snapshots(root: Path, activity: Activity, session: Session) -> None:
+    result = commit_record_batch(
+        root,
+        activity.work_reference,
+        (activity, session),
+        expected_snapshot_revision=None,
+    )
+    for revision in range(2, 6):
+        result = commit_record_batch(
+            root,
+            activity.work_reference,
+            (replace(session, notes=f"Synthetic revision {revision}."),),
+            expected_snapshot_revision=result.snapshot_revision,
+        )
+    assert result.snapshot_revision == 5
+
+
+def test_list_work_snapshots_parses_each_snapshot_once(
+    storage_case: tuple[Path, Activity, Session],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, activity, session = storage_case
+    _five_snapshots(root, activity, session)
+
+    original = storage_module._parse
+    parsed_snapshot_revisions: list[int] = []
+
+    def counted(path: Path, parser: Any, *, missing: bool = False) -> Any:
+        if path.parent == snapshot_path(
+            root,
+            activity.work_reference,
+            1,
+        ).parent:
+            parsed_snapshot_revisions.append(int(path.stem))
+        return original(path, parser, missing=missing)
+
+    monkeypatch.setattr(storage_module, "_parse", counted)
+
+    assert list_work_snapshots(root, activity.work_reference) == (1, 2, 3, 4, 5)
+    assert parsed_snapshot_revisions == [1, 2, 3, 4, 5]
+
+
+def test_list_work_snapshots_still_rejects_predecessor_digest_corruption(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    _five_snapshots(root, activity, session)
+
+    predecessor = snapshot_path(root, activity.work_reference, 3)
+    predecessor.write_bytes(predecessor.read_bytes() + b"\n")
+
+    with pytest.raises(
+        ConcordStorageIntegrityError,
+        match="snapshot predecessor digest mismatch",
+    ):
+        list_work_snapshots(root, activity.work_reference)
+
+
+def test_list_work_snapshots_still_rejects_noncontiguous_history(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    _five_snapshots(root, activity, session)
+
+    snapshot_path(root, activity.work_reference, 4).unlink()
+
+    with pytest.raises(
+        ConcordStorageIntegrityError,
+        match="noncontiguous",
+    ):
+        list_work_snapshots(root, activity.work_reference)

--- a/tests/test_storage_performance_issue93.py
+++ b/tests/test_storage_performance_issue93.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.workspace import ensure_workspace_root
+
+import concord.storage as storage_module
+from concord.model_conversion import record_from_dict
+from concord.models import Activity, Session
+from concord.storage import commit_record_batch, load_current_record_graph
+from concord.storage_errors import ConcordStorageIntegrityError
+from concord.storage_paths import snapshot_path
+
+FIXTURE = (
+    Path(__file__).parent
+    / "fixtures"
+    / "native_records"
+    / "evidence_only_activity.json"
+)
+
+
+@pytest.fixture
+def storage_case(tmp_path: Path) -> tuple[Path, Activity, Session]:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    metadata = create_class_metadata(
+        "class-1",
+        "2026-2027",
+        created_at=datetime(2026, 8, 29, tzinfo=timezone.utc),
+    )
+    write_class_metadata_for_class(root, metadata)
+    fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    activity = record_from_dict("activity", fixture["records"][0]["body"])
+    session = record_from_dict("session", fixture["records"][1]["body"])
+    assert isinstance(activity, Activity)
+    assert isinstance(session, Session)
+    return root, activity, session
+
+
+def _three_snapshots(root: Path, activity: Activity, session: Session) -> None:
+    first = commit_record_batch(
+        root,
+        activity.work_reference,
+        (activity, session),
+        expected_snapshot_revision=None,
+    )
+    second_session = replace(session, notes="Synthetic revision two.")
+    second = commit_record_batch(
+        root,
+        activity.work_reference,
+        (second_session,),
+        expected_snapshot_revision=first.snapshot_revision,
+    )
+    third_session = replace(session, notes="Synthetic revision three.")
+    commit_record_batch(
+        root,
+        activity.work_reference,
+        (third_session,),
+        expected_snapshot_revision=second.snapshot_revision,
+    )
+
+
+def test_current_graph_materializes_verified_state_once(
+    storage_case: tuple[Path, Activity, Session],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, activity, session = storage_case
+    _three_snapshots(root, activity, session)
+
+    original_chain = storage_module._load_snapshot_chain
+    original_graph = storage_module._validated_snapshot_graph
+    original_validate = storage_module.validate_record_graph
+    calls = {"chain": 0, "graph": 0, "validate": 0}
+
+    def counted_chain(*args: Any, **kwargs: Any) -> Any:
+        calls["chain"] += 1
+        return original_chain(*args, **kwargs)
+
+    def counted_graph(*args: Any, **kwargs: Any) -> Any:
+        calls["graph"] += 1
+        return original_graph(*args, **kwargs)
+
+    def counted_validate(*args: Any, **kwargs: Any) -> Any:
+        calls["validate"] += 1
+        return original_validate(*args, **kwargs)
+
+    monkeypatch.setattr(storage_module, "_load_snapshot_chain", counted_chain)
+    monkeypatch.setattr(storage_module, "_validated_snapshot_graph", counted_graph)
+    monkeypatch.setattr(storage_module, "validate_record_graph", counted_validate)
+
+    loaded = load_current_record_graph(root, activity.work_reference)
+
+    assert loaded.snapshot_revision == 3
+    assert calls == {"chain": 1, "graph": 1, "validate": 1}
+
+
+def test_current_graph_still_rejects_predecessor_digest_corruption(
+    storage_case: tuple[Path, Activity, Session],
+) -> None:
+    root, activity, session = storage_case
+    _three_snapshots(root, activity, session)
+
+    predecessor = snapshot_path(root, activity.work_reference, 1)
+    predecessor.write_bytes(predecessor.read_bytes() + b"\n")
+
+    with pytest.raises(
+        ConcordStorageIntegrityError,
+        match="snapshot predecessor digest mismatch",
+    ):
+        load_current_record_graph(root, activity.work_reference)

--- a/tests/test_validation_performance_document_issue93.py
+++ b/tests/test_validation_performance_document_issue93.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "development" / "validation-performance.md"
+INDEX = ROOT / "docs" / "README.md"
+
+
+def test_validation_performance_document_records_issue93_contract() -> None:
+    text = DOC.read_text(encoding="utf-8")
+
+    required = (
+        "faster validation != weaker validation",
+        "487.916 s",
+        "336.195 s",
+        "322.901 s",
+        "-33.8%",
+        "197.694 s",
+        "1,330",
+        "PDS_CONCORD_TEST_WHEEL",
+        "--reuse-static-caches",
+        "PDS_CONCORD_VALIDATION_CACHE_ROOT",
+        "55.1% faster",
+        "42.7% faster",
+        "49.1% faster",
+        "Ubuntu / Python 3.11",
+        "Windows / Python 3.14",
+        "pytest-xdist",
+        "post-pointer",
+        "predecessor SHA-256",
+        "scripts/benchmark_storage_performance_issue93.py",
+    )
+    for phrase in required:
+        assert phrase in text
+
+
+def test_validation_performance_document_is_indexed() -> None:
+    text = INDEX.read_text(encoding="utf-8")
+
+    assert (
+        "[`development/validation-performance.md`]"
+        "(development/validation-performance.md)"
+        in text
+    )

--- a/tests/test_validation_performance_issue93.py
+++ b/tests/test_validation_performance_issue93.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from scripts import validate_repository as validator
+
+
+def test_issue93_phase_timing_is_immutable() -> None:
+    timing = validator.PhaseTiming("pytest", 12.5)
+    assert timing.phase == "pytest"
+    assert timing.elapsed_seconds == 12.5
+    with pytest.raises(AttributeError):
+        timing.phase = "changed"  # type: ignore[misc]
+
+
+def test_issue93_run_records_timing_and_preserves_supplied_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    moments = iter((10.0, 12.5))
+    observed: dict[str, Any] = {}
+
+    monkeypatch.setattr(validator, "perf_counter", lambda: next(moments))
+
+    def fake_run(
+        command: list[str],
+        *,
+        cwd: Path,
+        check: bool,
+        env: dict[str, str],
+    ) -> None:
+        observed["command"] = command
+        observed["cwd"] = cwd
+        observed["check"] = check
+        observed["env"] = env
+
+    monkeypatch.setattr(validator.subprocess, "run", fake_run)
+
+    timings: list[validator.PhaseTiming] = []
+    supplied_env = {"PDS_TEST": "1"}
+    validator._run(
+        ["python", "-V"],
+        phase="synthetic phase",
+        timings=timings,
+        cwd=tmp_path,
+        env=supplied_env,
+    )
+
+    assert observed == {
+        "command": ["python", "-V"],
+        "cwd": tmp_path,
+        "check": True,
+        "env": supplied_env,
+    }
+    assert timings == [validator.PhaseTiming("synthetic phase", 2.5)]
+
+
+def test_issue93_run_records_failed_phase_timing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    moments = iter((20.0, 23.25))
+    monkeypatch.setattr(validator, "perf_counter", lambda: next(moments))
+
+    def fail_run(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise subprocess.CalledProcessError(7, ["synthetic"])
+
+    monkeypatch.setattr(validator.subprocess, "run", fail_run)
+
+    timings: list[validator.PhaseTiming] = []
+    with pytest.raises(subprocess.CalledProcessError):
+        validator._run(
+            ["synthetic"],
+            phase="failed phase",
+            timings=timings,
+        )
+
+    assert timings == [validator.PhaseTiming("failed phase", 3.25)]
+
+
+def test_issue93_timing_summary_is_stable(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    validator._print_timing_summary(
+        [
+            validator.PhaseTiming("pytest", 10.1254),
+            validator.PhaseTiming("package build", 2.0),
+        ],
+        12.5,
+    )
+
+    assert capsys.readouterr().out == (
+        "\n"
+        "Validation timing summary:\n"
+        "  pytest: 10.125s\n"
+        "  package build: 2.000s\n"
+        "  TOTAL: 12.500s\n"
+    )
+
+
+def test_issue93_complete_validator_exposes_required_measurement_phases() -> None:
+    source = Path(validator.__file__).read_text(encoding="utf-8")
+    for expected in (
+        '"Core wheel verification"',
+        '"Core grouping fixtures"',
+        '"pip check"',
+        '"pytest"',
+        '"Ruff"',
+        '"Mypy"',
+        '"documentation validation"',
+        '"release compatibility"',
+        '"source tree copy"',
+        '"package build"',
+        '"Twine"',
+        '"package content"',
+        '"release artifacts"',
+        '"installed-wheel smoke: base"',
+        '"installed-wheel smoke: shared feature scenarios"',
+        '"installed-wheel smoke: module operations"',
+        '"git diff check"',
+        '"--durations=25"',
+        "validation_started = perf_counter()",
+        "_print_timing_summary(",
+    ):
+        assert expected in source


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>Summary</h2><p>Closes #93.</p><p>Reduces Concord validation and CI runtime without weakening runtime coverage, canonical-storage integrity checks, packaging qualification, installed-wheel acceptance, or supported OS/Python coverage.</p><p>The work followed the issue’s intended sequence:</p><pre><code class="language-text">measure
    -&gt;
de-duplicate harness work
    -&gt;
profile remaining runtime
    -&gt;
optimize demonstrated hot paths
    -&gt;
factor CI
    -&gt;
remeasure
</code></pre><p>The final cold authoritative validator improved from <strong>487.916 s to 322.901 s</strong>, a <strong>33.8% reduction</strong>, while the full pytest phase improved from <strong>286.730 s to 197.694 s</strong>, a <strong>31.1% reduction</strong>.</p><h2>What changed</h2><h3>Validation timing and profiling</h3><ul><li><p>Added stable per-phase <code inline="">perf_counter()</code> timing to <code inline="">scripts/validate_repository.py</code>.</p></li><li><p>Added a final validation timing summary.</p></li><li><p>Added pytest slow-test reporting with <code inline="">--durations=25</code>.</p></li><li><p>Timing remains diagnostic only; no phase has a performance pass/fail threshold.</p></li></ul><h3>Installed-wheel qualification reuse</h3><p>Added <code inline="">scripts/smoke_test_feature_wheels.py</code> to run these independent installed scenarios in one fresh candidate-wheel environment:</p><ul><li><p>Activity copying</p></li><li><p>reusable presets</p></li><li><p>guided Activity setup</p></li><li><p>task-oriented Activity menu</p></li></ul><p>The individual smoke scripts remain independently runnable and retain their own assertions/workspaces.</p><p>The base installed producer acceptance and module-operations acceptance remain separate qualification boundaries.</p><p>Measured four-feature smoke time:</p><pre><code class="language-text">before: 84.288 s
after:   22.219 s
change: -73.6%
</code></pre><p>All installed-wheel qualification:</p><pre><code class="language-text">before: 162.059 s
after:   93.048 s
change: -42.6%
</code></pre><h3>Canonical-storage hot-path optimization</h3><p>Reduced repeated validation work while preserving the existing fail-closed storage contract.</p><p>Changes include:</p><ul><li><p>reuse of already verified current pointer / snapshot / graph state within one current-graph read;</p></li><li><p>reuse of verified current state during <code inline="">commit_record_batch()</code> pre-publication work;</p></li><li><p>preservation of final post-pointer current-graph verification;</p></li><li><p>linear chronological validation of snapshot histories instead of repeatedly walking overlapping predecessor chains;</p></li><li><p>single-pass validated record-history enumeration instead of validating the same revision history twice.</p></li></ul><p>The optimizations continue to enforce:</p><ul><li><p>immutable record revisions;</p></li><li><p>snapshot predecessor revision verification;</p></li><li><p>snapshot predecessor SHA-256 verification;</p></li><li><p>current-pointer digest verification;</p></li><li><p>record digest verification;</p></li><li><p>canonical identity/path agreement;</p></li><li><p>append-only semantics;</p></li><li><p>expected snapshot revision conflicts;</p></li><li><p>record-graph validation;</p></li><li><p>Core standards validation;</p></li><li><p>work/class identity validation;</p></li><li><p>symlink/path-security protections;</p></li><li><p>pre-pointer failure semantics;</p></li><li><p>post-pointer verification;</p></li><li><p>partial-success boundaries;</p></li><li><p>orphan/corruption detection.</p></li></ul><h3>Storage benchmark evidence</h3><p>Added:</p><pre><code class="language-text">scripts/benchmark_storage_performance_issue93.py
</code></pre><p>Using 12 snapshots and the median of 5 repetitions on Windows / Python 3.11.9:</p><pre><code class="language-text">list_work_snapshots
  legacy:     0.078408 s
  optimized:  0.035175 s
  improvement: 55.1%

load_current_record_graph
  legacy:     0.022176 s
  optimized:  0.012696 s
  improvement: 42.7%

record-history enumeration
  legacy:     0.034541 s
  optimized:  0.017584 s
  improvement: 49.1%
</code></pre><p>The benchmark is diagnostic only and establishes no timing threshold.</p><h3>Candidate release-wheel reuse</h3><p>The complete validator now builds the candidate release artifacts before pytest and supplies the exact candidate wheel through:</p><pre><code class="language-text">PDS_CONCORD_TEST_WHEEL
</code></pre><p>Package-metadata tests reuse that wheel rather than constructing an equivalent second wheel.</p><p>Standalone <code inline="">python -m pytest</code> remains self-contained and still builds its own wheel when the environment variable is absent.</p><h3>Opt-in reusable static-analysis caches</h3><p>Added:</p><pre><code class="language-text">--reuse-static-caches
</code></pre><p>and optional:</p><pre><code class="language-text">PDS_CONCORD_VALIDATION_CACHE_ROOT
</code></pre><p>Default authoritative validation remains cold and disposable.</p><p>When explicitly enabled for local development, Ruff and Mypy caches may be reused outside the repository. Cache reuse affects speed only, cannot be placed inside the repository, and does not alter coverage or pass/fail semantics.</p><p>CI does not use this option.</p><h3>CI factoring</h3><p>The supported compatibility matrix remains:</p><pre><code class="language-text">Ubuntu  x Python 3.11, 3.12, 3.13, 3.14
Windows x Python 3.11, 3.12, 3.13, 3.14
</code></pre><p>All eight cells still verify:</p><ul><li><p>authenticated released Core inputs;</p></li><li><p>Core installation;</p></li><li><p><code inline="">pip check</code>;</p></li><li><p>Concord import;</p></li><li><p>full pytest;</p></li><li><p><code inline="">git diff --check</code>;</p></li><li><p>repository residue/hygiene.</p></li></ul><p>Complete repository qualification now runs only on:</p><pre><code class="language-text">Ubuntu / Python 3.11
Windows / Python 3.14
</code></pre><p>Those two reference cells delegate to the authoritative <code inline="">scripts/validate_repository.py</code> gate and additionally perform:</p><ul><li><p>Ruff;</p></li><li><p>strict Mypy;</p></li><li><p>documentation validation;</p></li><li><p>release-compatibility validation;</p></li><li><p>clean wheel/sdist build;</p></li><li><p>Twine checks;</p></li><li><p>package-content validation;</p></li><li><p>release-artifact validation;</p></li><li><p>all installed-wheel acceptance scenarios.</p></li></ul><p>This preserves both operating systems and the supported Python range while reducing the number of CI cells repeating the expensive release-qualification tier from 8 to 2.</p><p>Actual aggregate GitHub runner-time improvement will be evaluated from this PR’s Actions run rather than inferred from the structural reduction.</p><h2>Performance results</h2><p>Authoritative pre-optimization baseline:</p><pre><code class="language-text">pytest: 286.730 s
complete validator: 487.916 s
</code></pre><p>Final cold qualification:</p><pre><code class="language-text">pytest: 197.694 s
complete validator: 322.901 s
</code></pre><p>Final improvement:</p>
Measure | Before | After | Change
-- | -- | -- | --
Full pytest | 286.730 s | 197.694 s | -31.1%
Four feature installed smokes | 84.288 s | 22.219 s | -73.6%
All installed-wheel qualification | 162.059 s | 93.048 s | -42.6%
Complete validator | 487.916 s | 322.901 s | -33.8%

<p>The complete validator saves <strong>165.015 seconds</strong> on the measured Windows / Python 3.11.9 environment.</p><h2>Validation</h2><p>Final cold authoritative validation:</p><pre><code class="language-text">1330 passed
10 skipped
Validator exit code: 0
</code></pre><p>Expected Windows skips remain limited to unavailable symlink/POSIX-specific filesystem regressions.</p><p>The complete gate also passed:</p><ul><li><p>Core 0.6.3 wheel verification</p></li><li><p>Core grouping-fixture verification</p></li><li><p><code inline="">pip check</code></p></li><li><p>Ruff</p></li><li><p>Mypy</p></li><li><p>documentation validation</p></li><li><p>release compatibility</p></li><li><p>wheel/sdist build</p></li><li><p>Twine</p></li><li><p>package-content checks</p></li><li><p>release-artifact verification</p></li><li><p>base installed-wheel acceptance</p></li><li><p>shared feature installed-wheel acceptance</p></li><li><p>module-operations installed-wheel acceptance</p></li><li><p><code inline="">git diff --check</code></p></li></ul><h2>Documentation</h2><p>Added:</p><pre><code class="language-text">docs/development/validation-performance.md
</code></pre><p>The document records:</p><ul><li><p>the authoritative validation command;</p></li><li><p>before/after measurements;</p></li><li><p>storage benchmark evidence;</p></li><li><p>cache semantics;</p></li><li><p>CI qualification structure;</p></li><li><p>preserved storage-integrity invariants;</p></li><li><p>remaining measured hotspots;</p></li><li><p>guidance for future performance work.</p></li></ul><p><code inline="">pytest-xdist</code> was deliberately not introduced.</p></body></html><!--EndFragment-->
</body>
</html>