### PR TITLE
test: qualify Concord group planning acceptance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -825,3 +825,13 @@ profile, provider/doctor boundaries, installed launcher identity, mixed
 PDS2 routing ownership and failure isolation, privacy/read-only guarantees,
 the current Suite release-qualification boundary, and installed-wheel
 qualification against released Core 0.6.3.
+
+### v0.3.0 Group-planning repository-local acceptance
+
+[`v0.3.0-group-planning-acceptance.md`](v0.3.0-group-planning-acceptance.md)
+
+Documents issue #69's fresh-state repository-local acceptance across direct
+Groups, manual/arrangement/random GroupPlans, exact Core-backed similar/mixed
+planning, all three missing-signal dispositions, preview/approval/application
+boundaries, Meridian runtime isolation, and the explicit deferral of real
+Meridian-producer acceptance until a stable producer export exists.

--- a/docs/v0.3.0-group-planning-acceptance.md
+++ b/docs/v0.3.0-group-planning-acceptance.md
@@ -1,0 +1,393 @@
+# v0.3.0 Group-planning repository-local acceptance
+
+**Status:** Implemented for issue #69
+
+**Applies to:** Concord `0.3.0.dev0` development against
+`pds-core>=0.6.3,<0.7`
+
+Issue #69 qualifies Concord's complete Group-formation family as one coherent
+repository-local capability. It does not add another planning algorithm or a new
+interoperability protocol. The production behavior being qualified was built in
+issues #49–#56.
+
+The authoritative repository-local acceptance is:
+
+```text
+tests/test_group_planning_acceptance_issue69.py
+```
+
+It starts from fresh synthetic Core/Concord state and exercises public Core and
+Concord application services. It does not install, import, invoke, discover, or
+read private state from Meridian.
+
+## Qualification boundary
+
+The mandatory acceptance dependency shape is:
+
+```text
+released Core contract
+        |
+        v
+synthetic Core class + exact roster
+        |
+        +------------------------------+
+        |                              |
+        v                              v
+ordinary Concord planning       Core grouping_signal_set_v1
+        |                              |
+        +---------------+--------------+
+                        |
+                        v
+                  Concord GroupPlan
+                        |
+                        v
+                    previewed
+                        |
+                        v
+                    approved
+                        |
+                        v
+              application preview
+                        |
+                        v
+              explicit application
+                        |
+                        v
+                     applied
+```
+
+The optional future producer chain is distinct:
+
+```text
+Meridian -> Core grouping_signal_set_v1 -> Concord
+```
+
+That chain is not a Concord runtime dependency and is not required for issue #69.
+
+## Qualified scenario matrix
+
+The repository-local acceptance covers all required Group-formation paths.
+
+| Path | Planning state | Approval/application | Signal dependency |
+| --- | --- | --- | --- |
+| direct canonical Groups | no GroupPlan | direct Group/GroupMembership writes | none |
+| manual GroupPlan | draft proposal edited by teacher | preview, approve, preview application, apply | none |
+| `student_id,group` arrangement | imported GroupPlan | preview, approve, preview application, apply | none |
+| deterministic random GroupPlan | seeded reproducible GroupPlan | preview, approve, preview application, apply | none |
+| `similar_signal` | exact Core-signal-bound GroupPlan | preview, approve, preview application, apply | Core signal |
+| `mixed_signal` | exact Core-signal-bound GroupPlan | preview, approve, preview application, apply | Core signal |
+| missing signal: `manual` | teacher places exact missing students | explicit disposition, preview, approve, apply | Core signal |
+| missing signal: `random` | deterministic missing-only placement | explicit disposition, preview, approve, apply | Core signal |
+| missing signal: `leave_unassigned` | exact missing population remains unresolved | explicit disposition, preview, approve, apply | Core signal |
+
+Every logically independent scenario receives a fresh synthetic workspace, class,
+roster, Activity, and Session so previous scenarios cannot supply hidden state.
+
+## Planning state is not canonical collaboration state
+
+The acceptance freezes this boundary:
+
+```text
+GroupPlan != Group != GroupMembership
+```
+
+For every GroupPlan path, the test proves:
+
+```text
+proposal creation
+    -> no canonical Group / GroupMembership
+
+preview
+    -> no canonical Group / GroupMembership
+
+approval
+    -> no canonical Group / GroupMembership
+
+application preview
+    -> read-only; no canonical Group / GroupMembership
+
+explicit apply
+    -> fresh canonical Group / GroupMembership identities
+    -> GroupPlan.status = applied
+```
+
+Direct Group creation remains a separate first-class path and does not create a
+GroupPlan merely to make the two workflows look alike.
+
+The application assertion also reloads the current record graph, requires graph
+validation to succeed, verifies exact Core-student participant references, and
+checks that application-created Group and GroupMembership identities are fresh
+rather than reused plan keys or student IDs.
+
+## Teacher approval remains an execution boundary
+
+The planning lifecycle exercised by repository-local acceptance is:
+
+```text
+draft
+    -> previewed
+    -> approved
+    -> application preview
+    -> explicit application
+    -> applied
+```
+
+Generated, imported, signal-informed, and incomplete-signal proposals are not
+allowed to skip directly from proposal generation to canonical membership state.
+The test calls the public lifecycle services rather than manufacturing an approved
+GroupPlan record as fixture state.
+
+## Exact Core signal binding
+
+Signal-backed acceptance constructs a synthetic public Core
+`grouping_signal_set_v1` and writes it through Core's public immutable exchange
+storage. Its provenance deliberately uses:
+
+```text
+source.kind = module_generated
+source.module_id = meridian
+```
+
+This is synthetic producer provenance data. It is not evidence that Meridian
+created the fixture and it does not cause Concord to import or dispatch Meridian.
+
+Concord selects the signal by exact:
+
+```text
+signal_set_id
+dimension_id
+Core canonical signal digest
+```
+
+The acceptance computes the digest using Core's public
+`calculate_grouping_signal_digest` service and requires the persisted GroupPlan to
+retain that exact binding.
+
+It also explicitly proves:
+
+```text
+Core canonical signal digest != source.snapshot_digest
+```
+
+`source.snapshot_digest` binds the producer's upstream source snapshot.
+The Core canonical signal digest binds the exact neutral planning input consumed by
+Concord. They are separate integrity relationships and are not interchangeable.
+
+No acceptance helper infers a signal from `latest`, `current`, creation time,
+filesystem order, or any other implicit selection rule.
+
+## Contextual ordinal-band boundary
+
+The synthetic signal uses ordinal Core bands only to exercise Concord's existing
+`similar_signal` and `mixed_signal` algorithms.
+
+The acceptance does not reinterpret them as academic or permanent student state:
+
+```text
+band != Score
+band != Grade
+band != percentage
+band != proficiency
+band != ability classification
+missing signal != band 0
+missing signal != lowest band
+```
+
+No raw academic values, percentages, evidence details, proficiency labels, or
+band-boundary policy are introduced into the acceptance fixture.
+
+## Missing and incomplete signals
+
+Partial Core signal coverage is valid input. The acceptance leaves two synthetic
+roster students without entries in the selected dimension and uses Core diagnostics
+to identify that exact missing population.
+
+No synthetic signal bands are invented for those students.
+
+### Manual disposition
+
+For `manual`, the teacher explicitly places every exact missing-signal student by
+student ID using Concord's existing manual GroupPlan editor. Only after all of the
+missing students are resolved is the `manual` disposition recorded. The six-student
+plan then proceeds through preview, approval, application preview, and explicit
+application.
+
+### Deterministic missing-only random disposition
+
+For `random`, Concord receives a separate explicit missing-signal seed. The test
+proves that:
+
+```text
+ordinary plan seed != missing-signal seed
+```
+
+and that only the exact missing population is randomized. Students already
+represented by the Core signal remain in their signal-derived planned groups.
+A second fresh workspace repeats the operation with the same seed and must produce
+the same proposal before the first plan is applied.
+
+### Leave-unassigned disposition
+
+For `leave_unassigned`, the unresolved population must remain exactly equal to the
+current Core-diagnosed missing population. Approval and application revalidate that
+narrow exception.
+
+Application therefore creates GroupMembership records only for represented
+students. The missing students receive no synthetic membership and no synthetic
+band.
+
+## Signal provenance does not leak into canonical Group state
+
+An applied signal-backed GroupPlan legitimately retains its exact planning
+provenance:
+
+```text
+strategy
+source_signal_set_id
+source_signal_set_digest
+source_signal_dimension_id
+missing-signal disposition when applicable
+```
+
+The created canonical Group and GroupMembership records do not copy:
+
+```text
+signal identity
+signal digest
+dimension identity
+ordinal band
+producer module identity
+producer snapshot identity
+planning strategy
+missing-signal disposition
+missing-signal random seed
+```
+
+The acceptance checks both the native record fields and representative serialized
+record content for this separation.
+
+This keeps signal data in teacher-restricted planning history rather than turning
+it into permanent collaboration metadata.
+
+## Meridian remains optional
+
+Mandatory #69 acceptance must remain valid on a machine where Meridian is either
+absent or installed.
+
+The test therefore has two independent guards:
+
+1. package metadata is parsed and must contain no Meridian dependency, optional
+   dependency, or entry-point coupling; and
+2. a fresh Python process replaces `__import__` with a guard that raises if any
+   `meridian` import is attempted while importing Concord workflows.
+
+The second guard is intentionally stronger than checking whether Meridian is
+installed. A developer may have Meridian installed for unrelated work; Concord
+still must not import it.
+
+The dependency direction remains:
+
+```text
+Meridian -> Core
+Concord  -> Core
+
+Meridian -X-> Concord
+Concord  -X-> Meridian
+```
+
+A producer name inside Core signal provenance is data, not runtime dispatch.
+
+## Optional real Meridian interoperability status
+
+**Optional real Meridian producer acceptance: deferred.**
+
+The upstream state was re-audited while implementing issue #69. The relevant
+Meridian sequence is not yet a stable producer artifact:
+
+```text
+Meridian #36
+    -> qualifies the neutral Core grouping-signal contract
+    -> explicitly stops before production generation/export
+
+Meridian #38
+    -> deterministic grouping-signal generation
+    -> open at #69 implementation time
+
+Meridian #39
+    -> grouping-signal preview and diagnostics
+    -> open at #69 implementation time
+
+Meridian #40
+    -> immutable signal export through Core and optional CSV
+    -> open at #69 implementation time
+```
+
+Therefore no authentic stable Meridian-produced `grouping_signal_set_v1` snapshot
+is vendored into Concord for #69, and no synthetic Core fixture is represented as
+if Meridian produced it.
+
+This deferral is intentional and nonblocking. A later producer-to-consumer or
+suite qualification may add:
+
+```text
+real Meridian generation
+    -> explicit Core immutable export
+    -> captured provenance-verifiable Core snapshot
+    -> Concord consumption without invoking Meridian
+```
+
+only after that producer path exists and is stable. That future qualification must
+not change Concord's runtime dependency direction.
+
+## CI and repository validation
+
+Issue #69 does not add a parallel validator or a dedicated CI job.
+
+The repository-local acceptance file is an ordinary pytest module, so the existing
+CI matrix and the complete repository validator exercise it through the full test
+suite. This preserves issue #93's validation factoring and avoids paying for a
+second duplicate Group-planning qualification phase.
+
+The authoritative final local gate remains:
+
+```powershell
+python scripts/validate_repository.py `
+  --core-wheel "<current released compatible Core wheel>"
+```
+
+`--allow-dirty` is acceptable during branch development. Final qualification must
+retain the existing exact Core authentication, full pytest, Ruff, mypy,
+documentation checks, build/package validation, installed-wheel qualification,
+and `git diff --check` semantics.
+
+## What issue #69 does not prove
+
+Repository-local acceptance does not claim that:
+
+```text
+Meridian currently generates the synthetic signal fixture
+Meridian currently exports a production signal to Core
+Concord requires Meridian
+signal provenance is runtime dispatch
+signal bands are proficiency or ability labels
+application preview mutates canonical state
+approval itself creates Groups
+```
+
+It also does not replace the installed/physical workflow acceptance owned by the
+next milestone issue.
+
+## Handoff to issue #70
+
+With repository-local Group planning qualified, the next acceptance layer is:
+
+```text
+#70 — Build representative installed and physical starter-workflow acceptance
+```
+
+That issue owns representative installed and physical flows from approved Groups
+through packet generation, print/scan return, assembly, review, scoring, and
+publication, including proof that signal data does not leak into artifacts or
+academic publication state.
+
+Issue #69 leaves that installed/physical boundary intact.

--- a/tests/test_group_planning_acceptance_document_issue69.py
+++ b/tests/test_group_planning_acceptance_document_issue69.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "v0.3.0-group-planning-acceptance.md"
+DOC_INDEX = ROOT / "docs" / "README.md"
+ACCEPTANCE = ROOT / "tests" / "test_group_planning_acceptance_issue69.py"
+
+
+def test_issue69_document_freezes_repository_local_acceptance_boundary() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    required = (
+        "**Status:** Implemented for issue #69",
+        "tests/test_group_planning_acceptance_issue69.py",
+        "GroupPlan != Group != GroupMembership",
+        "draft\n    -> previewed\n    -> approved",
+        "student_id,group",
+        "deterministic random GroupPlan",
+        "similar_signal",
+        "mixed_signal",
+        "calculate_grouping_signal_digest",
+        "Core canonical signal digest != source.snapshot_digest",
+        "missing signal != lowest band",
+        "manual",
+        "random",
+        "leave_unassigned",
+        "Concord  -X-> Meridian",
+        "Optional real Meridian producer acceptance: deferred.",
+        "Meridian #36",
+        "Meridian #38",
+        "Meridian #39",
+        "Meridian #40",
+        "no authentic stable Meridian-produced `grouping_signal_set_v1` snapshot",
+        "Issue #69 does not add a parallel validator or a dedicated CI job.",
+        "#70 — Build representative installed and physical starter-workflow acceptance",
+    )
+    for phrase in required:
+        assert phrase in text, phrase
+
+
+def test_issue69_document_is_indexed_and_matches_acceptance_guards() -> None:
+    index = DOC_INDEX.read_text(encoding="utf-8")
+    acceptance = ACCEPTANCE.read_text(encoding="utf-8")
+
+    assert (
+        "[`v0.3.0-group-planning-acceptance.md`]"
+        "(v0.3.0-group-planning-acceptance.md)"
+    ) in index
+
+    required_acceptance_guards = (
+        "test_package_metadata_keeps_meridian_outside_concord_dependencies",
+        "test_importing_concord_workflows_does_not_attempt_meridian_import",
+        'module_id="meridian"',
+        "calculate_grouping_signal_digest",
+        "test_similar_signal_plan_binds_core_digest_then_explicitly_applies",
+        "test_mixed_signal_plan_binds_core_digest_then_explicitly_applies",
+        "test_missing_signal_manual_resolution_requires_placement_then_applies",
+        "test_missing_signal_random_places_only_missing_reproducibly_then_applies",
+        "test_missing_signal_leave_unassigned_applies_without_missing_memberships",
+    )
+    for phrase in required_acceptance_guards:
+        assert phrase in acceptance, phrase

--- a/tests/test_group_planning_acceptance_issue69.py
+++ b/tests/test_group_planning_acceptance_issue69.py
@@ -1,0 +1,1220 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tomllib
+from dataclasses import fields
+from datetime import datetime, timezone
+from pathlib import Path
+
+from pds_core.class_metadata import (
+    create_class_metadata,
+    write_class_metadata_for_class,
+)
+from pds_core.classes import write_class_roster
+from pds_core.grouping_signal_storage import (
+    calculate_grouping_signal_digest,
+    write_grouping_signal,
+)
+from pds_core.grouping_signals import (
+    GroupingSignalDimension,
+    GroupingSignalSet,
+    GroupingSignalSource,
+    GroupingSignalStudentBand,
+)
+from pds_core.rosters import create_roster
+from pds_core.routing_models import ModuleWorkRef
+from pds_core.workspace import ensure_workspace_root
+
+from concord.model_validation import collect_record_graph_issues
+from concord.models import EffectiveContext, PlannedGroup
+from concord.storage import list_work_snapshots, load_current_record_graph
+from concord.workflows import (
+    AddMembershipsRequest,
+    ApplyGroupPlanRequest,
+    ApproveGroupPlanRequest,
+    CreateActivityContextRequest,
+    CreateGroupRequest,
+    CreateGroupWithMembersRequest,
+    CreateManualGroupPlanRequest,
+    CreateRandomGroupPlanRequest,
+    CreateSignalGroupPlanRequest,
+    GroupMemberSpec,
+    ImportArrangementGroupPlanRequest,
+    PlaceStudentInPlanRequest,
+    PrepareGroupPlanApplicationRequest,
+    PreviewGroupPlanRequest,
+    SetMissingSignalDispositionRequest,
+    WorkflowActor,
+    add_memberships,
+    apply_group_plan,
+    approve_group_plan,
+    create_activity_context,
+    create_group,
+    create_group_with_members,
+    create_manual_group_plan,
+    create_random_group_plan,
+    create_signal_group_plan,
+    import_arrangement_group_plan,
+    inspect_group_plan_missing_signal,
+    place_student_in_plan,
+    prepare_group_plan_application,
+    preview_group_plan,
+    set_missing_signal_disposition,
+    show_group_plan,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+CLASS_ID = "class-acceptance"
+ACTIVITY_ID = "activity-acceptance"
+SESSION_ID = "session-1"
+STUDENT_IDS = tuple(f"student-{index}" for index in range(1, 7))
+
+_PLANNING_ONLY_FIELDS = frozenset(
+    {
+        "strategy",
+        "seed",
+        "source_signal_set_id",
+        "source_signal_set_digest",
+        "source_signal_dimension_id",
+        "missing_signal_disposition",
+        "missing_signal_random_seed",
+        "applied_application_id",
+        "applied_application_digest",
+    }
+)
+
+
+def _clock(minute: int) -> datetime:
+    return datetime(2026, 8, 29, 20, minute, tzinfo=timezone.utc)
+
+
+def _actor() -> WorkflowActor:
+    return WorkflowActor(
+        actor_id="teacher-acceptance",
+        display_label="Synthetic Teacher",
+        role_label="teacher",
+    )
+
+
+def _context() -> EffectiveContext:
+    return EffectiveContext(
+        activity_id=ACTIVITY_ID,
+        session_ids=(SESSION_ID,),
+    )
+
+
+def _work() -> ModuleWorkRef:
+    return ModuleWorkRef(
+        module_id="concord",
+        class_id=CLASS_ID,
+        work_id=ACTIVITY_ID,
+    )
+
+
+def _workspace(tmp_path: Path) -> tuple[Path, int]:
+    root = ensure_workspace_root(tmp_path / "workspace")
+    write_class_metadata_for_class(
+        root,
+        create_class_metadata(
+            CLASS_ID,
+            "2026-2027",
+            created_at=_clock(0),
+        ),
+    )
+    write_class_roster(
+        root,
+        create_roster(
+            CLASS_ID,
+            tuple(
+                {
+                    "student_id": student_id,
+                    "last_name": f"Last{index}",
+                    "first_name": f"First{index}",
+                    "period": "1",
+                }
+                for index, student_id in enumerate(STUDENT_IDS, start=1)
+            ),
+        ),
+    )
+    created = create_activity_context(
+        CreateActivityContextRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            title="Repository-local Group Planning Acceptance",
+            activity_type="project",
+            scoring_orientation="evidence_only",
+            session_id=SESSION_ID,
+            actor=_actor(),
+            session_label="Acceptance Session",
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(1),
+    )
+    return root, created.commit.snapshot_revision
+
+
+def _assert_no_canonical_group_state(root: Path) -> None:
+    graph = load_current_record_graph(root, _work()).graph
+    assert graph.groups == ()
+    assert graph.memberships == ()
+    assert collect_record_graph_issues(graph) == ()
+
+
+def _apply_approved_plan(
+    root: Path,
+    *,
+    group_plan_id: str,
+    draft_snapshot_revision: int,
+    application_id: str,
+    clock_minute: int,
+    expected_unresolved_student_ids: tuple[str, ...] = (),
+):
+    """Exercise audited planning state, zero-write application preview, and apply."""
+    snapshots_before_preview = list_work_snapshots(root, _work())
+    previewed = preview_group_plan(
+        PreviewGroupPlanRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_plan_id=group_plan_id,
+            expected_snapshot_revision=draft_snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(clock_minute),
+    )
+    assert previewed.plan.status == "previewed"
+    assert previewed.summary.snapshot_revision == draft_snapshot_revision + 1
+    assert list_work_snapshots(root, _work()) == (
+        *snapshots_before_preview,
+        previewed.summary.snapshot_revision,
+    )
+    _assert_no_canonical_group_state(root)
+
+    approved = approve_group_plan(
+        ApproveGroupPlanRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_plan_id=group_plan_id,
+            expected_snapshot_revision=previewed.summary.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(clock_minute + 1),
+    )
+    assert approved.status == "approved"
+    assert approved.commit.snapshot_revision == previewed.summary.snapshot_revision + 1
+    _assert_no_canonical_group_state(root)
+
+    snapshots_before_application_preview = list_work_snapshots(root, _work())
+    application = prepare_group_plan_application(
+        PrepareGroupPlanApplicationRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_plan_id=group_plan_id,
+            application_id=application_id,
+            fallback_effective_context=_context(),
+        ),
+        workspace_root=root,
+    )
+    assert application.expected_snapshot_revision == approved.commit.snapshot_revision
+    assert application.unresolved_student_ids == expected_unresolved_student_ids
+    assert list_work_snapshots(root, _work()) == snapshots_before_application_preview
+    _assert_no_canonical_group_state(root)
+
+    result = apply_group_plan(
+        ApplyGroupPlanRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_plan_id=group_plan_id,
+            application_id=application.application_id,
+            application_digest=application.application_digest,
+            expected_snapshot_revision=application.expected_snapshot_revision,
+            actor=_actor(),
+            fallback_effective_context=_context(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(clock_minute + 2),
+    )
+    assert result.status == "applied"
+    assert result.application_id == application.application_id
+    assert result.application_digest == application.application_digest
+    assert result.commit.snapshot_revision == application.expected_snapshot_revision + 1
+    assert result.unresolved_count == len(expected_unresolved_student_ids)
+    assert result.group_ids == tuple(group.group_id for group in application.groups)
+    assert result.membership_ids == tuple(
+        membership.membership_id for membership in application.memberships
+    )
+    assert set(result.group_ids).isdisjoint(
+        group.planned_group_key for group in application.groups
+    )
+    assert set(result.membership_ids).isdisjoint(STUDENT_IDS)
+
+    graph = load_current_record_graph(root, _work()).graph
+    assert collect_record_graph_issues(graph) == ()
+    applied_plan = next(
+        plan for plan in graph.group_plans if plan.group_plan_id == group_plan_id
+    )
+    assert applied_plan.status == "applied"
+    assert applied_plan.applied_application_id == application.application_id
+    assert applied_plan.applied_application_digest == application.application_digest
+    assert {group.group_id for group in graph.groups} == set(result.group_ids)
+    assert {membership.membership_id for membership in graph.memberships} == set(
+        result.membership_ids
+    )
+
+    membership_by_id = {
+        membership.membership_id: membership for membership in graph.memberships
+    }
+    for expected in application.memberships:
+        membership = membership_by_id[expected.membership_id]
+        assert membership.group_id == expected.group_id
+        assert membership.participant_reference.participant_kind == "core_student"
+        assert membership.participant_reference.participant_id == expected.student_id
+        assert membership.participant_reference.owning_system == "core"
+        assert membership.effective_context == expected.effective_context
+
+    for record in (*graph.groups, *graph.memberships):
+        record_fields = {field.name for field in fields(record)}
+        assert record_fields.isdisjoint(_PLANNING_ONLY_FIELDS)
+
+    return application, result, graph
+
+
+
+def _core_signal() -> GroupingSignalSet:
+    dimension_id = "proficiency-band"
+    return GroupingSignalSet(
+        schema_version="1",
+        record_type="grouping_signal_set",
+        signal_set_id="signal-acceptance",
+        class_id=CLASS_ID,
+        created_at=_clock(1),
+        source=GroupingSignalSource(
+            kind="module_generated",
+            module_id="meridian",
+            snapshot_id="academic-period-2026-q1",
+            snapshot_digest_algorithm="sha256",
+            snapshot_digest="b" * 64,
+        ),
+        dimensions=(
+            GroupingSignalDimension(
+                dimension_id=dimension_id,
+                band_count=4,
+            ),
+        ),
+        student_bands=(
+            GroupingSignalStudentBand(
+                student_id="student-1",
+                dimension_id=dimension_id,
+                band=1,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-2",
+                dimension_id=dimension_id,
+                band=1,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-3",
+                dimension_id=dimension_id,
+                band=1,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-4",
+                dimension_id=dimension_id,
+                band=2,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-5",
+                dimension_id=dimension_id,
+                band=2,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-6",
+                dimension_id=dimension_id,
+                band=3,
+            ),
+        ),
+    )
+
+
+def _create_signal_plan(
+    root: Path,
+    *,
+    revision: int,
+    strategy: str,
+    group_plan_id: str,
+):
+    signal = _core_signal()
+    write_grouping_signal(root, signal)
+    canonical_digest = calculate_grouping_signal_digest(signal)
+    created = create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_plan_id=group_plan_id,
+            strategy=strategy,
+            signal_set_id=signal.signal_set_id,
+            dimension_id="proficiency-band",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            target_group_count=2,
+            expected_roster_student_ids=STUDENT_IDS,
+            expected_signal_set_digest=canonical_digest,
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(2),
+    )
+    detail = show_group_plan(
+        CLASS_ID,
+        ACTIVITY_ID,
+        group_plan_id,
+        workspace_root=root,
+    )
+    assert created.strategy == strategy
+    assert created.group_count == 2
+    assert created.assigned_student_count == 6
+    assert created.unresolved_student_count == 0
+    assert created.group_sizes == (3, 3)
+    assert created.signal_set_id == signal.signal_set_id
+    assert created.signal_set_digest == canonical_digest
+    assert created.signal_set_digest != signal.source.snapshot_digest
+    assert created.dimension_id == "proficiency-band"
+    assert detail.plan.status == "draft"
+    assert detail.plan.strategy == strategy
+    assert detail.plan.source_signal_set_id == signal.signal_set_id
+    assert detail.plan.source_signal_set_digest == canonical_digest
+    assert detail.plan.source_signal_dimension_id == "proficiency-band"
+    assert detail.plan.unresolved_student_ids == ()
+    _assert_no_canonical_group_state(root)
+    return signal, canonical_digest, created, detail
+
+
+def _assert_signal_metadata_stays_on_plan(
+    graph,
+    *,
+    group_plan_id: str,
+    signal: GroupingSignalSet,
+    canonical_digest: str,
+) -> None:
+    applied_plan = next(
+        plan for plan in graph.group_plans if plan.group_plan_id == group_plan_id
+    )
+    assert applied_plan.source_signal_set_id == signal.signal_set_id
+    assert applied_plan.source_signal_set_digest == canonical_digest
+    assert applied_plan.source_signal_dimension_id == "proficiency-band"
+
+    for record in (*graph.groups, *graph.memberships):
+        rendered = repr(record)
+        assert signal.signal_set_id not in rendered
+        assert canonical_digest not in rendered
+        assert "proficiency-band" not in rendered
+
+
+def test_package_metadata_keeps_meridian_outside_concord_dependencies() -> None:
+    with (ROOT / "pyproject.toml").open("rb") as handle:
+        project = tomllib.load(handle)["project"]
+
+    declared = [*project.get("dependencies", ())]
+    for dependencies in project.get("optional-dependencies", {}).values():
+        declared.extend(dependencies)
+
+    assert all("meridian" not in dependency.casefold() for dependency in declared)
+    assert "meridian" not in repr(project.get("entry-points", {})).casefold()
+
+
+def test_importing_concord_workflows_does_not_attempt_meridian_import() -> None:
+    script = """
+import builtins
+
+real_import = builtins.__import__
+
+
+def guarded_import(name, *args, **kwargs):
+    if name == "meridian" or name.startswith("meridian."):
+        raise RuntimeError(f"Concord attempted forbidden Meridian import: {name}")
+    return real_import(name, *args, **kwargs)
+
+
+builtins.__import__ = guarded_import
+import concord.workflows  # noqa: F401, E402
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=ROOT,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_direct_groups_remain_canonical_without_group_plan_or_signal(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    context = _context()
+
+    first = create_group_with_members(
+        CreateGroupWithMembersRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_id="group-a",
+            label="Group A",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            status="active",
+            effective_context=context,
+            members=tuple(
+                GroupMemberSpec(
+                    membership_id=f"membership-{index}",
+                    student_id=f"student-{index}",
+                    effective_context=context,
+                )
+                for index in range(1, 4)
+            ),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(2),
+    )
+    second = create_group(
+        CreateGroupRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_id="group-b",
+            label="Group B",
+            expected_snapshot_revision=first.commit.snapshot_revision,
+            actor=_actor(),
+            status="active",
+            effective_context=context,
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(3),
+    )
+    added = add_memberships(
+        AddMembershipsRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_id="group-b",
+            members=tuple(
+                GroupMemberSpec(
+                    membership_id=f"membership-{index}",
+                    student_id=f"student-{index}",
+                    effective_context=context,
+                )
+                for index in range(4, 7)
+            ),
+            expected_snapshot_revision=second.commit.snapshot_revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(4),
+    )
+
+    assert first.membership_ids == (
+        "membership-1",
+        "membership-2",
+        "membership-3",
+    )
+    assert added.membership_ids == (
+        "membership-4",
+        "membership-5",
+        "membership-6",
+    )
+
+    graph = load_current_record_graph(root, _work()).graph
+    assert graph.group_plans == ()
+    assert {group.group_id for group in graph.groups} == {"group-a", "group-b"}
+    assert len(graph.memberships) == 6
+    assert collect_record_graph_issues(graph) == ()
+
+    membership_by_id = {
+        membership.membership_id: membership for membership in graph.memberships
+    }
+    expected_groups = {
+        "membership-1": "group-a",
+        "membership-2": "group-a",
+        "membership-3": "group-a",
+        "membership-4": "group-b",
+        "membership-5": "group-b",
+        "membership-6": "group-b",
+    }
+    for index, student_id in enumerate(STUDENT_IDS, start=1):
+        membership = membership_by_id[f"membership-{index}"]
+        assert membership.group_id == expected_groups[membership.membership_id]
+        assert membership.participant_reference.participant_kind == "core_student"
+        assert membership.participant_reference.participant_id == student_id
+        assert membership.participant_reference.owning_system == "core"
+        assert membership.effective_context == context
+        assert membership.status == "active"
+
+    for record in (*graph.groups, *graph.memberships):
+        record_fields = {field.name for field in fields(record)}
+        assert record_fields.isdisjoint(_PLANNING_ONLY_FIELDS)
+
+
+def test_manual_group_plan_uses_editor_then_explicit_application(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    created = create_manual_group_plan(
+        CreateManualGroupPlanRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_plan_id="plan-manual",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            proposed_groups=(
+                PlannedGroup(planned_group_key="alpha", label="Alpha"),
+                PlannedGroup(planned_group_key="beta", label="Beta"),
+            ),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(2),
+    )
+    detail = show_group_plan(
+        CLASS_ID,
+        ACTIVITY_ID,
+        "plan-manual",
+        workspace_root=root,
+    )
+    assert detail.plan.strategy == "manual"
+    assert detail.plan.status == "draft"
+    assert detail.plan.unresolved_student_ids == STUDENT_IDS
+    _assert_no_canonical_group_state(root)
+
+    current_revision = created.commit.snapshot_revision
+    destinations = {
+        **{student_id: "alpha" for student_id in STUDENT_IDS[:3]},
+        **{student_id: "beta" for student_id in STUDENT_IDS[3:]},
+    }
+    for offset, student_id in enumerate(STUDENT_IDS, start=3):
+        placed = place_student_in_plan(
+            PlaceStudentInPlanRequest(
+                class_id=CLASS_ID,
+                activity_id=ACTIVITY_ID,
+                group_plan_id="plan-manual",
+                student_id=student_id,
+                planned_group_key=destinations[student_id],
+                expected_snapshot_revision=current_revision,
+                actor=_actor(),
+            ),
+            workspace_root=root,
+            clock=lambda offset=offset: _clock(offset),
+        )
+        assert placed.changed is True
+        current_revision = placed.detail.summary.snapshot_revision
+
+    detail = show_group_plan(
+        CLASS_ID,
+        ACTIVITY_ID,
+        "plan-manual",
+        workspace_root=root,
+    )
+    assert detail.plan.unresolved_student_ids == ()
+    assert tuple(
+        (group.planned_group_key, group.student_ids)
+        for group in detail.plan.proposed_groups
+    ) == (
+        ("alpha", STUDENT_IDS[:3]),
+        ("beta", STUDENT_IDS[3:]),
+    )
+    _assert_no_canonical_group_state(root)
+
+    application, result, _ = _apply_approved_plan(
+        root,
+        group_plan_id="plan-manual",
+        draft_snapshot_revision=current_revision,
+        application_id="apply-manual-acceptance",
+        clock_minute=10,
+    )
+    assert application.group_count == 2
+    assert application.membership_count == 6
+    assert result.group_count == 2
+    assert result.membership_count == 6
+
+
+def test_arrangement_csv_remains_a_plan_until_explicit_application(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    source = tmp_path / "arrangement.csv"
+    source.write_text(
+        "student_id,group\n"
+        "student-1,alpha\n"
+        "student-2,alpha\n"
+        "student-3,alpha\n"
+        "student-4,beta\n"
+        "student-5,beta\n"
+        "student-6,beta\n",
+        encoding="utf-8",
+    )
+    imported = import_arrangement_group_plan(
+        ImportArrangementGroupPlanRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_plan_id="plan-arrangement",
+            csv_path=source,
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(2),
+    )
+    assert imported.data_row_count == 6
+    assert imported.proposed_group_count == 2
+    assert imported.assigned_student_count == 6
+    assert imported.unresolved_student_count == 0
+
+    detail = show_group_plan(
+        CLASS_ID,
+        ACTIVITY_ID,
+        "plan-arrangement",
+        workspace_root=root,
+    )
+    assert detail.plan.strategy == "imported_arrangement"
+    assert detail.plan.status == "draft"
+    assert detail.plan.unresolved_student_ids == ()
+    assert tuple(
+        (group.planned_group_key, group.student_ids)
+        for group in detail.plan.proposed_groups
+    ) == (
+        ("alpha", STUDENT_IDS[:3]),
+        ("beta", STUDENT_IDS[3:]),
+    )
+    assert str(source) not in repr(detail.plan)
+    _assert_no_canonical_group_state(root)
+
+    application, result, _ = _apply_approved_plan(
+        root,
+        group_plan_id="plan-arrangement",
+        draft_snapshot_revision=imported.mutation.commit.snapshot_revision,
+        application_id="apply-arrangement-acceptance",
+        clock_minute=10,
+    )
+    assert application.group_count == 2
+    assert application.membership_count == 6
+    assert result.group_count == 2
+    assert result.membership_count == 6
+
+
+def test_random_group_plan_is_reproducible_then_explicitly_applied(
+    tmp_path: Path,
+) -> None:
+    first_root, first_revision = _workspace(tmp_path / "first")
+    first = create_random_group_plan(
+        CreateRandomGroupPlanRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_plan_id="plan-random",
+            expected_snapshot_revision=first_revision,
+            actor=_actor(),
+            seed="issue69-seed",
+            target_group_count=2,
+        ),
+        workspace_root=first_root,
+        clock=lambda: _clock(2),
+    )
+    first_detail = show_group_plan(
+        CLASS_ID,
+        ACTIVITY_ID,
+        "plan-random",
+        workspace_root=first_root,
+    )
+    assert first.group_count == 2
+    assert first.assigned_student_count == 6
+    assert first.group_sizes == (3, 3)
+    assert first_detail.plan.strategy == "random"
+    assert first_detail.plan.seed == "issue69-seed"
+    assert first_detail.plan.target_group_count == 2
+    assert first_detail.plan.unresolved_student_ids == ()
+    _assert_no_canonical_group_state(first_root)
+
+    second_root, second_revision = _workspace(tmp_path / "second")
+    second = create_random_group_plan(
+        CreateRandomGroupPlanRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_plan_id="plan-random",
+            expected_snapshot_revision=second_revision,
+            actor=_actor(),
+            seed="issue69-seed",
+            target_group_count=2,
+        ),
+        workspace_root=second_root,
+        clock=lambda: _clock(2),
+    )
+    second_detail = show_group_plan(
+        CLASS_ID,
+        ACTIVITY_ID,
+        "plan-random",
+        workspace_root=second_root,
+    )
+    assert second.group_sizes == first.group_sizes
+    assert second_detail.plan.proposed_groups == first_detail.plan.proposed_groups
+
+    application, result, _ = _apply_approved_plan(
+        first_root,
+        group_plan_id="plan-random",
+        draft_snapshot_revision=first.mutation.commit.snapshot_revision,
+        application_id="apply-random-acceptance",
+        clock_minute=10,
+    )
+    assert application.group_count == 2
+    assert application.membership_count == 6
+    assert result.group_count == 2
+    assert result.membership_count == 6
+
+
+def test_similar_signal_plan_binds_core_digest_then_explicitly_applies(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    signal, canonical_digest, created, detail = _create_signal_plan(
+        root,
+        revision=revision,
+        strategy="similar_signal",
+        group_plan_id="plan-similar",
+    )
+    assert tuple(
+        (group.planned_group_key, group.student_ids)
+        for group in detail.plan.proposed_groups
+    ) == (
+        ("similar-1", STUDENT_IDS[:3]),
+        ("similar-2", STUDENT_IDS[3:]),
+    )
+
+    application, result, graph = _apply_approved_plan(
+        root,
+        group_plan_id="plan-similar",
+        draft_snapshot_revision=created.mutation.commit.snapshot_revision,
+        application_id="apply-similar-acceptance",
+        clock_minute=10,
+    )
+    assert application.group_count == 2
+    assert application.membership_count == 6
+    assert result.group_count == 2
+    assert result.membership_count == 6
+    _assert_signal_metadata_stays_on_plan(
+        graph,
+        group_plan_id="plan-similar",
+        signal=signal,
+        canonical_digest=canonical_digest,
+    )
+
+
+def test_mixed_signal_plan_binds_core_digest_then_explicitly_applies(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    signal, canonical_digest, created, detail = _create_signal_plan(
+        root,
+        revision=revision,
+        strategy="mixed_signal",
+        group_plan_id="plan-mixed",
+    )
+    assert tuple(
+        (group.planned_group_key, group.student_ids)
+        for group in detail.plan.proposed_groups
+    ) == (
+        ("mixed-1", ("student-2", "student-5", "student-6")),
+        ("mixed-2", ("student-1", "student-3", "student-4")),
+    )
+
+    application, result, graph = _apply_approved_plan(
+        root,
+        group_plan_id="plan-mixed",
+        draft_snapshot_revision=created.mutation.commit.snapshot_revision,
+        application_id="apply-mixed-acceptance",
+        clock_minute=10,
+    )
+    assert application.group_count == 2
+    assert application.membership_count == 6
+    assert result.group_count == 2
+    assert result.membership_count == 6
+    _assert_signal_metadata_stays_on_plan(
+        graph,
+        group_plan_id="plan-mixed",
+        signal=signal,
+        canonical_digest=canonical_digest,
+    )
+
+
+
+
+def _partial_core_signal() -> GroupingSignalSet:
+    dimension_id = "proficiency-band"
+    return GroupingSignalSet(
+        schema_version="1",
+        record_type="grouping_signal_set",
+        signal_set_id="signal-partial-acceptance",
+        class_id=CLASS_ID,
+        created_at=_clock(1),
+        source=GroupingSignalSource(
+            kind="module_generated",
+            module_id="meridian",
+            snapshot_id="academic-period-2026-q1-partial",
+            snapshot_digest_algorithm="sha256",
+            snapshot_digest="c" * 64,
+        ),
+        dimensions=(
+            GroupingSignalDimension(
+                dimension_id=dimension_id,
+                band_count=4,
+            ),
+        ),
+        student_bands=(
+            GroupingSignalStudentBand(
+                student_id="student-1",
+                dimension_id=dimension_id,
+                band=4,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-2",
+                dimension_id=dimension_id,
+                band=1,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-3",
+                dimension_id=dimension_id,
+                band=3,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-4",
+                dimension_id=dimension_id,
+                band=2,
+            ),
+        ),
+    )
+
+
+def _create_partial_signal_plan(
+    root: Path,
+    *,
+    revision: int,
+    group_plan_id: str,
+):
+    signal = _partial_core_signal()
+    write_grouping_signal(root, signal)
+    canonical_digest = calculate_grouping_signal_digest(signal)
+    created = create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_plan_id=group_plan_id,
+            strategy="mixed_signal",
+            signal_set_id=signal.signal_set_id,
+            dimension_id="proficiency-band",
+            expected_snapshot_revision=revision,
+            actor=_actor(),
+            target_group_count=2,
+            expected_roster_student_ids=STUDENT_IDS,
+            expected_signal_set_digest=canonical_digest,
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(2),
+    )
+    detail = show_group_plan(
+        CLASS_ID,
+        ACTIVITY_ID,
+        group_plan_id,
+        workspace_root=root,
+    )
+    inspection = inspect_group_plan_missing_signal(
+        CLASS_ID,
+        ACTIVITY_ID,
+        group_plan_id,
+        workspace_root=root,
+    )
+    assert created.assigned_student_count == 4
+    assert created.unresolved_student_count == 2
+    assert detail.plan.unresolved_student_ids == ("student-5", "student-6")
+    assert inspection.missing_student_ids == ("student-5", "student-6")
+    assert inspection.missing_assigned_student_ids == ()
+    assert inspection.missing_unresolved_student_ids == inspection.missing_student_ids
+    assert inspection.signal_set_digest == canonical_digest
+    assert inspection.signal_set_digest != signal.source.snapshot_digest
+    assert {entry.student_id for entry in signal.student_bands} == set(STUDENT_IDS[:4])
+    _assert_no_canonical_group_state(root)
+    return signal, canonical_digest, created, detail, inspection
+
+
+def _set_missing_disposition(
+    root: Path,
+    *,
+    group_plan_id: str,
+    disposition: str,
+    expected_snapshot_revision: int,
+    random_seed: str | None = None,
+    clock_minute: int,
+):
+    return set_missing_signal_disposition(
+        SetMissingSignalDispositionRequest(
+            class_id=CLASS_ID,
+            activity_id=ACTIVITY_ID,
+            group_plan_id=group_plan_id,
+            disposition=disposition,
+            expected_snapshot_revision=expected_snapshot_revision,
+            actor=_actor(),
+            random_seed=random_seed,
+        ),
+        workspace_root=root,
+        clock=lambda: _clock(clock_minute),
+    )
+
+
+def _student_group_mapping(detail) -> dict[str, str]:
+    return {
+        student_id: group.planned_group_key
+        for group in detail.plan.proposed_groups
+        for student_id in group.student_ids
+    }
+
+
+def test_missing_signal_manual_resolution_requires_placement_then_applies(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    signal, canonical_digest, created, _, inspection = _create_partial_signal_plan(
+        root,
+        revision=revision,
+        group_plan_id="plan-missing-manual",
+    )
+    assert inspection.missing_student_ids == ("student-5", "student-6")
+
+    current_revision = created.mutation.commit.snapshot_revision
+    for minute, (student_id, group_key) in enumerate(
+        (("student-5", "mixed-1"), ("student-6", "mixed-2")),
+        start=3,
+    ):
+        placed = place_student_in_plan(
+            PlaceStudentInPlanRequest(
+                class_id=CLASS_ID,
+                activity_id=ACTIVITY_ID,
+                group_plan_id="plan-missing-manual",
+                student_id=student_id,
+                planned_group_key=group_key,
+                expected_snapshot_revision=current_revision,
+                actor=_actor(),
+            ),
+            workspace_root=root,
+            clock=lambda minute=minute: _clock(minute),
+        )
+        current_revision = placed.detail.summary.snapshot_revision
+
+    placed_detail = show_group_plan(
+        CLASS_ID,
+        ACTIVITY_ID,
+        "plan-missing-manual",
+        workspace_root=root,
+    )
+    assert placed_detail.plan.unresolved_student_ids == ()
+    placed_inspection = inspect_group_plan_missing_signal(
+        CLASS_ID,
+        ACTIVITY_ID,
+        "plan-missing-manual",
+        workspace_root=root,
+    )
+    assert placed_inspection.missing_student_ids == ("student-5", "student-6")
+    assert placed_inspection.missing_assigned_student_ids == (
+        "student-5",
+        "student-6",
+    )
+    assert placed_inspection.missing_unresolved_student_ids == ()
+
+    disposition = _set_missing_disposition(
+        root,
+        group_plan_id="plan-missing-manual",
+        disposition="manual",
+        expected_snapshot_revision=current_revision,
+        clock_minute=5,
+    )
+    detail = show_group_plan(
+        CLASS_ID,
+        ACTIVITY_ID,
+        "plan-missing-manual",
+        workspace_root=root,
+    )
+    assert disposition.disposition == "manual"
+    assert disposition.missing_student_count == 2
+    assert disposition.unresolved_student_count == 0
+    assert disposition.random_seed is None
+    assert detail.plan.missing_signal_disposition == "manual"
+    assert detail.plan.missing_signal_random_seed is None
+    assert detail.plan.unresolved_student_ids == ()
+    _assert_no_canonical_group_state(root)
+
+    application, result, graph = _apply_approved_plan(
+        root,
+        group_plan_id="plan-missing-manual",
+        draft_snapshot_revision=disposition.mutation.commit.snapshot_revision,
+        application_id="apply-missing-manual-acceptance",
+        clock_minute=10,
+    )
+    assert application.membership_count == 6
+    assert result.membership_count == 6
+    _assert_signal_metadata_stays_on_plan(
+        graph,
+        group_plan_id="plan-missing-manual",
+        signal=signal,
+        canonical_digest=canonical_digest,
+    )
+    applied_plan = next(
+        plan
+        for plan in graph.group_plans
+        if plan.group_plan_id == "plan-missing-manual"
+    )
+    assert applied_plan.missing_signal_disposition == "manual"
+    assert applied_plan.missing_signal_random_seed is None
+
+
+def test_missing_signal_random_places_only_missing_reproducibly_then_applies(
+    tmp_path: Path,
+) -> None:
+    first_root, first_revision = _workspace(tmp_path / "first")
+    signal, canonical_digest, first_created, first_before, _ = (
+        _create_partial_signal_plan(
+            first_root,
+            revision=first_revision,
+            group_plan_id="plan-missing-random",
+        )
+    )
+    represented_before = _student_group_mapping(first_before)
+    assert set(represented_before) == set(STUDENT_IDS[:4])
+
+    first_disposition = _set_missing_disposition(
+        first_root,
+        group_plan_id="plan-missing-random",
+        disposition="random",
+        random_seed="issue69-missing-seed",
+        expected_snapshot_revision=first_created.mutation.commit.snapshot_revision,
+        clock_minute=3,
+    )
+    first_after = show_group_plan(
+        CLASS_ID,
+        ACTIVITY_ID,
+        "plan-missing-random",
+        workspace_root=first_root,
+    )
+    represented_after = _student_group_mapping(first_after)
+    assert all(
+        represented_after[student_id] == group_key
+        for student_id, group_key in represented_before.items()
+    )
+    assert set(represented_after) == set(STUDENT_IDS)
+    assert first_after.plan.unresolved_student_ids == ()
+    assert first_after.plan.missing_signal_disposition == "random"
+    assert first_after.plan.missing_signal_random_seed == "issue69-missing-seed"
+    assert first_disposition.random_seed == "issue69-missing-seed"
+
+    second_root, second_revision = _workspace(tmp_path / "second")
+    _, _, second_created, _, _ = _create_partial_signal_plan(
+        second_root,
+        revision=second_revision,
+        group_plan_id="plan-missing-random",
+    )
+    _set_missing_disposition(
+        second_root,
+        group_plan_id="plan-missing-random",
+        disposition="random",
+        random_seed="issue69-missing-seed",
+        expected_snapshot_revision=second_created.mutation.commit.snapshot_revision,
+        clock_minute=3,
+    )
+    second_after = show_group_plan(
+        CLASS_ID,
+        ACTIVITY_ID,
+        "plan-missing-random",
+        workspace_root=second_root,
+    )
+    assert second_after.plan.proposed_groups == first_after.plan.proposed_groups
+
+    application, result, graph = _apply_approved_plan(
+        first_root,
+        group_plan_id="plan-missing-random",
+        draft_snapshot_revision=first_disposition.mutation.commit.snapshot_revision,
+        application_id="apply-missing-random-acceptance",
+        clock_minute=10,
+    )
+    assert application.membership_count == 6
+    assert result.membership_count == 6
+    _assert_signal_metadata_stays_on_plan(
+        graph,
+        group_plan_id="plan-missing-random",
+        signal=signal,
+        canonical_digest=canonical_digest,
+    )
+    applied_plan = next(
+        plan
+        for plan in graph.group_plans
+        if plan.group_plan_id == "plan-missing-random"
+    )
+    assert applied_plan.missing_signal_disposition == "random"
+    assert applied_plan.missing_signal_random_seed == "issue69-missing-seed"
+
+
+def test_missing_signal_leave_unassigned_applies_without_missing_memberships(
+    tmp_path: Path,
+) -> None:
+    root, revision = _workspace(tmp_path)
+    signal, canonical_digest, created, before, inspection = _create_partial_signal_plan(
+        root,
+        revision=revision,
+        group_plan_id="plan-missing-leave",
+    )
+    represented_mapping = _student_group_mapping(before)
+    assert set(represented_mapping) == set(STUDENT_IDS[:4])
+    assert inspection.missing_student_ids == ("student-5", "student-6")
+
+    disposition = _set_missing_disposition(
+        root,
+        group_plan_id="plan-missing-leave",
+        disposition="leave_unassigned",
+        expected_snapshot_revision=created.mutation.commit.snapshot_revision,
+        clock_minute=3,
+    )
+    detail = show_group_plan(
+        CLASS_ID,
+        ACTIVITY_ID,
+        "plan-missing-leave",
+        workspace_root=root,
+    )
+    assert disposition.disposition == "leave_unassigned"
+    assert disposition.unresolved_student_count == 2
+    assert detail.plan.unresolved_student_ids == ("student-5", "student-6")
+    assert detail.plan.missing_signal_disposition == "leave_unassigned"
+    assert detail.plan.missing_signal_random_seed is None
+    _assert_no_canonical_group_state(root)
+
+    application, result, graph = _apply_approved_plan(
+        root,
+        group_plan_id="plan-missing-leave",
+        draft_snapshot_revision=disposition.mutation.commit.snapshot_revision,
+        application_id="apply-missing-leave-acceptance",
+        clock_minute=10,
+        expected_unresolved_student_ids=("student-5", "student-6"),
+    )
+    assert application.membership_count == 4
+    assert result.membership_count == 4
+    assert result.unresolved_count == 2
+    membership_students = {
+        membership.participant_reference.participant_id
+        for membership in graph.memberships
+    }
+    assert membership_students == set(STUDENT_IDS[:4])
+    assert membership_students.isdisjoint({"student-5", "student-6"})
+    assert _student_group_mapping(detail) == represented_mapping
+    _assert_signal_metadata_stays_on_plan(
+        graph,
+        group_plan_id="plan-missing-leave",
+        signal=signal,
+        canonical_digest=canonical_digest,
+    )
+    applied_plan = next(
+        plan for plan in graph.group_plans if plan.group_plan_id == "plan-missing-leave"
+    )
+    assert applied_plan.unresolved_student_ids == ("student-5", "student-6")
+    assert applied_plan.missing_signal_disposition == "leave_unassigned"
+    assert applied_plan.missing_signal_random_seed is None


### PR DESCRIPTION
## Summary

Closes #69.

Adds repository-local acceptance for Concord's complete Group-planning capability without introducing any new production runtime behavior, Meridian dependency, CI matrix, or validation phase.

The acceptance suite proves that Concord's existing Group-planning features compose correctly from fresh Core/Concord state across:

* direct canonical Group creation;
* manual GroupPlans;
* `student_id,group` arrangement import;
* deterministic random GroupPlans;
* Core-conformant `similar_signal` planning;
* Core-conformant `mixed_signal` planning;
* manual missing-signal resolution;
* deterministic missing-only random resolution; and
* intentional `leave_unassigned` handling.

It also documents the repository-local interoperability boundary and explicitly defers real Meridian-produced snapshot acceptance until Meridian exposes a stable authentic producer artifact.

## What changed

### Repository-local Group-planning acceptance

Added:

```text
tests/test_group_planning_acceptance_issue69.py
```

The acceptance suite uses a fresh synthetic Core workspace, exact Core roster identities, and Concord's existing public workflow services.

No acceptance scenario writes canonical records directly as a shortcut around the behavior being qualified.

### Direct Group formation

Proves that direct Group creation remains a first-class Concord workflow:

```text
Core roster
    ->
Concord Group
    ->
Concord GroupMembership
```

with:

* no GroupPlan;
* no grouping signal;
* exact Core student identities;
* canonical graph validation; and
* no planning-only metadata on Group or GroupMembership records.

### Manual GroupPlan lifecycle

Exercises the real manual planning editor through:

```text
draft
    ->
planned group editing
    ->
previewed
    ->
approved
    ->
application preview
    ->
explicit application
    ->
applied
```

The acceptance reflects the implemented #50 lifecycle correctly: GroupPlan preview is a persisted **planning-state transition**, not a zero-write operation.

It verifies that preview and approval create no canonical Groups or Memberships.

Application preview remains genuinely read-only.

### Arrangement import

Exercises the exact existing CSV arrangement contract:

```csv
student_id,group
```

and proves that imported arrangements remain GroupPlans until explicit teacher-approved application.

The source path is not persisted as canonical planning state.

### Deterministic random planning

Exercises seeded random GroupPlan creation and proves:

* no signal is required;
* the exact roster is assigned;
* group sizes satisfy the existing balancing contract;
* identical input and seed reproduce the same proposal in a separate fresh workspace; and
* canonical Groups/Memberships are created only by explicit application.

### Complete Core signal planning

Exercises both:

```text
similar_signal
mixed_signal
```

against a synthetic signal written and consumed through Core's public grouping-signal contract.

The acceptance verifies:

* exact signal-set identity;
* exact selected dimension;
* binding to Core's **canonical grouping-signal digest**;
* distinction between the Core canonical digest and producer `source.snapshot_digest`;
* deterministic proposal generation;
* teacher preview and approval;
* explicit application; and
* no signal metadata leakage into canonical Group or GroupMembership records.

The synthetic signal may identify its producer provenance as `meridian`, but no Meridian package is installed, imported, or invoked.

### Incomplete signal handling

Exercises all three #55 teacher dispositions.

#### Manual resolution

Proves that students diagnosed by Core as missing signal data:

* receive no invented band;
* must be manually placed before the `manual` disposition is completed; and
* can then proceed through approval and application normally.

#### Deterministic missing-only random placement

Proves that:

* only the exact Core-diagnosed missing students participate;
* represented students are not moved;
* an explicit missing-signal seed is required;
* the result is reproducible in a second fresh workspace; and
* the final fully resolved plan applies normally.

#### `leave_unassigned`

Proves the narrow intentional partial-membership exception:

* unresolved students remain exactly the Core-diagnosed missing population;
* no synthetic group or band is invented;
* approval and application are permitted under the existing #55 contract;
* no GroupMembership is created for intentionally unassigned students; and
* the disposition remains planning provenance rather than leaking into canonical collaboration records.

## Planning/canonical-state boundary

The acceptance explicitly proves:

```text
GroupPlan
    !=
Group
    !=
GroupMembership
```

Across planning scenarios:

* draft creation does not create Groups;
* GroupPlan preview changes planning state only;
* approval remains planning-only;
* application preview performs no write;
* only explicit approved-plan application materializes Groups and Memberships.

The applied canonical state uses fresh derived Group and Membership identities and validates through Concord's normal record-graph machinery.

## Signal privacy and semantics

Signal-backed acceptance preserves the established neutral contract:

```text
band != Score
band != Grade
band != percentage
band != proficiency
band != permanent ability
missing signal != lowest band
```

The tests also verify that applied `Group` and `GroupMembership` records do not contain planning-only fields such as:

```text
signal_set_id
signal digest
dimension_id
ordinal band
missing-signal disposition
missing-signal seed
planning strategy
producer snapshot provenance
```

Legitimate signal/planning provenance remains on the GroupPlan.

## Meridian independence

The acceptance adds two explicit dependency-boundary guards.

### Package metadata

`pyproject.toml` is checked to ensure Concord introduces no Meridian dependency or Meridian entry point.

### Runtime import boundary

A fresh interpreter imports Concord with a guard that fails if the import process attempts to import `meridian`.

This deliberately tests:

```text
Concord does not require Meridian
```

rather than incorrectly requiring Meridian to be absent from a developer's environment.

No Concord runtime, optional, development, installed-smoke, or CI dependency on Meridian was added.

## Optional Meridian interoperability status

A fresh upstream audit found that real Meridian producer interoperability is not yet available as a stable acceptance input.

Current Meridian work establishes the neutral Core grouping-signal contract boundary, but deterministic signal generation/export and installed producer qualification remain later upstream work.

Therefore this PR does **not** fabricate a Meridian interoperability claim by placing `"module_id": "meridian"` in synthetic JSON and treating provenance text as proof of producer execution.

The required repository-local model remains:

```text
Core tests without Meridian or Concord
Meridian tests export without Concord
Concord tests planning against Core-conformant inputs without Meridian
```

A future authentic:

```text
Meridian
    ->
Core grouping_signal_set_v1
    ->
Concord
```

acceptance may be added when a stable producer-generated artifact with verifiable provenance exists.

Its absence does not block #69.

## Documentation

Added:

```text
docs/v0.3.0-group-planning-acceptance.md
```

and indexed it from:

```text
docs/README.md
```

The document records:

* the qualified Group-planning paths;
* Core/Concord ownership boundaries;
* direct Groups versus GroupPlans;
* the real preview/approval/application lifecycle;
* Core canonical signal digest semantics;
* incomplete-signal dispositions;
* privacy requirements;
* Meridian runtime independence;
* the deferred real-producer interoperability status;
* validation integration; and
* the handoff to #70 and #71.

Added:

```text
tests/test_group_planning_acceptance_document_issue69.py
```

to prevent the normative acceptance documentation from drifting away from the actual acceptance suite.

## Validation architecture

This PR deliberately preserves the performance and CI architecture established by #93.

It adds:

* no second validation engine;
* no new top-level validator phase;
* no new CI matrix;
* no installed virtual environment solely for #69;
* no pytest-xdist;
* no production acceptance framework.

The new #69 tests run as ordinary pytest coverage and therefore participate naturally in all supported OS/Python cells.

## Qualification

Focused #69 qualification:

```text
13 passed
Ruff passed
Mypy passed
documentation validation passed
git diff --check passed
```

Final authoritative repository qualification against released Core 0.6.3:

```text
1,353 collected
1,343 passed
10 skipped
```

The 10 skips are the expected Windows symlink/POSIX-only filesystem cases.

The complete validator also passed:

* Core wheel verification;
* Core grouping-fixture verification;
* `pip check`;
* full pytest;
* Ruff;
* Mypy across 176 source files;
* documentation validation;
* release compatibility;
* package build;
* Twine;
* package-content verification;
* release-artifact verification;
* base installed-wheel producer acceptance;
* shared installed feature acceptance;
* module-operations installed-wheel acceptance; and
* `git diff --check`.

No production source files were changed by this issue.

## Scope handoff

#69 establishes:

```text
repository-local Group-planning correctness
+
producer-independent Core interoperability
```

It does not replace #70.

#70 remains responsible for representative installed-distribution and physical/classroom workflow acceptance.

The milestone sequence remains:

```text
#69 repository-local Group-planning acceptance
    ->
#70 installed + physical representative acceptance
    ->
#71 final architecture/privacy/usability/release audit
```
