### PR TITLE
test: qualify installed and physical starter workflows

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -399,6 +399,18 @@ eight-cell compatibility versus two-cell complete CI qualification, storage
 microbenchmark evidence, preserved fail-closed invariants, and measured
 before/after results.
 
+### v0.3.0 installed and physical starter-workflow acceptance
+
+[`v0.3.0-installed-physical-starter-workflow-acceptance.md`](v0.3.0-installed-physical-starter-workflow-acceptance.md)
+
+Documents issue #70's single-environment installed qualification for seminar,
+signal-backed group-project, and peer-review starter workflows; exact Core 0.6.3
+baseline; GroupPlan-to-canonical-state boundary; paper/PDS2/retained-scan path;
+grouping-signal privacy sentinel; owner-only all-three-family real-paper sample; physical
+hardware/settings provenance; raw-evidence retention prohibition; and the
+post-merge `PENDING OWNER` gate before #71.
+
+
 ### Future v0.3.0 Group Planning / Template / Packet plan
 
 [`pds-group-planning-interoperability-development-plan.md`](pds-group-planning-interoperability-development-plan.md)

--- a/docs/v0.3.0-installed-physical-starter-workflow-acceptance.md
+++ b/docs/v0.3.0-installed-physical-starter-workflow-acceptance.md
@@ -1,0 +1,382 @@
+# v0.3.0 Installed and Physical Starter-Workflow Acceptance
+
+Classification: **issue #70 installed-distribution, paper-path, privacy, and owner-only physical acceptance contract**.
+
+Issue #70 qualifies the already-implemented Concord v0.3.0 planning, starter Template, Packet, paper-return, review, scoring, and publication layers. It is an acceptance issue, not a redesign issue. A production change belongs here only when acceptance exposes a concrete defect in the smallest responsible layer.
+
+## Governing boundary
+
+The authoritative flow remains:
+
+```text
+synthetic Core class / roster
+-> Activity setup
+-> teacher-reviewed GroupPlan
+-> explicit GroupPlan approval
+-> read-only GroupPlan application preview
+-> explicit application to fresh canonical Groups / GroupMemberships
+-> packaged starter Template / Packet selection
+-> Activity-specific Packet instantiation
+-> fresh Artifact / ArtifactPage allocation
+-> Core PDS2 route identity
+-> printable PDF
+-> paper return
+-> Core-retained scan
+-> Core owner dispatch
+-> Concord ArtifactPage return
+-> Artifact assembly
+-> explicit teacher review
+-> explicit scoring
+-> Academic Work registration / result-manifest generation
+-> explicit publication
+-> public result readback
+```
+
+Core remains authoritative for workspace/class/roster state, PDS2, route registration and dispatch, retained source scans, Academic Work Registration, Publication Records, and neutral grouping-signal interchange. Concord remains authoritative for Activity/Session, GroupPlan, canonical Group/GroupMembership state, Templates, Packets, Artifacts/Pages, Review/Moderation, Criterion Sets/Scales, Scores, and Concord result manifests.
+
+A returned scan is evidence return only. It must not infer teacher review, moderation, scoring, publication, or any other teacher judgment.
+
+## Exact installed baseline
+
+The final acceptance run must use a noneditable Concord wheel installed outside the source checkout together with the exact released Core baseline:
+
+```text
+Concord distribution: pds-concord
+Concord version: 0.3.0.dev0
+Python: >=3.11
+Core distribution: pds-core
+Core version: 0.6.3
+Core wheel: pds_core-0.6.3-py3-none-any.whl
+Core wheel SHA-256: 98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5
+```
+
+The final completion record must also include the exact Concord wheel filename, byte length, SHA-256, final commit, Python/platform, and confirmation that the same Concord/Core wheel bytes were used for the authoritative installed qualification and the physical run.
+
+The installed environment must contain no editable Concord install, sibling source checkout on `PYTHONPATH`, Meridian runtime dependency, suite-shell runtime dependency, or real student data. `pip check` must pass. Imports must resolve from the isolated environment's `site-packages`.
+
+## Automated installed acceptance matrix
+
+`scripts/smoke_test_feature_wheels.py` registers exactly one shared `starter workflows` scenario. `scripts/smoke_test_starter_workflows_wheel.py` runs all representative #70 cases in that one isolated environment.
+
+### Seminar
+
+The seminar case exercises:
+
+```text
+#65 guided Activity setup
+manual signal-free GroupPlan
+preview -> approval -> application preview -> explicit application
+socratic_seminar packaged starter
+participant Packet targets with canonical Group context
+real PDF / PDS2 rendering
+production rasterization and barcode decode
+Core retained-source custody and dispatch
+Artifact assembly
+explicit Artifact Review
+participant Scores
+Academic Work registration / manifest / publication / public readback
+```
+
+### Group project
+
+The group-project case exercises:
+
+```text
+complete synthetic Core grouping signal
+similar_signal GroupPlan
+preview -> approval -> application preview -> explicit application
+project_plan packaged starter
+group Packet targets
+real PDF / PDS2 rendering
+production return / Core retention / dispatch
+Artifact assembly
+explicit group Artifact Review
+group-target Scores
+manifest / publication / public readback
+```
+
+The signal-set ID, selected dimension ID, source module/snapshot identity, source snapshot digest, and canonical signal digest are planning-only. Sentinel values for those fields must remain absent from canonical Groups/Memberships, Packet instances, printable PDFs, PDS2 payloads, returned Artifact state, Reviews, Scores, result manifests, Publication Records, and public readback.
+
+### Peer review
+
+The peer-review case exercises:
+
+```text
+deterministic random signal-free GroupPlan
+preview -> approval -> application preview -> explicit application
+peer_review_writing packaged starter
+participant Packet targets with canonical Group context
+real PDF / PDS2 rendering
+production return / Core retention / dispatch
+Artifact assembly
+explicit Artifact Review
+participant Scores
+manifest / publication / public readback
+```
+
+Starter page counts are derived from each packaged starter contract. Acceptance must not freeze a starter's current page count unless that count is itself a normative public contract.
+
+## Genuine physical acceptance
+
+Automation qualifies generated PDFs and the production decode/dispatch path, but generated PDFs routed directly back into intake are **not** physical evidence. The physical gate is owner/tester-only and occurs after the preparation PR is merged, using the exact wheel bytes that passed the final installed qualification.
+
+Use synthetic classroom identities and synthetic writing only. Do not commit generated PDFs, raw scans, retained scan files, marked paper images, workspace copies, virtual environments, or other physical evidence artifacts.
+
+The physical gate covers **all three required starter families**. It is not sufficient to print only the seminar case.
+
+### Bounded physical sample
+
+The minimum owner-executed sample is six target packets:
+
+```text
+seminar:
+  one participant packet from canonical Group A
+  one participant packet from canonical Group B
+
+group project:
+  both canonical Group-targeted packets
+
+peer review:
+  one participant packet from canonical Group A
+  one participant packet from canonical Group B
+```
+
+Every page of those six selected packets must be physically printed and returned through the scan path. The scanner may produce one combined PDF or several supported scan files; verification is against the exact union of expected route and ArtifactPage identities.
+
+### Physical workflow requirements
+
+For each starter family:
+
+1. Prepare the synthetic Core class/roster and Activity from the exact installed wheel.
+2. Exercise the real GroupPlan proposal, preview, approval, application preview, and explicit application lifecycle.
+3. Resolve the packaged starter and instantiate Activity-specific Packet state.
+4. Allocate fresh Artifact, ArtifactPage, and Core PDS2 route identities.
+5. Render the real printable PDF from the installed distribution.
+6. Print the selected packets on real paper.
+7. Physically write `PDS70` plus representative synthetic marks on paper from each starter family.
+8. Scan every printed sample page with a real scanner.
+9. Submit the actual scanned bytes through production `route_scan_sources` without an injected or fabricated decoder.
+10. Verify Core retained the actual scan and dispatched every exact expected Concord route/Page identity.
+11. Verify scan intake did not infer Artifact Review or Score state.
+12. Assemble each physically returned Artifact from retained scan lineage.
+13. Enter explicit synthetic teacher Review state for every physically returned Artifact.
+14. Enter explicit Scores linked to the physically returned Artifact evidence.
+15. Register Academic Work for each representative Activity.
+16. Generate each Concord result manifest explicitly.
+17. Publish each representative result through Core explicitly.
+18. Read each published result back through the public reader.
+19. Reconfirm that project grouping-signal/private planning provenance did not leak downstream.
+
+Result before the owner performs the cases: `PENDING OWNER`
+
+## Physical visual acceptance
+
+Before resume, inspect at least one printed sample from each starter family and confirm:
+
+```text
+page size / orientation
+header readability
+intentional target label where applicable
+instructions
+response / writing areas
+page numbering
+QR / PDS2 placement and clarity
+footer
+no clipping
+no overlap
+no unexpected blank pages
+```
+
+For the project sample, also visually confirm that no grouping-signal set ID, dimension/band label, digest, source snapshot, strategy, or other private planning rationale is visible on the paper.
+
+The helper requires an explicit visual-inspection attestation. It does not convert that attestation into a PASS; the owner still classifies the result.
+
+## Persistent operator harness
+
+Use:
+
+```text
+scripts/run_physical_starter_workflow_acceptance_issue70.py
+```
+
+The helper has two public stages.
+
+### PREPARE
+
+Run from reconciled post-merge `main` with the same preserved candidate wheel bytes that will be used for final installed qualification:
+
+```powershell
+$run = "$HOME\Downloads\pds-concord-issue70-physical"
+$concordWheel = "<exact post-merge pds_concord-0.3.0.dev0 wheel>"
+$coreWheel = "$HOME\Downloads\pds_core-0.6.3-py3-none-any.whl"
+
+python scripts/run_physical_starter_workflow_acceptance_issue70.py prepare `
+  $concordWheel `
+  $coreWheel `
+  $run
+```
+
+PREPARE creates one persistent synthetic workspace in the local run directory, installs the exact wheels into an isolated environment, runs `pip check`, prepares all three GroupPlan paths, and writes the six printable sample PDFs under:
+
+```text
+<run>/print/
+```
+
+The run directory is local evidence state and must not be committed.
+
+Print all six files. Mark real paper with `PDS70` and representative synthetic writing. Inspect at least one printed packet from seminar, project, and peer review. Then scan every printed page.
+
+### VERIFY / RESUME
+
+Pass every real scan file using repeated `--scan` arguments. One combined scanner PDF is valid if it contains all printed sample pages.
+
+Example:
+
+```powershell
+python scripts/run_physical_starter_workflow_acceptance_issue70.py resume `
+  $run `
+  --scan "$HOME\Downloads\issue70-scan-1.pdf" `
+  --scan "$HOME\Downloads\issue70-scan-2.pdf" `
+  --physical-mark-confirmed `
+  --visual-inspection-confirmed `
+  --tester "<tester name>" `
+  --printer "<printer make/model>" `
+  --printer-path "<driver/path if known>" `
+  --paper-size "Letter" `
+  --print-scaling "Actual size" `
+  --print-sides simplex `
+  --print-color-mode grayscale `
+  --scanner "<scanner make/model>" `
+  --scanner-path "<scanner software/driver>" `
+  --scan-dpi 300 `
+  --scan-color-mode grayscale `
+  --scan-sides simplex `
+  --scan-adjustments "<rotation/crop/other relevant settings or none>"
+```
+
+RESUME rejects any scan whose bytes exactly equal one of the generated printable PDFs, requires the physical-mark and visual-inspection attestations, sends the actual scan files through production intake, checks all six packet identity sets, and completes assembly, explicit Review, explicit scoring, Academic Work registration, manifest generation, publication, and public readback for the physically returned subset.
+
+It writes:
+
+```text
+<run>/physical-evidence-summary.json
+<run>/issue70-completion-comment.md
+```
+
+These are local synthetic/provenance summaries. The generated issue-comment template deliberately says `OWNER CLASSIFICATION REQUIRED`. The helper must never auto-declare a physical PASS.
+
+## Physical evidence metadata
+
+Record all of the following in the issue #70 completion comment:
+
+```text
+final commit
+Concord wheel filename
+Concord wheel byte length
+Concord wheel SHA-256
+Core wheel filename
+Core wheel SHA-256
+Python version
+platform / OS
+authoritative installed qualification result
+confirmation that installed + physical used identical wheel bytes
+tester
+date and local time
+printer make/model
+printer driver or print path when known
+paper size
+print scaling / fit setting
+simplex or duplex
+print color/grayscale mode
+scanner make/model
+scanner software / driver path when known
+scan resolution (DPI)
+scan color mode
+scan simplex or duplex
+automatic crop/rotation or other material adjustments
+physical source page count
+Core retained source_scan_id value(s)
+Concord route_id value(s) by workflow
+Concord artifact_instance_id value(s) by workflow
+Concord artifact_page_id value(s) by workflow
+manifest digest / publication id and revision by workflow
+physical visual-inspection classification
+seminar physical outcome
+project physical outcome
+peer-review physical outcome
+overall physical outcome
+```
+
+Do not put real student names, real student work, sensitive data, secrets, machine-specific absolute paths, or raw physical evidence in the durable completion comment.
+
+## Outcomes and failure classification
+
+Record each physical workflow and the overall gate as exactly one of:
+
+```text
+PASS
+PASS WITH DOCUMENTED LIMITATION
+FAIL
+```
+
+A documented limitation must record the symptom, exact scenario, reproduction, failure classification, workaround if any, release impact, and follow-up issue if required.
+
+Classify failures as one of:
+
+```text
+software-contract failure
+physical/environment dependency
+operator/procedure error
+documented limitation
+```
+
+Printer scaling, scanner crop/contrast/orientation, driver behavior, damaged paper, and unavailable physical hardware are environment considerations; they must be recorded rather than silently waived.
+
+## Privacy and artifact-retention rule
+
+Repository history may contain the acceptance harness, deterministic synthetic inputs, procedure, and textual completion metadata. It must not contain:
+
+```text
+raw scans
+generated acceptance PDFs
+marked paper images
+retained physical source files
+physical workspace copies
+virtual environments
+real student data
+```
+
+The issue comment may record stable synthetic IDs, hashes, outcome, hardware/settings metadata, and limitation text. It must not attach raw scans or generated packet PDFs merely to prove the run.
+
+## Issue #70 completion record
+
+Use this shape after the physical run:
+
+```text
+Issue #70 completion record
+
+final commit: PENDING OWNER
+Concord wheel: PENDING OWNER
+Concord wheel byte length: PENDING OWNER
+Concord wheel SHA-256: PENDING OWNER
+Core wheel: pds_core-0.6.3-py3-none-any.whl
+Core wheel SHA-256: 98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5
+Python/platform: PENDING OWNER
+authoritative installed starter-workflow qualification: PENDING OWNER
+same wheel bytes used for installed + physical: PENDING OWNER
+physical tester/date: PENDING OWNER
+printer/settings: PENDING OWNER
+scanner/settings: PENDING OWNER
+physical visual inspection: PENDING OWNER
+physical seminar: PENDING OWNER
+physical group project: PENDING OWNER
+physical peer review: PENDING OWNER
+retained source / route / Artifact identity summary: PENDING OWNER
+manifest/publication identity summary: PENDING OWNER
+physical acceptance: PENDING OWNER
+READY FOR #71: NO
+```
+
+Automation must never replace `PENDING OWNER` or `OWNER CLASSIFICATION REQUIRED` with a physical PASS. Issue #70 remains open after the preparation PR merges until the owner/tester has actually printed, marked, visually inspected, scanned, routed, assembled, reviewed, scored, published, and recorded all three physical workflow results.
+
+A `PASS WITH DOCUMENTED LIMITATION` may permit #71 only when the limitation is explicitly nonblocking and its release impact is documented. A `FAIL` does not permit #71.

--- a/scripts/run_physical_starter_workflow_acceptance_issue70.py
+++ b/scripts/run_physical_starter_workflow_acceptance_issue70.py
@@ -1,0 +1,1815 @@
+"""Prepare and resume Concord issue #70 owner-only physical acceptance."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import venv
+from pathlib import Path
+from typing import Any, cast
+
+EXPECTED_CORE_VERSION = "0.6.3"
+EXPECTED_CORE_WHEEL = "pds_core-0.6.3-py3-none-any.whl"
+EXPECTED_CORE_SHA256 = (
+    "98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5"
+)
+EXPECTED_CONCORD_VERSION = "0.3.0.dev0"
+RUN_METADATA = "run-metadata.json"
+STATE_FILE = "physical-state.json"
+EVIDENCE_FILE = "physical-evidence-summary.json"
+COMMENT_FILE = "issue70-completion-comment.md"
+PRINT_DIR = "print"
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _python(venv_root: Path) -> Path:
+    return (
+        venv_root / "Scripts" / "python.exe"
+        if os.name == "nt"
+        else venv_root / "bin" / "python"
+    )
+
+
+def _run(command: list[str], cwd: Path) -> None:
+    subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    )
+
+
+def _load_json(path: Path) -> dict[str, object]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise RuntimeError(f"expected JSON object: {path}")
+    return value
+
+
+def _write_json(path: Path, value: dict[str, object]) -> None:
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _json_string(value: dict[str, object], key: str) -> str:
+    item = value.get(key)
+    if not isinstance(item, str) or not item:
+        raise RuntimeError(f"JSON state is missing string field: {key}")
+    return item
+
+
+def _json_int(value: dict[str, object], key: str) -> int:
+    item = value.get(key)
+    if isinstance(item, bool) or not isinstance(item, int):
+        raise RuntimeError(f"JSON state is missing integer field: {key}")
+    return item
+
+
+def _json_strings(value: dict[str, object], key: str) -> tuple[str, ...]:
+    item = value.get(key)
+    if not isinstance(item, list) or not item:
+        raise RuntimeError(f"JSON state is missing string-list field: {key}")
+    if any(not isinstance(entry, str) or not entry for entry in item):
+        raise RuntimeError(f"JSON state has invalid string-list field: {key}")
+    return tuple(item)
+
+
+def _json_cases(value: dict[str, object]) -> tuple[dict[str, object], ...]:
+    raw = value.get("cases")
+    if not isinstance(raw, list) or not raw:
+        raise RuntimeError("physical state is missing cases")
+    result: list[dict[str, object]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            raise RuntimeError("physical state contains an invalid case")
+        if any(not isinstance(key, str) for key in item):
+            raise RuntimeError("physical state case contains a non-string key")
+        result.append(cast(dict[str, object], item))
+    return tuple(result)
+
+
+def _git_head(root: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    value = result.stdout.strip()
+    if result.returncode != 0 or len(value) != 40:
+        raise RuntimeError(
+            "could not determine final commit; run from a Git checkout at the "
+            "exact merged commit"
+        )
+    return value
+
+
+def _require_fresh_run_root(run_root: Path) -> None:
+    if run_root.exists():
+        if any(run_root.iterdir()):
+            raise RuntimeError(
+                f"physical acceptance run directory is not empty: {run_root}"
+            )
+    else:
+        run_root.mkdir(parents=True)
+
+
+def _script_path() -> Path:
+    return Path(__file__).resolve()
+
+
+def _prepare_public(args: argparse.Namespace) -> int:
+    concord_wheel = Path(args.concord_wheel).resolve()
+    core_wheel = Path(args.core_wheel).resolve()
+    run_root = Path(args.run_root).resolve()
+    for label, path in (("Concord wheel", concord_wheel), ("Core wheel", core_wheel)):
+        if not path.is_file():
+            raise RuntimeError(f"{label} does not exist: {path}")
+    if core_wheel.name != EXPECTED_CORE_WHEEL:
+        raise RuntimeError(
+            f"Core wheel must be {EXPECTED_CORE_WHEEL}, got {core_wheel.name}"
+        )
+    core_sha256 = _sha256(core_wheel)
+    if core_sha256 != EXPECTED_CORE_SHA256:
+        raise RuntimeError(
+            "Core wheel SHA-256 does not match the released issue #70 baseline"
+        )
+    concord_sha256 = _sha256(concord_wheel)
+    _require_fresh_run_root(run_root)
+
+    source_root = _script_path().parents[1]
+    final_commit = _git_head(source_root)
+    venv_root = run_root / "venv"
+    venv.EnvBuilder(with_pip=True, clear=True).create(venv_root)
+    python = _python(venv_root)
+    _run([str(python), "-m", "pip", "install", str(core_wheel)], run_root)
+    _run([str(python), "-m", "pip", "install", str(concord_wheel)], run_root)
+    _run([str(python), "-m", "pip", "check"], run_root)
+
+    metadata: dict[str, object] = {
+        "schema_version": 1,
+        "final_commit": final_commit,
+        "concord_wheel_filename": concord_wheel.name,
+        "concord_wheel_path": str(concord_wheel),
+        "concord_wheel_byte_length": concord_wheel.stat().st_size,
+        "concord_wheel_sha256": concord_sha256,
+        "core_wheel_filename": core_wheel.name,
+        "core_wheel_path": str(core_wheel),
+        "core_wheel_byte_length": core_wheel.stat().st_size,
+        "core_wheel_sha256": core_sha256,
+        "venv_relative_path": "venv",
+        "state_relative_path": STATE_FILE,
+    }
+    _write_json(run_root / RUN_METADATA, metadata)
+    _run(
+        [
+            str(python),
+            "-I",
+            str(_script_path()),
+            "_installed-prepare",
+            str(run_root),
+        ],
+        run_root,
+    )
+    print("\nPhysical acceptance preparation complete.")
+    print(f"Print every PDF under: {run_root / PRINT_DIR}")
+    print("Physically write PDS70 and representative synthetic marks on each family.")
+    print("Scan every printed page, then run the resume command with all scan paths.")
+    return 0
+
+
+def _resume_public(args: argparse.Namespace) -> int:
+    run_root = Path(args.run_root).resolve()
+    metadata = _load_json(run_root / RUN_METADATA)
+    venv_relative = metadata.get("venv_relative_path")
+    if not isinstance(venv_relative, str):
+        raise RuntimeError("run metadata is missing venv_relative_path")
+    python = _python(run_root / venv_relative)
+    if not python.is_file():
+        raise RuntimeError(f"physical acceptance venv is unavailable: {python}")
+    scans = tuple(Path(value).resolve() for value in args.scan)
+    if not scans:
+        raise RuntimeError("at least one physical scan is required")
+    for scan in scans:
+        if not scan.is_file():
+            raise RuntimeError(f"physical scan does not exist: {scan}")
+
+    command = [
+        str(python),
+        "-I",
+        str(_script_path()),
+        "_installed-resume",
+        str(run_root),
+    ]
+    for scan in scans:
+        command.extend(("--scan", str(scan)))
+    command.extend(("--tester", args.tester))
+    command.extend(("--printer", args.printer))
+    command.extend(("--printer-path", args.printer_path))
+    command.extend(("--paper-size", args.paper_size))
+    command.extend(("--print-scaling", args.print_scaling))
+    command.extend(("--print-sides", args.print_sides))
+    command.extend(("--print-color-mode", args.print_color_mode))
+    command.extend(("--scanner", args.scanner))
+    command.extend(("--scanner-path", args.scanner_path))
+    command.extend(("--scan-dpi", str(args.scan_dpi)))
+    command.extend(("--scan-color-mode", args.scan_color_mode))
+    command.extend(("--scan-sides", args.scan_sides))
+    command.extend(("--scan-adjustments", args.scan_adjustments))
+    if args.physical_mark_confirmed:
+        command.append("--physical-mark-confirmed")
+    if args.visual_inspection_confirmed:
+        command.append("--visual-inspection-confirmed")
+    _run(command, run_root)
+    print("\nTechnical physical-path execution completed.")
+    print(f"Evidence summary: {run_root / EVIDENCE_FILE}")
+    print(f"Issue-comment template: {run_root / COMMENT_FILE}")
+    print(
+        "The harness does not declare a physical PASS. Review the evidence and "
+        "classify seminar, project, peer review, and overall acceptance manually."
+    )
+    return 0
+
+
+def _require_installed(module: object, distribution: str) -> str:
+    origin = Path(getattr(module, "__file__")).resolve()
+    if "site-packages" not in str(origin).casefold():
+        raise RuntimeError(
+            f"{distribution} did not import from isolated site-packages: {origin}"
+        )
+    return str(origin)
+
+
+def _installed_modules() -> dict[str, object]:
+    from importlib import metadata
+
+    import pds_core
+
+    import concord
+
+    if metadata.version("pds-core") != EXPECTED_CORE_VERSION:
+        raise RuntimeError("installed pds-core version does not match issue #70")
+    if metadata.version("pds-concord") != EXPECTED_CONCORD_VERSION:
+        raise RuntimeError("installed pds-concord version does not match issue #70")
+    requirements = tuple(metadata.requires("pds-concord") or ())
+    forbidden = ("meridian", "paper-data-suite")
+    if any(
+        name in requirement.casefold()
+        for requirement in requirements
+        for name in forbidden
+    ):
+        raise RuntimeError("physical acceptance installed forbidden runtime dependency")
+    return {
+        "concord_origin": _require_installed(concord, "pds-concord"),
+        "core_origin": _require_installed(pds_core, "pds-core"),
+    }
+
+
+def _actor() -> Any:
+    from concord.workflows import WorkflowActor
+
+    return WorkflowActor(
+        actor_id="teacher-issue70-physical",
+        display_label="Synthetic Teacher",
+        role_label="teacher",
+    )
+
+
+def _current_revision(root: Path, class_id: str, activity_id: str) -> int:
+    from concord.workflows import show_activity
+
+    return show_activity(
+        class_id,
+        activity_id,
+        workspace_root=root,
+    ).summary.snapshot_revision
+
+
+def _installed_prepare(run_root: Path) -> int:
+    import shutil as installed_shutil
+    from datetime import datetime, timezone
+    from importlib import metadata
+
+    from pds_core.class_metadata import (
+        create_class_metadata,
+        write_class_metadata_for_class,
+    )
+    from pds_core.classes import write_class_roster
+    from pds_core.grouping_signal_storage import (
+        calculate_grouping_signal_digest,
+        write_grouping_signal,
+    )
+    from pds_core.grouping_signals import (
+        GroupingSignalDimension,
+        GroupingSignalSet,
+        GroupingSignalSource,
+        GroupingSignalStudentBand,
+    )
+    from pds_core.pds2 import parse_pds2_payload
+    from pds_core.rosters import create_roster
+    from pds_core.routing_models import ModuleWorkRef
+    from pds_core.workspace import ensure_workspace_root
+
+    from concord.models import EffectiveContext, PlannedGroup
+    from concord.starter_templates import get_starter_template
+    from concord.storage import load_current_record_graph
+    from concord.workflows import (
+        ApplyGroupPlanRequest,
+        ApproveGroupPlanRequest,
+        CreateActivityContextRequest,
+        CreateManualGroupPlanRequest,
+        CreateRandomGroupPlanRequest,
+        CreateSignalGroupPlanRequest,
+        PrepareGroupPlanApplicationRequest,
+        PreparePacketInstantiationRequest,
+        PrepareStarterTemplateInstallRequest,
+        PreviewGroupPlanRequest,
+        apply_group_plan,
+        approve_group_plan,
+        commit_packet_instantiation,
+        commit_starter_template_install,
+        create_activity_context,
+        create_manual_group_plan,
+        create_random_group_plan,
+        create_signal_group_plan,
+        prepare_group_plan_application,
+        prepare_packet_instantiation,
+        prepare_starter_template_install,
+        preview_group_plan,
+    )
+    from concord.workflows.packet import (
+        PreparePacketFromTemplateRequest,
+        commit_packet_from_template,
+        prepare_packet_from_template,
+    )
+    from concord.workflows.packet_rendering import (
+        RenderPacketInstanceRequest,
+        render_packet_instance,
+    )
+
+    installed = _installed_modules()
+    outer = _load_json(run_root / RUN_METADATA)
+    workspace = ensure_workspace_root(run_root / "workspace")
+    os.environ["PDS_WORKSPACE_ROOT"] = str(workspace)
+    print_root = run_root / PRINT_DIR
+    print_root.mkdir()
+    class_id = "class-issue70-physical"
+    actor = _actor()
+
+    write_class_metadata_for_class(
+        workspace,
+        create_class_metadata(
+            class_id,
+            "2026-2027",
+            created_at=datetime(2026, 8, 30, tzinfo=timezone.utc),
+        ),
+    )
+    write_class_roster(
+        workspace,
+        create_roster(
+            class_id,
+            tuple(
+                {
+                    "student_id": f"student-{index}",
+                    "last_name": f"Synthetic{index}",
+                    "first_name": f"Learner{index}",
+                    "period": "1",
+                }
+                for index in range(1, 5)
+            ),
+        ),
+    )
+
+    cases: list[dict[str, object]] = []
+    all_print_hashes: set[str] = set()
+    all_artifact_ids: set[str] = set()
+    all_page_ids: set[str] = set()
+    all_route_ids: set[str] = set()
+
+    def add_case(
+        *,
+        workflow: str,
+        case_id: str,
+        activity_id: str,
+        session_id: str,
+        target_kind: str,
+        target_id: str,
+        group_id: str,
+        packet_instance: Any,
+        private_tokens: tuple[str, ...] = (),
+    ) -> None:
+        work = ModuleWorkRef("concord", class_id, activity_id)
+        graph = load_current_record_graph(workspace, work).graph
+        if len(packet_instance.artifact_bindings) != 1:
+            raise RuntimeError(f"{case_id} must bind exactly one Artifact")
+        artifact_id = packet_instance.artifact_bindings[0].artifact_instance_id
+        artifact = next(
+            item
+            for item in graph.artifact_instances
+            if item.artifact_instance_id == artifact_id
+        )
+        rendered = render_packet_instance(
+            RenderPacketInstanceRequest(
+                class_id=class_id,
+                activity_id=activity_id,
+                packet_instance_id=packet_instance.packet_instance_id,
+                actor=actor,
+            ),
+            workspace_root=workspace,
+        )
+        if rendered.page_count != len(artifact.page_ids):
+            raise RuntimeError(f"{case_id} rendered unexpected page count")
+        route_ids: list[str] = []
+        for payload in rendered.payloads:
+            locator = parse_pds2_payload(payload)
+            if (
+                locator.module_id != "concord"
+                or locator.class_id != class_id
+                or locator.work_id != activity_id
+            ):
+                raise RuntimeError(f"{case_id} rendered an unexpected PDS2 locator")
+            route_ids.append(locator.route_id)
+        if len(route_ids) != len(artifact.page_ids):
+            raise RuntimeError(f"{case_id} PDS2/page cardinality does not match")
+        data = rendered.output_path.read_bytes()
+        for token in private_tokens:
+            if token.encode("utf-8") in data:
+                raise RuntimeError(f"{case_id} leaked planning provenance into PDF")
+            if any(token in payload for payload in rendered.payloads):
+                raise RuntimeError(f"{case_id} leaked planning provenance into PDS2")
+        filename = f"PRINT-{case_id}.pdf"
+        print_path = print_root / filename
+        installed_shutil.copy2(rendered.output_path, print_path)
+        print_hash = _sha256(print_path)
+        if print_hash in all_print_hashes:
+            raise RuntimeError("physical sample unexpectedly reused printable bytes")
+        if artifact_id in all_artifact_ids:
+            raise RuntimeError("physical sample unexpectedly reused Artifact identity")
+        if any(page_id in all_page_ids for page_id in artifact.page_ids):
+            raise RuntimeError(
+                "physical sample unexpectedly reused ArtifactPage identity"
+            )
+        if any(route_id in all_route_ids for route_id in route_ids):
+            raise RuntimeError("physical sample unexpectedly reused route identity")
+        all_print_hashes.add(print_hash)
+        all_artifact_ids.add(artifact_id)
+        all_page_ids.update(artifact.page_ids)
+        all_route_ids.update(route_ids)
+        cases.append(
+            {
+                "case_id": case_id,
+                "workflow": workflow,
+                "activity_id": activity_id,
+                "session_id": session_id,
+                "target_kind": target_kind,
+                "target_id": target_id,
+                "group_id": group_id,
+                "packet_instance_id": packet_instance.packet_instance_id,
+                "artifact_instance_id": artifact_id,
+                "artifact_page_ids": list(artifact.page_ids),
+                "route_ids": sorted(route_ids),
+                "page_count": rendered.page_count,
+                "print_pdf_relative_path": f"{PRINT_DIR}/{filename}",
+                "print_pdf_sha256": print_hash,
+            }
+        )
+
+    # Seminar: manual signal-free planning; select one participant from each Group.
+    seminar_activity_id = "activity-seminar-issue70-physical"
+    seminar_session_id = "session-seminar-issue70-physical"
+    seminar_created = create_activity_context(
+        CreateActivityContextRequest(
+            class_id=class_id,
+            activity_id=seminar_activity_id,
+            title="Issue 70 Physical Seminar",
+            activity_type="socratic_seminar",
+            scoring_orientation="local_criteria_only",
+            session_id=seminar_session_id,
+            actor=actor,
+            activity_status="active",
+            session_status="active",
+            session_label="Physical Seminar Session",
+        ),
+        workspace_root=workspace,
+    )
+    seminar_context = EffectiveContext(
+        activity_id=seminar_activity_id,
+        session_ids=(seminar_session_id,),
+    )
+    seminar_plan = create_manual_group_plan(
+        CreateManualGroupPlanRequest(
+            class_id=class_id,
+            activity_id=seminar_activity_id,
+            group_plan_id="plan-seminar-issue70-physical",
+            expected_snapshot_revision=seminar_created.commit.snapshot_revision,
+            actor=actor,
+            proposed_groups=(
+                PlannedGroup(
+                    planned_group_key="seminar-a",
+                    label="Physical Seminar A",
+                    student_ids=("student-1", "student-2"),
+                    effective_context=seminar_context,
+                ),
+                PlannedGroup(
+                    planned_group_key="seminar-b",
+                    label="Physical Seminar B",
+                    student_ids=("student-3", "student-4"),
+                    effective_context=seminar_context,
+                ),
+            ),
+            target_group_count=2,
+        ),
+        workspace_root=workspace,
+    )
+    seminar_preview = preview_group_plan(
+        PreviewGroupPlanRequest(
+            class_id=class_id,
+            activity_id=seminar_activity_id,
+            group_plan_id=seminar_plan.group_plan_id,
+            expected_snapshot_revision=seminar_plan.commit.snapshot_revision,
+            actor=actor,
+        ),
+        workspace_root=workspace,
+    )
+    seminar_approved = approve_group_plan(
+        ApproveGroupPlanRequest(
+            class_id=class_id,
+            activity_id=seminar_activity_id,
+            group_plan_id=seminar_plan.group_plan_id,
+            expected_snapshot_revision=seminar_preview.summary.snapshot_revision,
+            actor=actor,
+        ),
+        workspace_root=workspace,
+    )
+    if seminar_approved.status != "approved":
+        raise RuntimeError("physical seminar GroupPlan approval failed")
+    seminar_application = prepare_group_plan_application(
+        PrepareGroupPlanApplicationRequest(
+            class_id=class_id,
+            activity_id=seminar_activity_id,
+            group_plan_id=seminar_plan.group_plan_id,
+            application_id="apply-seminar-issue70-physical",
+            fallback_effective_context=seminar_context,
+        ),
+        workspace_root=workspace,
+    )
+    seminar_applied = apply_group_plan(
+        ApplyGroupPlanRequest(
+            class_id=class_id,
+            activity_id=seminar_activity_id,
+            group_plan_id=seminar_plan.group_plan_id,
+            application_id=seminar_application.application_id,
+            application_digest=seminar_application.application_digest,
+            expected_snapshot_revision=seminar_application.expected_snapshot_revision,
+            actor=actor,
+            fallback_effective_context=seminar_context,
+        ),
+        workspace_root=workspace,
+    )
+    if seminar_applied.group_count != 2 or seminar_applied.membership_count != 4:
+        raise RuntimeError("physical seminar GroupPlan application failed")
+    seminar_starter = get_starter_template("socratic_seminar")
+    commit_starter_template_install(
+        prepare_starter_template_install(
+            PrepareStarterTemplateInstallRequest(
+                starter_key=seminar_starter.starter_key,
+                actor=actor,
+            ),
+            workspace_root=workspace,
+        ),
+        workspace_root=workspace,
+    )
+    commit_packet_from_template(
+        prepare_packet_from_template(
+            PreparePacketFromTemplateRequest(
+                packet_definition_id="packet-seminar-issue70-physical",
+                packet_version_id="packet-seminar-issue70-physical-v1",
+                packet_component_id="component-seminar-issue70-physical",
+                name="Issue 70 Physical Seminar Packet",
+                purpose="Owner-only physical acceptance.",
+                template_id=seminar_starter.template_id,
+                template_version_id=seminar_starter.template_version_id,
+                audience_kind="participant",
+                actor=actor,
+            ),
+            workspace_root=workspace,
+        ),
+        workspace_root=workspace,
+    )
+    seminar_generation = prepare_packet_instantiation(
+        PreparePacketInstantiationRequest(
+            class_id=class_id,
+            activity_id=seminar_activity_id,
+            session_id=seminar_session_id,
+            packet_definition_id="packet-seminar-issue70-physical",
+            packet_version_id="packet-seminar-issue70-physical-v1",
+            actor=actor,
+        ),
+        workspace_root=workspace,
+    )
+    commit_packet_instantiation(
+        seminar_generation,
+        workspace_root=workspace,
+        generation_id="generation-seminar-issue70-physical",
+    )
+    seminar_graph = load_current_record_graph(
+        workspace,
+        ModuleWorkRef("concord", class_id, seminar_activity_id),
+    ).graph
+    seminar_packets = {
+        item.target_context.participant_reference.participant_id: item
+        for item in seminar_graph.packet_instances
+        if item.generation_id == "generation-seminar-issue70-physical"
+        and item.target_context.participant_reference is not None
+    }
+    for student_id in ("student-1", "student-3"):
+        packet = seminar_packets[student_id]
+        group_id = packet.target_context.group_id
+        if group_id is None or group_id not in seminar_applied.group_ids:
+            raise RuntimeError("physical seminar sample lost canonical Group context")
+        add_case(
+            workflow="seminar",
+            case_id=f"seminar-{student_id}",
+            activity_id=seminar_activity_id,
+            session_id=seminar_session_id,
+            target_kind="core_student",
+            target_id=student_id,
+            group_id=group_id,
+            packet_instance=packet,
+        )
+
+    # Group project: complete synthetic signal-backed planning; print both
+    # canonical Group packets.
+    project_activity_id = "activity-project-issue70-physical"
+    project_session_id = "session-project-issue70-physical"
+    project_created = create_activity_context(
+        CreateActivityContextRequest(
+            class_id=class_id,
+            activity_id=project_activity_id,
+            title="Issue 70 Physical Group Project",
+            activity_type="project",
+            scoring_orientation="local_criteria_only",
+            session_id=project_session_id,
+            actor=actor,
+            activity_status="active",
+            session_status="active",
+            session_label="Physical Project Session",
+        ),
+        workspace_root=workspace,
+    )
+    project_context = EffectiveContext(
+        activity_id=project_activity_id,
+        session_ids=(project_session_id,),
+    )
+    private_signal_set_id = "issue70-physical-private-signal-set"
+    private_dimension_id = "issue70-physical-private-band"
+    private_source_module = "issue70_physical_private_producer"
+    private_snapshot_id = "issue70-physical-private-snapshot"
+    private_snapshot_digest = "7" * 64
+    signal = GroupingSignalSet(
+        schema_version="1",
+        record_type="grouping_signal_set",
+        signal_set_id=private_signal_set_id,
+        class_id=class_id,
+        created_at=datetime(2026, 8, 30, 12, 0, tzinfo=timezone.utc),
+        source=GroupingSignalSource(
+            kind="module_generated",
+            module_id=private_source_module,
+            snapshot_id=private_snapshot_id,
+            snapshot_digest_algorithm="sha256",
+            snapshot_digest=private_snapshot_digest,
+        ),
+        dimensions=(
+            GroupingSignalDimension(
+                dimension_id=private_dimension_id,
+                band_count=4,
+            ),
+        ),
+        student_bands=(
+            GroupingSignalStudentBand(
+                student_id="student-1",
+                dimension_id=private_dimension_id,
+                band=1,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-2",
+                dimension_id=private_dimension_id,
+                band=1,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-3",
+                dimension_id=private_dimension_id,
+                band=4,
+            ),
+            GroupingSignalStudentBand(
+                student_id="student-4",
+                dimension_id=private_dimension_id,
+                band=4,
+            ),
+        ),
+    )
+    write_grouping_signal(workspace, signal)
+    private_canonical_digest = calculate_grouping_signal_digest(signal)
+    private_tokens = (
+        private_signal_set_id,
+        private_dimension_id,
+        private_source_module,
+        private_snapshot_id,
+        private_snapshot_digest,
+        private_canonical_digest,
+    )
+    project_plan = create_signal_group_plan(
+        CreateSignalGroupPlanRequest(
+            class_id=class_id,
+            activity_id=project_activity_id,
+            group_plan_id="plan-project-issue70-physical",
+            strategy="similar_signal",
+            signal_set_id=private_signal_set_id,
+            dimension_id=private_dimension_id,
+            expected_snapshot_revision=project_created.commit.snapshot_revision,
+            actor=actor,
+            target_group_count=2,
+            expected_roster_student_ids=(
+                "student-1",
+                "student-2",
+                "student-3",
+                "student-4",
+            ),
+            expected_signal_set_digest=private_canonical_digest,
+        ),
+        workspace_root=workspace,
+    )
+    project_preview = preview_group_plan(
+        PreviewGroupPlanRequest(
+            class_id=class_id,
+            activity_id=project_activity_id,
+            group_plan_id=project_plan.mutation.group_plan_id,
+            expected_snapshot_revision=project_plan.mutation.commit.snapshot_revision,
+            actor=actor,
+        ),
+        workspace_root=workspace,
+    )
+    project_approved = approve_group_plan(
+        ApproveGroupPlanRequest(
+            class_id=class_id,
+            activity_id=project_activity_id,
+            group_plan_id=project_plan.mutation.group_plan_id,
+            expected_snapshot_revision=project_preview.summary.snapshot_revision,
+            actor=actor,
+        ),
+        workspace_root=workspace,
+    )
+    if project_approved.status != "approved":
+        raise RuntimeError("physical project GroupPlan approval failed")
+    project_application = prepare_group_plan_application(
+        PrepareGroupPlanApplicationRequest(
+            class_id=class_id,
+            activity_id=project_activity_id,
+            group_plan_id=project_plan.mutation.group_plan_id,
+            application_id="apply-project-issue70-physical",
+            fallback_effective_context=project_context,
+        ),
+        workspace_root=workspace,
+    )
+    project_applied = apply_group_plan(
+        ApplyGroupPlanRequest(
+            class_id=class_id,
+            activity_id=project_activity_id,
+            group_plan_id=project_plan.mutation.group_plan_id,
+            application_id=project_application.application_id,
+            application_digest=project_application.application_digest,
+            expected_snapshot_revision=project_application.expected_snapshot_revision,
+            actor=actor,
+            fallback_effective_context=project_context,
+        ),
+        workspace_root=workspace,
+    )
+    if project_applied.group_count != 2 or project_applied.membership_count != 4:
+        raise RuntimeError("physical project GroupPlan application failed")
+    project_starter = get_starter_template("project_plan")
+    commit_starter_template_install(
+        prepare_starter_template_install(
+            PrepareStarterTemplateInstallRequest(
+                starter_key=project_starter.starter_key,
+                actor=actor,
+            ),
+            workspace_root=workspace,
+        ),
+        workspace_root=workspace,
+    )
+    commit_packet_from_template(
+        prepare_packet_from_template(
+            PreparePacketFromTemplateRequest(
+                packet_definition_id="packet-project-issue70-physical",
+                packet_version_id="packet-project-issue70-physical-v1",
+                packet_component_id="component-project-issue70-physical",
+                name="Issue 70 Physical Project Packet",
+                purpose="Owner-only physical acceptance.",
+                template_id=project_starter.template_id,
+                template_version_id=project_starter.template_version_id,
+                audience_kind="group",
+                actor=actor,
+            ),
+            workspace_root=workspace,
+        ),
+        workspace_root=workspace,
+    )
+    project_generation = prepare_packet_instantiation(
+        PreparePacketInstantiationRequest(
+            class_id=class_id,
+            activity_id=project_activity_id,
+            session_id=project_session_id,
+            packet_definition_id="packet-project-issue70-physical",
+            packet_version_id="packet-project-issue70-physical-v1",
+            actor=actor,
+        ),
+        workspace_root=workspace,
+    )
+    commit_packet_instantiation(
+        project_generation,
+        workspace_root=workspace,
+        generation_id="generation-project-issue70-physical",
+    )
+    project_graph = load_current_record_graph(
+        workspace,
+        ModuleWorkRef("concord", class_id, project_activity_id),
+    ).graph
+    project_packets = tuple(
+        item
+        for item in project_graph.packet_instances
+        if item.generation_id == "generation-project-issue70-physical"
+    )
+    if len(project_packets) != 2:
+        raise RuntimeError("physical project sample must contain both Group packets")
+    for index, packet in enumerate(
+        sorted(project_packets, key=lambda item: item.target_context.group_id or ""),
+        start=1,
+    ):
+        group_id = packet.target_context.group_id
+        if group_id is None or group_id not in project_applied.group_ids:
+            raise RuntimeError("physical project packet lost canonical Group context")
+        add_case(
+            workflow="project",
+            case_id=f"project-group-{index}",
+            activity_id=project_activity_id,
+            session_id=project_session_id,
+            target_kind="concord_group",
+            target_id=group_id,
+            group_id=group_id,
+            packet_instance=packet,
+            private_tokens=private_tokens,
+        )
+
+    # Peer review: deterministic random signal-free planning; one participant per Group.
+    peer_activity_id = "activity-peer-review-issue70-physical"
+    peer_session_id = "session-peer-review-issue70-physical"
+    peer_created = create_activity_context(
+        CreateActivityContextRequest(
+            class_id=class_id,
+            activity_id=peer_activity_id,
+            title="Issue 70 Physical Peer Review",
+            activity_type="project",
+            scoring_orientation="local_criteria_only",
+            session_id=peer_session_id,
+            actor=actor,
+            activity_status="active",
+            session_status="active",
+            session_label="Physical Peer Review Session",
+        ),
+        workspace_root=workspace,
+    )
+    peer_context = EffectiveContext(
+        activity_id=peer_activity_id,
+        session_ids=(peer_session_id,),
+    )
+    peer_plan = create_random_group_plan(
+        CreateRandomGroupPlanRequest(
+            class_id=class_id,
+            activity_id=peer_activity_id,
+            group_plan_id="plan-peer-review-issue70-physical",
+            expected_snapshot_revision=peer_created.commit.snapshot_revision,
+            actor=actor,
+            seed="issue70-physical-peer-review-seed",
+            target_group_count=2,
+        ),
+        workspace_root=workspace,
+    )
+    peer_preview = preview_group_plan(
+        PreviewGroupPlanRequest(
+            class_id=class_id,
+            activity_id=peer_activity_id,
+            group_plan_id=peer_plan.mutation.group_plan_id,
+            expected_snapshot_revision=peer_plan.mutation.commit.snapshot_revision,
+            actor=actor,
+        ),
+        workspace_root=workspace,
+    )
+    peer_approved = approve_group_plan(
+        ApproveGroupPlanRequest(
+            class_id=class_id,
+            activity_id=peer_activity_id,
+            group_plan_id=peer_plan.mutation.group_plan_id,
+            expected_snapshot_revision=peer_preview.summary.snapshot_revision,
+            actor=actor,
+        ),
+        workspace_root=workspace,
+    )
+    if peer_approved.status != "approved":
+        raise RuntimeError("physical peer-review GroupPlan approval failed")
+    peer_application = prepare_group_plan_application(
+        PrepareGroupPlanApplicationRequest(
+            class_id=class_id,
+            activity_id=peer_activity_id,
+            group_plan_id=peer_plan.mutation.group_plan_id,
+            application_id="apply-peer-review-issue70-physical",
+            fallback_effective_context=peer_context,
+        ),
+        workspace_root=workspace,
+    )
+    peer_applied = apply_group_plan(
+        ApplyGroupPlanRequest(
+            class_id=class_id,
+            activity_id=peer_activity_id,
+            group_plan_id=peer_plan.mutation.group_plan_id,
+            application_id=peer_application.application_id,
+            application_digest=peer_application.application_digest,
+            expected_snapshot_revision=peer_application.expected_snapshot_revision,
+            actor=actor,
+            fallback_effective_context=peer_context,
+        ),
+        workspace_root=workspace,
+    )
+    if peer_applied.group_count != 2 or peer_applied.membership_count != 4:
+        raise RuntimeError("physical peer-review GroupPlan application failed")
+    peer_starter = get_starter_template("peer_review_writing")
+    commit_starter_template_install(
+        prepare_starter_template_install(
+            PrepareStarterTemplateInstallRequest(
+                starter_key=peer_starter.starter_key,
+                actor=actor,
+            ),
+            workspace_root=workspace,
+        ),
+        workspace_root=workspace,
+    )
+    commit_packet_from_template(
+        prepare_packet_from_template(
+            PreparePacketFromTemplateRequest(
+                packet_definition_id="packet-peer-review-issue70-physical",
+                packet_version_id="packet-peer-review-issue70-physical-v1",
+                packet_component_id="component-peer-review-issue70-physical",
+                name="Issue 70 Physical Peer Review Packet",
+                purpose="Owner-only physical acceptance.",
+                template_id=peer_starter.template_id,
+                template_version_id=peer_starter.template_version_id,
+                audience_kind="participant",
+                actor=actor,
+            ),
+            workspace_root=workspace,
+        ),
+        workspace_root=workspace,
+    )
+    peer_generation = prepare_packet_instantiation(
+        PreparePacketInstantiationRequest(
+            class_id=class_id,
+            activity_id=peer_activity_id,
+            session_id=peer_session_id,
+            packet_definition_id="packet-peer-review-issue70-physical",
+            packet_version_id="packet-peer-review-issue70-physical-v1",
+            actor=actor,
+        ),
+        workspace_root=workspace,
+    )
+    commit_packet_instantiation(
+        peer_generation,
+        workspace_root=workspace,
+        generation_id="generation-peer-review-issue70-physical",
+    )
+    peer_graph = load_current_record_graph(
+        workspace,
+        ModuleWorkRef("concord", class_id, peer_activity_id),
+    ).graph
+    peer_packets = tuple(
+        item
+        for item in peer_graph.packet_instances
+        if item.generation_id == "generation-peer-review-issue70-physical"
+        and item.target_context.participant_reference is not None
+    )
+    packet_by_group: dict[str, Any] = {}
+    for packet in sorted(
+        peer_packets,
+        key=lambda item: item.target_context.participant_reference.participant_id,
+    ):
+        group_id = packet.target_context.group_id
+        if group_id is None or group_id not in peer_applied.group_ids:
+            raise RuntimeError(
+                "physical peer-review packet lost canonical Group context"
+            )
+        packet_by_group.setdefault(group_id, packet)
+    if set(packet_by_group) != set(peer_applied.group_ids):
+        raise RuntimeError("physical peer-review sample does not span both Groups")
+    for index, (group_id, packet) in enumerate(
+        sorted(packet_by_group.items()), start=1
+    ):
+        participant = packet.target_context.participant_reference
+        if participant is None:
+            raise RuntimeError("physical peer-review sample lost participant identity")
+        add_case(
+            workflow="peer_review",
+            case_id=f"peer-group-{index}-{participant.participant_id}",
+            activity_id=peer_activity_id,
+            session_id=peer_session_id,
+            target_kind="core_student",
+            target_id=participant.participant_id,
+            group_id=group_id,
+            packet_instance=packet,
+        )
+
+    if len(cases) != 6:
+        raise RuntimeError("issue #70 physical sample must contain exactly six packets")
+    workflow_counts = {
+        workflow: sum(case["workflow"] == workflow for case in cases)
+        for workflow in ("seminar", "project", "peer_review")
+    }
+    if workflow_counts != {"seminar": 2, "project": 2, "peer_review": 2}:
+        raise RuntimeError("issue #70 physical sample workflow cardinality is wrong")
+    state: dict[str, object] = {
+        "schema_version": 2,
+        "status": "prepared_for_physical_return",
+        "workspace_relative_path": "workspace",
+        "class_id": class_id,
+        "cases": cases,
+        "workflow_counts": workflow_counts,
+        "private_project_tokens": list(private_tokens),
+        "installed_concord_version": metadata.version("pds-concord"),
+        "installed_core_version": metadata.version("pds-core"),
+        "installed_concord_origin": installed["concord_origin"],
+        "installed_core_origin": installed["core_origin"],
+        "concord_wheel_sha256": outer["concord_wheel_sha256"],
+        "core_wheel_sha256": outer["core_wheel_sha256"],
+    }
+    _write_json(run_root / STATE_FILE, state)
+    print("PREPARED issue #70 physical sample")
+    for case in cases:
+        print(
+            f"{case['case_id']}: {run_root / str(case['print_pdf_relative_path'])}"
+        )
+    print("expected_packets=6")
+    print(
+        "expected_pages="
+        + str(sum(_json_int(case, "page_count") for case in cases))
+    )
+    return 0
+
+
+def _installed_resume(args: argparse.Namespace) -> int:
+    import platform
+    from datetime import datetime
+    from importlib import metadata
+
+    from pds_core.routing_models import ModuleWorkRef
+
+    from concord.academic_result_manifest_generation import (
+        GenerateAcademicResultManifestRequest,
+        generate_academic_result_manifest,
+    )
+    from concord.academic_result_publication import publish_concord_academic_results
+    from concord.academic_result_reader import (
+        lookup_academic_result_score,
+        read_academic_result_manifest,
+    )
+    from concord.academic_work_registration import register_concord_academic_work
+    from concord.models import (
+        EvidenceReference,
+        PrivacyPolicy,
+        ScoreTargetReference,
+        ScoringScaleLevel,
+        SubjectReference,
+    )
+    from concord.routing.scan_intake import (
+        SUPPORTED_SCAN_EXTENSIONS,
+        route_scan_sources,
+    )
+    from concord.storage import load_current_record_graph
+    from concord.workflows import (
+        AddArtifactReviewRequest,
+        AddScoreRequest,
+        AssembleArtifactRequest,
+        ConcordRouteDispatchResult,
+        CreateCriterionSetRequest,
+        CreateScoringScaleRequest,
+        CriterionSpec,
+        ScoreEvidenceLinkSpec,
+        SelectActivityCriterionSetsRequest,
+        add_artifact_review,
+        add_score,
+        assemble_returned_artifact,
+        create_criterion_set,
+        create_scoring_scale,
+        select_activity_criterion_sets,
+    )
+
+    run_root = Path(args.run_root).resolve()
+    installed = _installed_modules()
+    outer = _load_json(run_root / RUN_METADATA)
+    state = _load_json(run_root / STATE_FILE)
+    if state.get("status") != "prepared_for_physical_return":
+        raise RuntimeError("physical acceptance state is not ready for resume")
+    if not args.physical_mark_confirmed:
+        raise RuntimeError(
+            "resume requires --physical-mark-confirmed after handwriting PDS70 "
+            "on representative paper from every starter family"
+        )
+    if not args.visual_inspection_confirmed:
+        raise RuntimeError(
+            "resume requires --visual-inspection-confirmed after inspecting at least "
+            "one printed sample from seminar, project, and peer-review families"
+        )
+    workspace_relative = state.get("workspace_relative_path")
+    if not isinstance(workspace_relative, str):
+        raise RuntimeError("physical state is missing workspace path")
+    workspace = run_root / workspace_relative
+    os.environ["PDS_WORKSPACE_ROOT"] = str(workspace)
+    class_id = _json_string(state, "class_id")
+    cases = _json_cases(state)
+    private_tokens = _json_strings(state, "private_project_tokens")
+    scans = tuple(Path(value).resolve() for value in args.scan)
+    if not scans:
+        raise RuntimeError("at least one scan path is required")
+
+    print_hashes = {
+        _json_string(case, "print_pdf_sha256")
+        for case in cases
+    }
+    scan_digests: dict[str, str] = {}
+    for scan in scans:
+        if scan.suffix.lower() not in SUPPORTED_SCAN_EXTENSIONS:
+            raise RuntimeError(f"unsupported physical scan extension: {scan.suffix}")
+        digest = _sha256(scan)
+        if digest in print_hashes:
+            raise RuntimeError(
+                "physical scan bytes exactly equal generated printable bytes; an "
+                "untouched generated PDF is not physical acceptance evidence"
+            )
+        scan_digests[scan.name] = digest
+
+    route_to_case: dict[str, dict[str, object]] = {}
+    expected_pages_by_case: dict[str, set[str]] = {}
+    expected_routes_by_case: dict[str, set[str]] = {}
+    total_expected_pages = 0
+    for case in cases:
+        case_id = _json_string(case, "case_id")
+        artifact_id = _json_string(case, "artifact_instance_id")
+        page_ids = set(_json_strings(case, "artifact_page_ids"))
+        route_ids = set(_json_strings(case, "route_ids"))
+        if len(page_ids) != len(route_ids) or len(page_ids) != _json_int(
+            case, "page_count"
+        ):
+            raise RuntimeError(
+                f"{case_id} persisted physical identity count is invalid"
+            )
+        expected_pages_by_case[case_id] = page_ids
+        expected_routes_by_case[case_id] = route_ids
+        total_expected_pages += len(page_ids)
+        for route_id in route_ids:
+            if route_id in route_to_case:
+                raise RuntimeError("physical state contains duplicate route identity")
+            route_to_case[route_id] = case
+
+    actor = _actor()
+    for activity_id in sorted({_json_string(case, "activity_id") for case in cases}):
+        work = ModuleWorkRef("concord", class_id, activity_id)
+        before = load_current_record_graph(workspace, work).graph
+        if before.artifact_reviews or before.score_records:
+            raise RuntimeError("physical resume requires pre-Review, pre-Score state")
+
+    returned = route_scan_sources(scans, workspace_root=workspace)
+    if returned.failure_count != 0 or returned.dispatched_count != total_expected_pages:
+        raise RuntimeError(
+            "physical scan did not dispatch every required sample page without failures"
+        )
+    observed_pages_by_case: dict[str, set[str]] = {
+        case_id: set() for case_id in expected_pages_by_case
+    }
+    observed_routes_by_case: dict[str, set[str]] = {
+        case_id: set() for case_id in expected_routes_by_case
+    }
+    retained_source_ids: set[str] = set()
+    physical_source_page_count = 0
+    for source in returned.sources:
+        if source.source_error is not None or source.retained_source is None:
+            raise RuntimeError("physical scan source was not retained successfully")
+        retained_source_ids.add(source.retained_source.source_scan_id)
+        physical_source_page_count += len(source.pages)
+        for page in source.pages:
+            if page.status != "dispatched" or page.locator is None:
+                raise RuntimeError("physical scan page did not dispatch")
+            matched_case = route_to_case.get(page.locator.route_id)
+            if matched_case is None:
+                raise RuntimeError("physical scan resolved an unexpected route")
+            case_id = _json_string(matched_case, "case_id")
+            activity_id = _json_string(matched_case, "activity_id")
+            artifact_id = _json_string(matched_case, "artifact_instance_id")
+            if (
+                page.locator.module_id != "concord"
+                or page.locator.class_id != class_id
+                or page.locator.work_id != activity_id
+            ):
+                raise RuntimeError(f"{case_id} physical route escaped expected work")
+            dispatch = page.module_result
+            if not isinstance(dispatch, ConcordRouteDispatchResult):
+                raise RuntimeError("physical scan returned an unexpected owner result")
+            if dispatch.artifact_instance_id != artifact_id:
+                raise RuntimeError(f"{case_id} physical route reached wrong Artifact")
+            observed_routes_by_case[case_id].add(page.locator.route_id)
+            observed_pages_by_case[case_id].add(dispatch.artifact_page_id)
+
+    for case in cases:
+        case_id = _json_string(case, "case_id")
+        if observed_routes_by_case[case_id] != expected_routes_by_case[case_id]:
+            raise RuntimeError(f"{case_id} physical route set is incomplete")
+        if observed_pages_by_case[case_id] != expected_pages_by_case[case_id]:
+            raise RuntimeError(f"{case_id} physical ArtifactPage set is incomplete")
+
+    # Scan intake must not infer teacher judgment.
+    for activity_id in sorted({_json_string(case, "activity_id") for case in cases}):
+        work = ModuleWorkRef("concord", class_id, activity_id)
+        graph = load_current_record_graph(workspace, work).graph
+        if graph.artifact_reviews:
+            raise RuntimeError("scan intake inferred Artifact Review state")
+        if graph.score_records:
+            raise RuntimeError("scan intake inferred Score state")
+
+    # Assemble and explicitly review each physically returned Artifact.
+    for index, case in enumerate(cases, start=1):
+        case_id = _json_string(case, "case_id")
+        activity_id = _json_string(case, "activity_id")
+        artifact_id = _json_string(case, "artifact_instance_id")
+        assembled = assemble_returned_artifact(
+            AssembleArtifactRequest(
+                class_id=class_id,
+                activity_id=activity_id,
+                artifact_instance_id=artifact_id,
+                expected_snapshot_revision=_current_revision(
+                    workspace, class_id, activity_id
+                ),
+                actor=actor,
+            ),
+            workspace_root=workspace,
+        )
+        if assembled.page_count != _json_int(case, "page_count"):
+            raise RuntimeError(f"{case_id} physical Artifact assembly is incomplete")
+        workflow = _json_string(case, "workflow")
+        privacy_classification: Any = (
+            "group_and_teacher" if workflow == "project" else "teacher_and_subjects"
+        )
+        privacy = PrivacyPolicy(classification=privacy_classification)
+        review = add_artifact_review(
+            AddArtifactReviewRequest(
+                class_id=class_id,
+                activity_id=activity_id,
+                artifact_instance_id=artifact_id,
+                artifact_review_id=f"review-issue70-physical-{index}",
+                readability_judgment="readable",
+                page_completeness_judgment="complete",
+                filing_judgment="correct",
+                author_judgment="confirmed",
+                subject_judgment="confirmed",
+                privacy_judgment=privacy_classification,
+                relevance_judgment="relevant",
+                moderation_requirement="not_required",
+                scoring_readiness="ready",
+                review_outcome="ready",
+                privacy_policy=privacy,
+                expected_snapshot_revision=_current_revision(
+                    workspace, class_id, activity_id
+                ),
+                actor=actor,
+                notes="Owner-only physical issue #70 synthetic acceptance.",
+            ),
+            workspace_root=workspace,
+        )
+        if review.artifact_review_id != f"review-issue70-physical-{index}":
+            raise RuntimeError(f"{case_id} physical Review did not persist")
+
+    workflow_specs: dict[str, dict[str, str]] = {
+        "seminar": {
+            "scale_id": "scale-seminar-issue70-physical",
+            "scale_lineage": "scale-seminar-issue70-physical-lineage",
+            "criterion_set_id": "criteria-seminar-issue70-physical",
+            "criterion_lineage": "criteria-seminar-issue70-physical-lineage",
+            "criterion_id": "criterion-seminar-issue70-physical",
+            "criterion_key": "seminar-participation",
+            "criterion_label": "Seminar participation",
+            "target_kind": "core_student",
+            "privacy": "teacher_and_subjects",
+        },
+        "project": {
+            "scale_id": "scale-project-issue70-physical",
+            "scale_lineage": "scale-project-issue70-physical-lineage",
+            "criterion_set_id": "criteria-project-issue70-physical",
+            "criterion_lineage": "criteria-project-issue70-physical-lineage",
+            "criterion_id": "criterion-project-issue70-physical",
+            "criterion_key": "project-collaboration",
+            "criterion_label": "Project collaboration",
+            "target_kind": "concord_group",
+            "privacy": "group_and_teacher",
+        },
+        "peer_review": {
+            "scale_id": "scale-peer-review-issue70-physical",
+            "scale_lineage": "scale-peer-review-issue70-physical-lineage",
+            "criterion_set_id": "criteria-peer-review-issue70-physical",
+            "criterion_lineage": "criteria-peer-review-issue70-physical-lineage",
+            "criterion_id": "criterion-peer-review-issue70-physical",
+            "criterion_key": "peer-review-quality",
+            "criterion_label": "Peer-review quality",
+            "target_kind": "core_student",
+            "privacy": "teacher_and_subjects",
+        },
+    }
+
+    score_ids_by_workflow: dict[str, list[str]] = {
+        "seminar": [],
+        "project": [],
+        "peer_review": [],
+    }
+    for workflow, spec in workflow_specs.items():
+        workflow_cases = tuple(
+            case for case in cases if _json_string(case, "workflow") == workflow
+        )
+        if len(workflow_cases) != 2:
+            raise RuntimeError(f"{workflow} physical sample must contain two packets")
+        activity_id = _json_string(workflow_cases[0], "activity_id")
+        scale = create_scoring_scale(
+            CreateScoringScaleRequest(
+                class_id=class_id,
+                activity_id=activity_id,
+                scoring_scale_id=spec["scale_id"],
+                lineage_id=spec["scale_lineage"],
+                name=f"Issue 70 Physical {workflow} Scale",
+                revision=1,
+                scale_type="categorical",
+                levels=(
+                    ScoringScaleLevel(
+                        value="developing",
+                        label="Developing",
+                        meaning="Synthetic developing level.",
+                    ),
+                    ScoringScaleLevel(
+                        value="meets",
+                        label="Meets",
+                        meaning="Synthetic meets level.",
+                    ),
+                ),
+                status="active",
+                expected_snapshot_revision=_current_revision(
+                    workspace, class_id, activity_id
+                ),
+                actor=actor,
+                intended_use="Owner-only issue #70 physical acceptance.",
+            ),
+            workspace_root=workspace,
+        )
+        criteria = create_criterion_set(
+            CreateCriterionSetRequest(
+                class_id=class_id,
+                activity_id=activity_id,
+                criterion_set_id=spec["criterion_set_id"],
+                lineage_id=spec["criterion_lineage"],
+                name=f"Issue 70 Physical {workflow} Criteria",
+                purpose="Owner-only issue #70 physical acceptance.",
+                revision=1,
+                scope="activity_specific",
+                criterion_set_kind="local",
+                criteria=(
+                    CriterionSpec(
+                        criterion_id=spec["criterion_id"],
+                        key=spec["criterion_key"],
+                        label=spec["criterion_label"],
+                        definition="Synthetic physical acceptance criterion.",
+                        criterion_kind="local",
+                        supported_target_kinds=(cast(Any, spec["target_kind"]),),
+                        default_scoring_scale_id=spec["scale_id"],
+                    ),
+                ),
+                status="active",
+                expected_snapshot_revision=scale.commit.snapshot_revision,
+                actor=actor,
+            ),
+            workspace_root=workspace,
+        )
+        selected = select_activity_criterion_sets(
+            SelectActivityCriterionSetsRequest(
+                class_id=class_id,
+                activity_id=activity_id,
+                criterion_set_ids=(spec["criterion_set_id"],),
+                expected_snapshot_revision=criteria.commit.snapshot_revision,
+                actor=actor,
+            ),
+            workspace_root=workspace,
+        )
+        if selected.criterion_set_ids != (spec["criterion_set_id"],):
+            raise RuntimeError(f"{workflow} physical Criterion Set was not selected")
+        privacy_value: Any = spec["privacy"]
+        target_kind: Any = spec["target_kind"]
+        privacy = PrivacyPolicy(classification=privacy_value)
+        for index, case in enumerate(workflow_cases, start=1):
+            target_id = _json_string(case, "target_id")
+            artifact_id = _json_string(case, "artifact_instance_id")
+            session_id = _json_string(case, "session_id")
+            if spec["target_kind"] == "concord_group":
+                subject = SubjectReference(
+                    subject_kind="concord_group",
+                    subject_id=target_id,
+                    owning_system="concord",
+                )
+                owning_system: Any = "concord"
+            else:
+                subject = SubjectReference(
+                    subject_kind="core_student",
+                    subject_id=target_id,
+                    owning_system="core",
+                )
+                owning_system = "core"
+            evidence = EvidenceReference(
+                evidence_kind="artifact_instance",
+                owning_system="concord",
+                record_id=artifact_id,
+                subject_context=(subject,),
+                moderation_requirement="not_required",
+            )
+            score_id = f"score-{workflow}-issue70-physical-{index}"
+            score = add_score(
+                AddScoreRequest(
+                    class_id=class_id,
+                    activity_id=activity_id,
+                    score_record_id=score_id,
+                    target_reference=ScoreTargetReference(
+                        target_kind=target_kind,
+                        target_id=target_id,
+                        owning_system=owning_system,
+                    ),
+                    criterion_id=spec["criterion_id"],
+                    scoring_scale_id=spec["scale_id"],
+                    disposition="scored",
+                    basis="linked_evidence",
+                    privacy_policy=privacy,
+                    expected_snapshot_revision=_current_revision(
+                        workspace, class_id, activity_id
+                    ),
+                    actor=actor,
+                    session_id=session_id,
+                    value="meets",
+                    evidence_links=(
+                        ScoreEvidenceLinkSpec(
+                            score_evidence_link_id=(
+                                f"link-{workflow}-issue70-physical-{index}"
+                            ),
+                            evidence_reference=evidence,
+                            relevance_description=(
+                                "Synthetic physically returned issue #70 Artifact."
+                            ),
+                            subject_context=(subject,),
+                        ),
+                    ),
+                ),
+                workspace_root=workspace,
+            )
+            if score.score_record_id != score_id:
+                raise RuntimeError(f"{workflow} physical Score did not persist")
+            score_ids_by_workflow[workflow].append(score_id)
+
+    publication_summaries: dict[str, dict[str, object]] = {}
+    for workflow, workflow_cases in (
+        (
+            name,
+            tuple(case for case in cases if _json_string(case, "workflow") == name),
+        )
+        for name in ("seminar", "project", "peer_review")
+    ):
+        activity_id = _json_string(workflow_cases[0], "activity_id")
+        work = ModuleWorkRef("concord", class_id, activity_id)
+        registration = register_concord_academic_work(
+            workspace,
+            class_id,
+            activity_id,
+            academic_intent="formative",
+            lifecycle="active",
+        )
+        if registration.registration.registration_revision != 1:
+            raise RuntimeError(f"{workflow} Academic Work registration failed")
+        manifest_request = GenerateAcademicResultManifestRequest(
+            class_id=class_id,
+            activity_id=activity_id,
+            expected_snapshot_revision=_current_revision(
+                workspace, class_id, activity_id
+            ),
+            actor=actor,
+            revision_reason="initial",
+        )
+        generated = generate_academic_result_manifest(
+            manifest_request,
+            workspace_root=workspace,
+        )
+        public_before = read_academic_result_manifest(generated.content)
+        for score_id in score_ids_by_workflow[workflow]:
+            public_score = lookup_academic_result_score(public_before, score_id)
+            if public_score.value != "meets" or public_score.disposition != "scored":
+                raise RuntimeError(f"{workflow} public Score readback is incorrect")
+        publication = publish_concord_academic_results(
+            manifest_request,
+            workspace_root=workspace,
+        )
+        if not publication.compatibility.compatible:
+            raise RuntimeError(f"{workflow} physical publication is incompatible")
+        if publication.publication.work != work:
+            raise RuntimeError(f"{workflow} physical publication work is incorrect")
+        public_after = read_academic_result_manifest(
+            publication.manifest_generation.content
+        )
+        if public_after != public_before:
+            raise RuntimeError(f"{workflow} publication changed public semantics")
+        if workflow == "project":
+            for token in private_tokens:
+                encoded = token.encode("utf-8")
+                if (
+                    encoded in generated.content
+                    or encoded in publication.manifest_generation.content
+                ):
+                    raise RuntimeError(
+                        "project planning-only provenance leaked into result manifest"
+                    )
+                if token in repr(publication.publication):
+                    raise RuntimeError(
+                        "project planning-only provenance leaked into "
+                        "Publication Record"
+                    )
+        publication_summaries[workflow] = {
+            "manifest_digest": publication.publication.manifest_digest,
+            "publication_id": publication.publication.publication_id,
+            "publication_revision": publication.publication.record_set_revision,
+            "score_record_ids": list(score_ids_by_workflow[workflow]),
+        }
+
+    # Re-check project downstream records after physical review/scoring/publication.
+    project_case = next(
+        case for case in cases if _json_string(case, "workflow") == "project"
+    )
+    project_work = ModuleWorkRef(
+        "concord",
+        class_id,
+        _json_string(project_case, "activity_id"),
+    )
+    project_graph = load_current_record_graph(workspace, project_work).graph
+    for record in (
+        *project_graph.groups,
+        *project_graph.memberships,
+        *project_graph.packet_instances,
+        *project_graph.artifact_instances,
+        *project_graph.artifact_pages,
+        *project_graph.scan_references,
+        *project_graph.artifact_reviews,
+        *project_graph.score_records,
+    ):
+        representation = repr(record)
+        if any(token in representation for token in private_tokens):
+            raise RuntimeError("project planning provenance leaked downstream")
+
+    workflow_route_ids: dict[str, list[str]] = {}
+    workflow_page_ids: dict[str, list[str]] = {}
+    workflow_artifact_ids: dict[str, list[str]] = {}
+    for workflow in ("seminar", "project", "peer_review"):
+        workflow_cases = tuple(
+            case for case in cases if _json_string(case, "workflow") == workflow
+        )
+        workflow_route_ids[workflow] = sorted(
+            route_id
+            for case in workflow_cases
+            for route_id in observed_routes_by_case[_json_string(case, "case_id")]
+        )
+        workflow_page_ids[workflow] = sorted(
+            page_id
+            for case in workflow_cases
+            for page_id in observed_pages_by_case[_json_string(case, "case_id")]
+        )
+        workflow_artifact_ids[workflow] = sorted(
+            _json_string(case, "artifact_instance_id") for case in workflow_cases
+        )
+
+    evidence_summary: dict[str, object] = {
+        "schema_version": 2,
+        "technical_path": "COMPLETED",
+        "owner_physical_classification_required": True,
+        "physical_mark_confirmed": True,
+        "visual_inspection_confirmed": True,
+        "final_commit": outer["final_commit"],
+        "concord_wheel_filename": outer["concord_wheel_filename"],
+        "concord_wheel_byte_length": outer["concord_wheel_byte_length"],
+        "concord_wheel_sha256": outer["concord_wheel_sha256"],
+        "core_wheel_filename": outer["core_wheel_filename"],
+        "core_wheel_byte_length": outer["core_wheel_byte_length"],
+        "core_wheel_sha256": outer["core_wheel_sha256"],
+        "python_version": sys.version.split()[0],
+        "platform": platform.platform(),
+        "installed_concord_version": metadata.version("pds-concord"),
+        "installed_core_version": metadata.version("pds-core"),
+        "installed_concord_origin": installed["concord_origin"],
+        "installed_core_origin": installed["core_origin"],
+        "tester": args.tester,
+        "date_local_time": datetime.now().astimezone().isoformat(timespec="seconds"),
+        "printer": args.printer,
+        "printer_path": args.printer_path,
+        "paper_size": args.paper_size,
+        "print_scaling": args.print_scaling,
+        "print_sides": args.print_sides,
+        "print_color_mode": args.print_color_mode,
+        "scanner": args.scanner,
+        "scanner_path": args.scanner_path,
+        "scan_dpi": args.scan_dpi,
+        "scan_color_mode": args.scan_color_mode,
+        "scan_sides": args.scan_sides,
+        "scan_adjustments": args.scan_adjustments,
+        "physical_scan_filenames_sha256": scan_digests,
+        "physical_source_page_count": physical_source_page_count,
+        "retained_source_scan_ids": sorted(retained_source_ids),
+        "workflow_route_ids": workflow_route_ids,
+        "workflow_artifact_ids": workflow_artifact_ids,
+        "workflow_artifact_page_ids": workflow_page_ids,
+        "workflow_publications": publication_summaries,
+        "workflow_owner_classifications": {
+            "seminar": "OWNER CLASSIFICATION REQUIRED",
+            "project": "OWNER CLASSIFICATION REQUIRED",
+            "peer_review": "OWNER CLASSIFICATION REQUIRED",
+        },
+        "overall_owner_classification": "OWNER CLASSIFICATION REQUIRED",
+    }
+    _write_json(run_root / EVIDENCE_FILE, evidence_summary)
+
+    comment_lines = [
+        "Issue #70 completion record",
+        "",
+        f"final commit: {outer['final_commit']}",
+        f"Concord wheel: {outer['concord_wheel_filename']}",
+        f"Concord wheel byte length: {outer['concord_wheel_byte_length']}",
+        f"Concord wheel SHA-256: {outer['concord_wheel_sha256']}",
+        f"Core wheel: {outer['core_wheel_filename']}",
+        f"Core wheel SHA-256: {outer['core_wheel_sha256']}",
+        f"Python/platform: {sys.version.split()[0]} / {platform.platform()}",
+        "authoritative installed starter-workflow qualification: OWNER RECORD REQUIRED",
+        "same wheel bytes used for installed + physical: OWNER CONFIRMATION REQUIRED",
+        (
+            f"physical tester/date: {args.tester} / "
+            f"{evidence_summary['date_local_time']}"
+        ),
+        (
+            f"printer/settings: {args.printer}; {args.printer_path}; "
+            f"{args.paper_size}; {args.print_scaling}; {args.print_sides}; "
+            f"{args.print_color_mode}"
+        ),
+        (
+            f"scanner/settings: {args.scanner}; {args.scanner_path}; "
+            f"{args.scan_dpi} DPI; {args.scan_color_mode}; {args.scan_sides}; "
+            f"{args.scan_adjustments}"
+        ),
+        "physical visual inspection: OWNER CLASSIFICATION REQUIRED",
+        "physical seminar: OWNER CLASSIFICATION REQUIRED",
+        "physical group project: OWNER CLASSIFICATION REQUIRED",
+        "physical peer review: OWNER CLASSIFICATION REQUIRED",
+        (
+            "retained source ids: " + ",".join(sorted(retained_source_ids))
+        ),
+        (
+            "seminar route/artifact summary: routes="
+            + ",".join(workflow_route_ids["seminar"])
+            + "; artifacts="
+            + ",".join(workflow_artifact_ids["seminar"])
+        ),
+        (
+            "project route/artifact summary: routes="
+            + ",".join(workflow_route_ids["project"])
+            + "; artifacts="
+            + ",".join(workflow_artifact_ids["project"])
+        ),
+        (
+            "peer-review route/artifact summary: routes="
+            + ",".join(workflow_route_ids["peer_review"])
+            + "; artifacts="
+            + ",".join(workflow_artifact_ids["peer_review"])
+        ),
+        (
+            "publication ids: seminar="
+            + str(publication_summaries["seminar"]["publication_id"])
+            + "; project="
+            + str(publication_summaries["project"]["publication_id"])
+            + "; peer_review="
+            + str(publication_summaries["peer_review"]["publication_id"])
+        ),
+        "physical acceptance: OWNER CLASSIFICATION REQUIRED",
+        "READY FOR #71: NO",
+    ]
+    (run_root / COMMENT_FILE).write_text(
+        "\n".join(comment_lines) + "\n",
+        encoding="utf-8",
+    )
+    state["status"] = "technical_resume_completed"
+    state["evidence_relative_path"] = EVIDENCE_FILE
+    state["comment_relative_path"] = COMMENT_FILE
+    _write_json(run_root / STATE_FILE, state)
+    print("COMPLETED issue #70 technical physical return path")
+    print(f"evidence={run_root / EVIDENCE_FILE}")
+    print(f"comment_template={run_root / COMMENT_FILE}")
+    print("owner_classification=REQUIRED_FOR_ALL_THREE_WORKFLOWS")
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Prepare/resume owner-only Concord issue #70 physical acceptance."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("concord_wheel", type=Path)
+    prepare.add_argument("core_wheel", type=Path)
+    prepare.add_argument("run_root", type=Path)
+
+    resume = subparsers.add_parser("resume")
+    resume.add_argument("run_root", type=Path)
+    resume.add_argument("--scan", action="append", required=True)
+    resume.add_argument("--physical-mark-confirmed", action="store_true")
+    resume.add_argument("--visual-inspection-confirmed", action="store_true")
+    resume.add_argument("--tester", required=True)
+    resume.add_argument("--printer", required=True)
+    resume.add_argument("--printer-path", default="unknown")
+    resume.add_argument("--paper-size", required=True)
+    resume.add_argument("--print-scaling", required=True)
+    resume.add_argument(
+        "--print-sides", choices=("simplex", "duplex"), required=True
+    )
+    resume.add_argument("--print-color-mode", required=True)
+    resume.add_argument("--scanner", required=True)
+    resume.add_argument("--scanner-path", default="unknown")
+    resume.add_argument("--scan-dpi", type=int, required=True)
+    resume.add_argument("--scan-color-mode", required=True)
+    resume.add_argument(
+        "--scan-sides", choices=("simplex", "duplex"), required=True
+    )
+    resume.add_argument("--scan-adjustments", default="none")
+
+    internal_prepare = subparsers.add_parser("_installed-prepare")
+    internal_prepare.add_argument("run_root", type=Path)
+
+    internal_resume = subparsers.add_parser("_installed-resume")
+    internal_resume.add_argument("run_root", type=Path)
+    internal_resume.add_argument("--scan", action="append", required=True)
+    internal_resume.add_argument("--physical-mark-confirmed", action="store_true")
+    internal_resume.add_argument("--visual-inspection-confirmed", action="store_true")
+    internal_resume.add_argument("--tester", required=True)
+    internal_resume.add_argument("--printer", required=True)
+    internal_resume.add_argument("--printer-path", required=True)
+    internal_resume.add_argument("--paper-size", required=True)
+    internal_resume.add_argument("--print-scaling", required=True)
+    internal_resume.add_argument(
+        "--print-sides", choices=("simplex", "duplex"), required=True
+    )
+    internal_resume.add_argument("--print-color-mode", required=True)
+    internal_resume.add_argument("--scanner", required=True)
+    internal_resume.add_argument("--scanner-path", required=True)
+    internal_resume.add_argument("--scan-dpi", type=int, required=True)
+    internal_resume.add_argument("--scan-color-mode", required=True)
+    internal_resume.add_argument(
+        "--scan-sides", choices=("simplex", "duplex"), required=True
+    )
+    internal_resume.add_argument("--scan-adjustments", required=True)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.command == "prepare":
+        return _prepare_public(args)
+    if args.command == "resume":
+        return _resume_public(args)
+    if args.command == "_installed-prepare":
+        return _installed_prepare(Path(args.run_root).resolve())
+    if args.command == "_installed-resume":
+        return _installed_resume(args)
+    raise RuntimeError(f"unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_test_feature_wheels.py
+++ b/scripts/smoke_test_feature_wheels.py
@@ -36,6 +36,11 @@ SCENARIOS: tuple[tuple[str, str, str], ...] = (
         "task_oriented_activity_menu_smoke.py",
         "scripts/smoke_test_task_oriented_activity_menu_wheel.py",
     ),
+    (
+        "starter workflows",
+        "starter_workflows_smoke.py",
+        "scripts/smoke_test_starter_workflows_wheel.py",
+    ),
 )
 
 

--- a/scripts/smoke_test_starter_workflows_wheel.py
+++ b/scripts/smoke_test_starter_workflows_wheel.py
@@ -1,0 +1,2053 @@
+"""Install Concord/Core wheels in isolation and smoke-test starter workflows."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import tempfile
+import textwrap
+import venv
+from pathlib import Path
+
+
+def _python(venv_root: Path) -> Path:
+    return (
+        venv_root / "Scripts" / "python.exe"
+        if os.name == "nt"
+        else venv_root / "bin" / "python"
+    )
+
+
+def _run(command: list[str], cwd: Path) -> None:
+    subprocess.run(
+        command,
+        cwd=cwd,
+        check=True,
+        env={**os.environ, "PYTHONDONTWRITEBYTECODE": "1"},
+    )
+
+
+def _smoke_code() -> str:
+    """Return the installed-only representative starter acceptance program."""
+    return textwrap.dedent(
+        r'''
+        from __future__ import annotations
+
+        import os
+        import tempfile
+        from datetime import datetime, timezone
+        from importlib import metadata
+        from pathlib import Path
+        from unittest.mock import patch
+
+        import concord
+        import pds_core
+        from pds_core.class_metadata import (
+            create_class_metadata,
+            write_class_metadata_for_class,
+        )
+        from pds_core.classes import write_class_roster
+        from pds_core.grouping_signal_storage import (
+            calculate_grouping_signal_digest,
+            write_grouping_signal,
+        )
+        from pds_core.grouping_signals import (
+            GroupingSignalDimension,
+            GroupingSignalSet,
+            GroupingSignalSource,
+            GroupingSignalStudentBand,
+        )
+        from pds_core.pds2 import parse_pds2_payload
+        from pds_core.rosters import create_roster
+        from pds_core.routing_models import ModuleWorkRef
+        from pds_core.workspace import ensure_workspace_root
+
+        from concord.academic_result_manifest_generation import (
+            GenerateAcademicResultManifestRequest,
+            generate_academic_result_manifest,
+        )
+        from concord.academic_result_publication import (
+            publish_concord_academic_results,
+        )
+        from concord.academic_result_reader import (
+            lookup_academic_result_score,
+            read_academic_result_manifest,
+        )
+        from concord.academic_work_registration import (
+            register_concord_academic_work,
+        )
+        from concord.menu_context import MenuSessionContext
+        from concord.menu_guided_activity import launch_guided_activity_menu
+        from concord.models import (
+            EffectiveContext,
+            EvidenceReference,
+            PlannedGroup,
+            PrivacyPolicy,
+            ScoreTargetReference,
+            ScoringScaleLevel,
+            SubjectReference,
+        )
+        from concord.routing.scan_intake import route_scan_sources
+        from concord.starter_templates import get_starter_template
+        from concord.storage import load_current_record_graph
+        from concord.workflows import (
+            AddArtifactReviewRequest,
+            AddScoreRequest,
+            ApplyGroupPlanRequest,
+            ApproveGroupPlanRequest,
+            AssembleArtifactRequest,
+            CreateActivityContextRequest,
+            CreateCriterionSetRequest,
+            CreateManualGroupPlanRequest,
+            CreateRandomGroupPlanRequest,
+            CreateScoringScaleRequest,
+            CreateSignalGroupPlanRequest,
+            CriterionSpec,
+            PrepareGroupPlanApplicationRequest,
+            PreparePacketInstantiationRequest,
+            PrepareStarterTemplateInstallRequest,
+            PreviewGroupPlanRequest,
+            RenderPacketGenerationRequest,
+            ScoreEvidenceLinkSpec,
+            SelectActivityCriterionSetsRequest,
+            WorkflowActor,
+            add_artifact_review,
+            add_score,
+            apply_group_plan,
+            approve_group_plan,
+            assemble_returned_artifact,
+            commit_packet_instantiation,
+            commit_starter_template_install,
+            create_activity_context,
+            create_criterion_set,
+            create_manual_group_plan,
+            create_random_group_plan,
+            create_scoring_scale,
+            create_signal_group_plan,
+            list_activities,
+            list_groups,
+            list_memberships,
+            list_sessions,
+            prepare_group_plan_application,
+            prepare_packet_instantiation,
+            prepare_starter_template_install,
+            preview_group_plan,
+            render_packet_generation,
+            select_activity_criterion_sets,
+            show_activity,
+        )
+        from concord.workflows.packet import (
+            PreparePacketFromTemplateRequest,
+            commit_packet_from_template,
+            prepare_packet_from_template,
+        )
+
+
+        def stage(name: str) -> None:
+            print(f"issue70 seminar: {name}: PASS", flush=True)
+
+
+        def project_stage(name: str) -> None:
+            print(f"issue70 project: {name}: PASS", flush=True)
+
+
+        def peer_stage(name: str) -> None:
+            print(f"issue70 peer review: {name}: PASS", flush=True)
+
+
+        def assert_private_absent(value: object, tokens: tuple[str, ...]) -> None:
+            rendered = (
+                value
+                if isinstance(value, bytes)
+                else repr(value).encode("utf-8")
+            )
+            for token in tokens:
+                assert token.encode("utf-8") not in rendered
+
+
+        def require_installed(module: object, distribution: str) -> None:
+            origin = Path(getattr(module, "__file__")).resolve()
+            lowered = str(origin).casefold()
+            if "site-packages" not in lowered:
+                raise AssertionError(
+                    f"{distribution} did not import from isolated "
+                    f"site-packages: {origin}"
+                )
+
+
+        assert metadata.version("pds-core") == "0.6.3"
+        assert metadata.version("pds-concord") == "0.3.0.dev0"
+        require_installed(pds_core, "pds-core")
+        require_installed(concord, "pds-concord")
+        requirements = tuple(metadata.requires("pds-concord") or ())
+        forbidden = ("meridian", "paper-data-suite")
+        assert not any(
+            name in requirement.casefold()
+            for requirement in requirements
+            for name in forbidden
+        )
+        stage("installed provenance")
+
+        with tempfile.TemporaryDirectory(prefix="concord-issue70-seminar-") as raw:
+            root = ensure_workspace_root(Path(raw) / "workspace")
+            os.environ["PDS_WORKSPACE_ROOT"] = str(root)
+            class_id = "class-issue70"
+            class_metadata = create_class_metadata(
+                class_id,
+                "2026-2027",
+                created_at=datetime(2026, 8, 30, tzinfo=timezone.utc),
+            )
+            write_class_metadata_for_class(root, class_metadata)
+            roster = create_roster(
+                class_id,
+                (
+                    {
+                        "student_id": "student-1",
+                        "last_name": "One",
+                        "first_name": "Alex",
+                        "period": "1",
+                    },
+                    {
+                        "student_id": "student-2",
+                        "last_name": "Two",
+                        "first_name": "Blake",
+                        "period": "1",
+                    },
+                    {
+                        "student_id": "student-3",
+                        "last_name": "Three",
+                        "first_name": "Casey",
+                        "period": "1",
+                    },
+                    {
+                        "student_id": "student-4",
+                        "last_name": "Four",
+                        "first_name": "Drew",
+                        "period": "1",
+                    },
+                ),
+            )
+            write_class_roster(root, roster)
+            actor = WorkflowActor(
+                actor_id="teacher-issue70",
+                display_label="Synthetic Teacher",
+                role_label="teacher",
+            )
+            state = MenuSessionContext(actor=actor)
+            guided_inputs = (
+                "1",  # start fresh
+                "1",  # exact synthetic Core class
+                "Issue 70 Seminar",
+                "1",  # discussion / seminar
+                "4",  # local classroom criteria
+                "",   # optional description
+                "",   # default first-session label
+                "CREATE",
+                "2",  # finish for now; later stages use public services
+            )
+            with patch("builtins.input", side_effect=guided_inputs):
+                launch_guided_activity_menu(state)
+
+            activities = list_activities(workspace_root=root, class_id=class_id)
+            assert len(activities) == 1
+            activity = activities[0]
+            assert activity.title == "Issue 70 Seminar"
+            assert activity.scoring_orientation == "local_criteria_only"
+            sessions = list_sessions(
+                class_id,
+                activity.activity_id,
+                workspace_root=root,
+            )
+            assert len(sessions) == 1
+            session_id = sessions[0].session_id
+            activity_id = activity.activity_id
+            work = ModuleWorkRef("concord", class_id, activity_id)
+            stage("guided Activity setup")
+
+            context = EffectiveContext(
+                activity_id=activity_id,
+                session_ids=(session_id,),
+            )
+            manual = create_manual_group_plan(
+                CreateManualGroupPlanRequest(
+                    class_id=class_id,
+                    activity_id=activity_id,
+                    group_plan_id="plan-seminar-issue70",
+                    expected_snapshot_revision=activity.snapshot_revision,
+                    actor=actor,
+                    proposed_groups=(
+                        PlannedGroup(
+                            planned_group_key="plan-a",
+                            label="Seminar Group A",
+                            student_ids=("student-1", "student-2"),
+                            effective_context=context,
+                        ),
+                        PlannedGroup(
+                            planned_group_key="plan-b",
+                            label="Seminar Group B",
+                            student_ids=("student-3", "student-4"),
+                            effective_context=context,
+                        ),
+                    ),
+                    target_group_count=2,
+                ),
+                workspace_root=root,
+            )
+            assert manual.status == "draft"
+            assert not list_groups(class_id, activity_id, workspace_root=root)
+            assert not list_memberships(class_id, activity_id, workspace_root=root)
+
+            previewed = preview_group_plan(
+                PreviewGroupPlanRequest(
+                    class_id=class_id,
+                    activity_id=activity_id,
+                    group_plan_id=manual.group_plan_id,
+                    expected_snapshot_revision=manual.commit.snapshot_revision,
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert previewed.plan.status == "previewed"
+            assert not list_groups(class_id, activity_id, workspace_root=root)
+
+            approved = approve_group_plan(
+                ApproveGroupPlanRequest(
+                    class_id=class_id,
+                    activity_id=activity_id,
+                    group_plan_id=manual.group_plan_id,
+                    expected_snapshot_revision=previewed.summary.snapshot_revision,
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert approved.status == "approved"
+            assert not list_groups(class_id, activity_id, workspace_root=root)
+
+            application_preview = prepare_group_plan_application(
+                PrepareGroupPlanApplicationRequest(
+                    class_id=class_id,
+                    activity_id=activity_id,
+                    group_plan_id=manual.group_plan_id,
+                    application_id="apply-seminar-issue70",
+                ),
+                workspace_root=root,
+            )
+            assert application_preview.group_count == 2
+            assert application_preview.membership_count == 4
+            assert application_preview.unresolved_count == 0
+            assert not list_groups(class_id, activity_id, workspace_root=root)
+
+            applied = apply_group_plan(
+                ApplyGroupPlanRequest(
+                    class_id=class_id,
+                    activity_id=activity_id,
+                    group_plan_id=manual.group_plan_id,
+                    application_id=application_preview.application_id,
+                    application_digest=application_preview.application_digest,
+                    expected_snapshot_revision=(
+                        application_preview.expected_snapshot_revision
+                    ),
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert applied.status == "applied"
+            assert applied.group_count == 2
+            assert applied.membership_count == 4
+            assert len(list_groups(class_id, activity_id, workspace_root=root)) == 2
+            assert (
+                len(
+                    list_memberships(
+                        class_id, activity_id, workspace_root=root
+                    )
+                )
+                == 4
+            )
+            group_ids = frozenset(applied.group_ids)
+            stage("GroupPlan approval and application")
+
+            starter = get_starter_template("socratic_seminar")
+            seminar_page_count = starter.page_count
+            assert seminar_page_count > 0
+            assert "participant" in starter.suggested_audience_kinds
+            assert starter.default_authorship_mode == "individual_author"
+            assert starter.default_subject_kind == "core_student"
+            starter_prepared = prepare_starter_template_install(
+                PrepareStarterTemplateInstallRequest(
+                    starter_key=starter.starter_key,
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            starter_result = commit_starter_template_install(
+                starter_prepared,
+                workspace_root=root,
+            )
+            assert starter_result.outcome == "installed"
+            assert starter_result.template_id == starter.template_id
+            assert starter_result.template_version_id == starter.template_version_id
+
+            packet_prepared = prepare_packet_from_template(
+                PreparePacketFromTemplateRequest(
+                    packet_definition_id="packet-seminar-issue70",
+                    packet_version_id="packet-seminar-issue70-v1",
+                    packet_component_id="component-seminar-issue70",
+                    name="Issue 70 Seminar Packet",
+                    purpose="Representative installed seminar acceptance.",
+                    template_id=starter.template_id,
+                    template_version_id=starter.template_version_id,
+                    audience_kind="participant",
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            packet_result = commit_packet_from_template(
+                packet_prepared,
+                workspace_root=root,
+            )
+            assert packet_result.status == "active"
+            stage("installed starter and Packet selection")
+
+            prepared_generation = prepare_packet_instantiation(
+                PreparePacketInstantiationRequest(
+                    class_id=class_id,
+                    activity_id=activity_id,
+                    session_id=session_id,
+                    packet_definition_id="packet-seminar-issue70",
+                    packet_version_id="packet-seminar-issue70-v1",
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert prepared_generation.ready_for_commit
+            assert prepared_generation.packet_instance_count == 4
+            assert prepared_generation.artifact_count == 4
+            assert prepared_generation.page_count == 4 * seminar_page_count
+            assert prepared_generation.route_count == 4 * seminar_page_count
+            planned_students = {
+                target.target_context.participant_reference.participant_id
+                for target in prepared_generation.target_plans
+                if target.target_context.participant_reference is not None
+            }
+            assert planned_students == {
+                "student-1",
+                "student-2",
+                "student-3",
+                "student-4",
+            }
+
+            committed_generation = commit_packet_instantiation(
+                prepared_generation,
+                workspace_root=root,
+                generation_id="generation-seminar-issue70",
+            )
+            assert len(committed_generation.packet_instance_ids) == 4
+            assert len(committed_generation.artifact_instance_ids) == 4
+            assert len(committed_generation.artifact_page_ids) == 4 * seminar_page_count
+            assert len(committed_generation.route_ids) == 4 * seminar_page_count
+            assert committed_generation.routes_expected == 4 * seminar_page_count
+            assert committed_generation.routes_verified == 4 * seminar_page_count
+
+            graph = load_current_record_graph(root, work).graph
+            packet_instances = tuple(
+                item
+                for item in graph.packet_instances
+                if item.generation_id == "generation-seminar-issue70"
+            )
+            assert len(packet_instances) == 4
+            artifact_by_student: dict[str, str] = {}
+            group_by_student: dict[str, str] = {}
+            for packet_instance in packet_instances:
+                target = packet_instance.target_context
+                assert target.audience_kind == "participant"
+                assert target.participant_reference is not None
+                assert target.participant_reference.participant_kind == "core_student"
+                assert target.participant_reference.owning_system == "core"
+                assert target.group_id in group_ids
+                assert len(packet_instance.artifact_bindings) == 1
+                student_id = target.participant_reference.participant_id
+                artifact_by_student[student_id] = (
+                    packet_instance.artifact_bindings[0].artifact_instance_id
+                )
+                assert target.group_id is not None
+                group_by_student[student_id] = target.group_id
+            assert set(artifact_by_student) == planned_students
+            assert len(set(artifact_by_student.values())) == 4
+            assert group_by_student["student-1"] == group_by_student["student-2"]
+            assert group_by_student["student-3"] == group_by_student["student-4"]
+            assert group_by_student["student-1"] != group_by_student["student-3"]
+            stage("participant Packet instantiation")
+
+            rendered = render_packet_generation(
+                RenderPacketGenerationRequest(
+                    class_id=class_id,
+                    activity_id=activity_id,
+                    generation_id="generation-seminar-issue70",
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert len(rendered.packets) == 4
+            assert rendered.page_count == 4 * seminar_page_count
+            assert rendered.route_count == 4 * seminar_page_count
+            route_ids = set(committed_generation.route_ids)
+            decoded_route_ids: set[str] = set()
+            pdf_paths: list[Path] = []
+            for packet in rendered.packets:
+                assert packet.output_path.is_file()
+                assert packet.page_count == seminar_page_count
+                assert packet.route_count == seminar_page_count
+                assert len(packet.payloads) == seminar_page_count
+                pdf_paths.append(packet.output_path)
+                for payload in packet.payloads:
+                    locator = parse_pds2_payload(payload)
+                    assert locator.module_id == "concord"
+                    assert locator.class_id == class_id
+                    assert locator.work_id == activity_id
+                    assert locator.route_id in route_ids
+                    decoded_route_ids.add(locator.route_id)
+            assert decoded_route_ids == route_ids
+            stage("real PDF and PDS2 rendering")
+
+            returned = route_scan_sources(pdf_paths, workspace_root=root)
+            assert returned.dispatched_count == 4 * seminar_page_count
+            assert returned.failure_count == 0
+            observed_routes: set[str] = set()
+            observed_pages: set[str] = set()
+            retained_scan_ids: set[str] = set()
+            for source in returned.sources:
+                assert source.source_error is None
+                assert source.retained_source is not None
+                retained_scan_ids.add(source.retained_source.source_scan_id)
+                assert len(source.pages) == seminar_page_count
+                for page in source.pages:
+                    assert page.status == "dispatched"
+                    assert page.locator is not None
+                    assert page.locator.module_id == "concord"
+                    assert page.locator.class_id == class_id
+                    assert page.locator.work_id == activity_id
+                    assert page.locator.route_id in route_ids
+                    observed_routes.add(page.locator.route_id)
+                    dispatch = page.module_result
+                    assert dispatch is not None
+                    assert dispatch.route_id == page.locator.route_id
+                    assert dispatch.artifact_instance_id in artifact_by_student.values()
+                    assert (
+                        dispatch.artifact_page_id
+                        in committed_generation.artifact_page_ids
+                    )
+                    observed_pages.add(dispatch.artifact_page_id)
+            assert observed_routes == route_ids
+            assert observed_pages == set(committed_generation.artifact_page_ids)
+            assert len(retained_scan_ids) == 4
+
+            graph = load_current_record_graph(root, work).graph
+            assert len(graph.scan_references) == 4 * seminar_page_count
+            returned_pages = {
+                item.artifact_page_id
+                for item in graph.artifact_pages
+                if item.artifact_page_id in committed_generation.artifact_page_ids
+                and item.page_status == "returned"
+            }
+            assert returned_pages == set(committed_generation.artifact_page_ids)
+            for artifact_id in artifact_by_student.values():
+                artifact = next(
+                    item
+                    for item in graph.artifact_instances
+                    if item.artifact_instance_id == artifact_id
+                )
+                assert artifact.artifact_status == "returned"
+            stage("production rasterization, Core retention, and dispatch")
+
+            for student_id, artifact_id in sorted(artifact_by_student.items()):
+                assembled = assemble_returned_artifact(
+                    AssembleArtifactRequest(
+                        class_id=class_id,
+                        activity_id=activity_id,
+                        artifact_instance_id=artifact_id,
+                        expected_snapshot_revision=show_activity(
+                            class_id,
+                            activity_id,
+                            workspace_root=root,
+                        ).summary.snapshot_revision,
+                        actor=actor,
+                    ),
+                    workspace_root=root,
+                )
+                assert assembled.page_count == seminar_page_count
+                assert assembled.output_path.is_file()
+                assert assembled.manifest_path.is_file()
+                assert assembled.artifact_instance_id == artifact_id
+                assert student_id in artifact_by_student
+            stage("Artifact assembly")
+
+            privacy = PrivacyPolicy(classification="teacher_and_subjects")
+            for index, (student_id, artifact_id) in enumerate(
+                sorted(artifact_by_student.items()),
+                start=1,
+            ):
+                review = add_artifact_review(
+                    AddArtifactReviewRequest(
+                        class_id=class_id,
+                        activity_id=activity_id,
+                        artifact_instance_id=artifact_id,
+                        artifact_review_id=f"review-seminar-{index}",
+                        readability_judgment="readable",
+                        page_completeness_judgment="complete",
+                        filing_judgment="correct",
+                        author_judgment="confirmed",
+                        subject_judgment="confirmed",
+                        privacy_judgment="teacher_and_subjects",
+                        relevance_judgment="relevant",
+                        moderation_requirement="not_required",
+                        scoring_readiness="ready",
+                        review_outcome="ready",
+                        privacy_policy=privacy,
+                        expected_snapshot_revision=show_activity(
+                            class_id,
+                            activity_id,
+                            workspace_root=root,
+                        ).summary.snapshot_revision,
+                        actor=actor,
+                    ),
+                    workspace_root=root,
+                )
+                assert review.artifact_review_id == f"review-seminar-{index}"
+                assert student_id in planned_students
+            stage("explicit Artifact review")
+
+            scale = create_scoring_scale(
+                CreateScoringScaleRequest(
+                    class_id=class_id,
+                    activity_id=activity_id,
+                    scoring_scale_id="scale-seminar-issue70",
+                    lineage_id="scale-seminar-issue70-lineage",
+                    name="Seminar Participation",
+                    revision=1,
+                    scale_type="categorical",
+                    levels=(
+                        ScoringScaleLevel(
+                            value="developing",
+                            label="Developing",
+                            meaning="Synthetic developing level.",
+                        ),
+                        ScoringScaleLevel(
+                            value="meets",
+                            label="Meets",
+                            meaning="Synthetic meets level.",
+                        ),
+                    ),
+                    status="active",
+                    expected_snapshot_revision=show_activity(
+                        class_id,
+                        activity_id,
+                        workspace_root=root,
+                    ).summary.snapshot_revision,
+                    actor=actor,
+                    intended_use="Synthetic issue #70 acceptance only.",
+                ),
+                workspace_root=root,
+            )
+            criterion_set = create_criterion_set(
+                CreateCriterionSetRequest(
+                    class_id=class_id,
+                    activity_id=activity_id,
+                    criterion_set_id="criteria-seminar-issue70",
+                    lineage_id="criteria-seminar-issue70-lineage",
+                    name="Seminar Criteria",
+                    purpose="Synthetic issue #70 acceptance only.",
+                    revision=1,
+                    scope="activity_specific",
+                    criterion_set_kind="local",
+                    criteria=(
+                        CriterionSpec(
+                            criterion_id="criterion-seminar-participation",
+                            key="seminar-participation",
+                            label="Seminar participation",
+                            definition="Synthetic acceptance criterion.",
+                            criterion_kind="local",
+                            supported_target_kinds=("core_student",),
+                            default_scoring_scale_id="scale-seminar-issue70",
+                        ),
+                    ),
+                    status="active",
+                    expected_snapshot_revision=scale.commit.snapshot_revision,
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            selected = select_activity_criterion_sets(
+                SelectActivityCriterionSetsRequest(
+                    class_id=class_id,
+                    activity_id=activity_id,
+                    criterion_set_ids=("criteria-seminar-issue70",),
+                    expected_snapshot_revision=criterion_set.commit.snapshot_revision,
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert selected.criterion_set_ids == ("criteria-seminar-issue70",)
+
+            score_ids: list[str] = []
+            for index, (student_id, artifact_id) in enumerate(
+                sorted(artifact_by_student.items()),
+                start=1,
+            ):
+                subject = SubjectReference(
+                    subject_kind="core_student",
+                    subject_id=student_id,
+                    owning_system="core",
+                )
+                evidence = EvidenceReference(
+                    evidence_kind="artifact_instance",
+                    owning_system="concord",
+                    record_id=artifact_id,
+                    subject_context=(subject,),
+                    moderation_requirement="not_required",
+                )
+                score_id = f"score-seminar-{index}"
+                score = add_score(
+                    AddScoreRequest(
+                        class_id=class_id,
+                        activity_id=activity_id,
+                        score_record_id=score_id,
+                        target_reference=ScoreTargetReference(
+                            target_kind="core_student",
+                            target_id=student_id,
+                            owning_system="core",
+                        ),
+                        criterion_id="criterion-seminar-participation",
+                        scoring_scale_id="scale-seminar-issue70",
+                        disposition="scored",
+                        basis="linked_evidence",
+                        privacy_policy=privacy,
+                        expected_snapshot_revision=show_activity(
+                            class_id,
+                            activity_id,
+                            workspace_root=root,
+                        ).summary.snapshot_revision,
+                        actor=actor,
+                        session_id=session_id,
+                        value="meets",
+                        evidence_links=(
+                            ScoreEvidenceLinkSpec(
+                                score_evidence_link_id=f"link-seminar-{index}",
+                                evidence_reference=evidence,
+                                relevance_description=(
+                                    "Synthetic returned seminar artifact."
+                                ),
+                                subject_context=(subject,),
+                            ),
+                        ),
+                    ),
+                    workspace_root=root,
+                )
+                assert score.score_record_id == score_id
+                score_ids.append(score_id)
+            stage("explicit Score recording")
+
+            registration = register_concord_academic_work(
+                root,
+                class_id,
+                activity_id,
+                academic_intent="formative",
+                lifecycle="active",
+            )
+            assert registration.registration.registration_revision == 1
+            manifest_request = GenerateAcademicResultManifestRequest(
+                class_id=class_id,
+                activity_id=activity_id,
+                expected_snapshot_revision=show_activity(
+                    class_id,
+                    activity_id,
+                    workspace_root=root,
+                ).summary.snapshot_revision,
+                actor=actor,
+                revision_reason="initial",
+            )
+            generated = generate_academic_result_manifest(
+                manifest_request,
+                workspace_root=root,
+            )
+            assert generated.disposition == "created"
+            assert generated.revision == 1
+            assert len(generated.manifest.scores) == 4
+            public_before_publish = read_academic_result_manifest(generated.content)
+            for score_id in score_ids:
+                public_score = lookup_academic_result_score(
+                    public_before_publish,
+                    score_id,
+                )
+                assert public_score.score_record_id == score_id
+                assert public_score.disposition == "scored"
+                assert public_score.value == "meets"
+
+            publication = publish_concord_academic_results(
+                manifest_request,
+                workspace_root=root,
+            )
+            assert publication.disposition == "created"
+            assert publication.compatibility.compatible
+            assert publication.publication.work == work
+            assert publication.publication.record_set_revision == generated.revision
+            assert publication.publication.manifest_digest == generated.sha256
+            public_after_publish = read_academic_result_manifest(
+                publication.manifest_generation.content
+            )
+            assert public_after_publish == public_before_publish
+            for score_id in score_ids:
+                assert lookup_academic_result_score(
+                    public_after_publish,
+                    score_id,
+                ).score_record_id == score_id
+            stage("Academic Work, manifest, publication, and public readback")
+
+            final_graph = load_current_record_graph(root, work).graph
+            assert len(final_graph.groups) == 2
+            assert len(final_graph.memberships) == 4
+            assert len(final_graph.packet_instances) == 4
+            assert len(final_graph.artifact_instances) == 4
+            assert len(final_graph.artifact_pages) == 4 * seminar_page_count
+            assert len(final_graph.scan_references) == 4 * seminar_page_count
+            assert len(final_graph.artifact_reviews) == 4
+            assert len(final_graph.score_records) == 4
+            assert not any(
+                module_name.startswith("meridian")
+                for module_name in tuple(__import__("sys").modules)
+            )
+            stage("seminar workflow complete")
+
+            # Representative group-project workflow. The signal metadata is deliberately
+            # sentinel-like so accidental downstream leakage is mechanically visible.
+            project_activity_id = "activity-project-issue70"
+            project_session_id = "session-project-issue70"
+            project_created = create_activity_context(
+                CreateActivityContextRequest(
+                    class_id=class_id,
+                    activity_id=project_activity_id,
+                    title="Issue 70 Group Project",
+                    activity_type="project",
+                    scoring_orientation="local_criteria_only",
+                    session_id=project_session_id,
+                    actor=actor,
+                    activity_status="active",
+                    session_status="active",
+                    session_label="Project Session",
+                ),
+                workspace_root=root,
+            )
+            project_work = ModuleWorkRef("concord", class_id, project_activity_id)
+            project_context = EffectiveContext(
+                activity_id=project_activity_id,
+                session_ids=(project_session_id,),
+            )
+            private_signal_set_id = "issue70-private-signal-set"
+            private_dimension_id = "issue70-private-proficiency-band"
+            private_source_module = "issue70_private_producer"
+            private_snapshot_id = "issue70-private-snapshot"
+            private_snapshot_digest = "7" * 64
+            signal = GroupingSignalSet(
+                schema_version="1",
+                record_type="grouping_signal_set",
+                signal_set_id=private_signal_set_id,
+                class_id=class_id,
+                created_at=datetime(2026, 8, 30, 12, 0, tzinfo=timezone.utc),
+                source=GroupingSignalSource(
+                    kind="module_generated",
+                    module_id=private_source_module,
+                    snapshot_id=private_snapshot_id,
+                    snapshot_digest_algorithm="sha256",
+                    snapshot_digest=private_snapshot_digest,
+                ),
+                dimensions=(
+                    GroupingSignalDimension(
+                        dimension_id=private_dimension_id,
+                        band_count=4,
+                    ),
+                ),
+                student_bands=(
+                    GroupingSignalStudentBand(
+                        student_id="student-1",
+                        dimension_id=private_dimension_id,
+                        band=1,
+                    ),
+                    GroupingSignalStudentBand(
+                        student_id="student-2",
+                        dimension_id=private_dimension_id,
+                        band=1,
+                    ),
+                    GroupingSignalStudentBand(
+                        student_id="student-3",
+                        dimension_id=private_dimension_id,
+                        band=4,
+                    ),
+                    GroupingSignalStudentBand(
+                        student_id="student-4",
+                        dimension_id=private_dimension_id,
+                        band=4,
+                    ),
+                ),
+            )
+            write_grouping_signal(root, signal)
+            private_canonical_digest = calculate_grouping_signal_digest(signal)
+            private_tokens = (
+                private_signal_set_id,
+                private_dimension_id,
+                private_source_module,
+                private_snapshot_id,
+                private_snapshot_digest,
+                private_canonical_digest,
+            )
+            signal_plan = create_signal_group_plan(
+                CreateSignalGroupPlanRequest(
+                    class_id=class_id,
+                    activity_id=project_activity_id,
+                    group_plan_id="plan-project-issue70",
+                    strategy="similar_signal",
+                    signal_set_id=private_signal_set_id,
+                    dimension_id=private_dimension_id,
+                    expected_snapshot_revision=project_created.commit.snapshot_revision,
+                    actor=actor,
+                    target_group_count=2,
+                    expected_roster_student_ids=(
+                        "student-1",
+                        "student-2",
+                        "student-3",
+                        "student-4",
+                    ),
+                    expected_signal_set_digest=private_canonical_digest,
+                ),
+                workspace_root=root,
+            )
+            assert signal_plan.strategy == "similar_signal"
+            assert signal_plan.group_count == 2
+            assert signal_plan.assigned_student_count == 4
+            assert signal_plan.unresolved_student_count == 0
+            assert signal_plan.signal_set_id == private_signal_set_id
+            assert signal_plan.signal_set_digest == private_canonical_digest
+            assert signal_plan.dimension_id == private_dimension_id
+            assert not list_groups(class_id, project_activity_id, workspace_root=root)
+            assert not list_memberships(
+                class_id,
+                project_activity_id,
+                workspace_root=root,
+            )
+            project_previewed = preview_group_plan(
+                PreviewGroupPlanRequest(
+                    class_id=class_id,
+                    activity_id=project_activity_id,
+                    group_plan_id=signal_plan.mutation.group_plan_id,
+                    expected_snapshot_revision=(
+                        signal_plan.mutation.commit.snapshot_revision
+                    ),
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert project_previewed.plan.status == "previewed"
+            assert project_previewed.plan.source_signal_set_id == private_signal_set_id
+            assert (
+                project_previewed.plan.source_signal_set_digest
+                == private_canonical_digest
+            )
+            assert (
+                project_previewed.plan.source_signal_dimension_id
+                == private_dimension_id
+            )
+            project_approved = approve_group_plan(
+                ApproveGroupPlanRequest(
+                    class_id=class_id,
+                    activity_id=project_activity_id,
+                    group_plan_id=signal_plan.mutation.group_plan_id,
+                    expected_snapshot_revision=(
+                        project_previewed.summary.snapshot_revision
+                    ),
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert project_approved.status == "approved"
+            project_application = prepare_group_plan_application(
+                PrepareGroupPlanApplicationRequest(
+                    class_id=class_id,
+                    activity_id=project_activity_id,
+                    group_plan_id=signal_plan.mutation.group_plan_id,
+                    application_id="apply-project-issue70",
+                    fallback_effective_context=project_context,
+                ),
+                workspace_root=root,
+            )
+            assert project_application.group_count == 2
+            assert project_application.membership_count == 4
+            assert project_application.unresolved_count == 0
+            project_applied = apply_group_plan(
+                ApplyGroupPlanRequest(
+                    class_id=class_id,
+                    activity_id=project_activity_id,
+                    group_plan_id=signal_plan.mutation.group_plan_id,
+                    application_id=project_application.application_id,
+                    application_digest=project_application.application_digest,
+                    expected_snapshot_revision=(
+                        project_application.expected_snapshot_revision
+                    ),
+                    actor=actor,
+                    fallback_effective_context=project_context,
+                ),
+                workspace_root=root,
+            )
+            assert project_applied.status == "applied"
+            assert project_applied.group_count == 2
+            assert project_applied.membership_count == 4
+            project_group_ids = frozenset(project_applied.group_ids)
+            project_graph = load_current_record_graph(root, project_work).graph
+            applied_plan = next(
+                plan
+                for plan in project_graph.group_plans
+                if plan.group_plan_id == signal_plan.mutation.group_plan_id
+            )
+            assert applied_plan.source_signal_set_id == private_signal_set_id
+            assert applied_plan.source_signal_set_digest == private_canonical_digest
+            assert applied_plan.source_signal_dimension_id == private_dimension_id
+            for record in (*project_graph.groups, *project_graph.memberships):
+                assert_private_absent(record, private_tokens)
+            project_stage("signal-backed GroupPlan approval and privacy boundary")
+
+            project_starter = get_starter_template("project_plan")
+            project_page_count = project_starter.page_count
+            assert project_page_count > 0
+            assert project_starter.suggested_audience_kinds == ("group",)
+            assert project_starter.default_authorship_mode == "collective_group_author"
+            assert project_starter.default_subject_kind == "concord_group"
+            project_starter_result = commit_starter_template_install(
+                prepare_starter_template_install(
+                    PrepareStarterTemplateInstallRequest(
+                        starter_key=project_starter.starter_key,
+                        actor=actor,
+                    ),
+                    workspace_root=root,
+                ),
+                workspace_root=root,
+            )
+            assert project_starter_result.outcome == "installed"
+            project_packet = commit_packet_from_template(
+                prepare_packet_from_template(
+                    PreparePacketFromTemplateRequest(
+                        packet_definition_id="packet-project-issue70",
+                        packet_version_id="packet-project-issue70-v1",
+                        packet_component_id="component-project-issue70",
+                        name="Issue 70 Project Packet",
+                        purpose="Representative installed group-project acceptance.",
+                        template_id=project_starter.template_id,
+                        template_version_id=project_starter.template_version_id,
+                        audience_kind="group",
+                        actor=actor,
+                    ),
+                    workspace_root=root,
+                ),
+                workspace_root=root,
+            )
+            assert project_packet.status == "active"
+            project_prepared_generation = prepare_packet_instantiation(
+                PreparePacketInstantiationRequest(
+                    class_id=class_id,
+                    activity_id=project_activity_id,
+                    session_id=project_session_id,
+                    packet_definition_id="packet-project-issue70",
+                    packet_version_id="packet-project-issue70-v1",
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert project_prepared_generation.ready_for_commit
+            assert project_prepared_generation.packet_instance_count == 2
+            assert project_prepared_generation.artifact_count == 2
+            assert project_prepared_generation.page_count == 2 * project_page_count
+            assert project_prepared_generation.route_count == 2 * project_page_count
+            assert_private_absent(project_prepared_generation, private_tokens)
+            project_committed_generation = commit_packet_instantiation(
+                project_prepared_generation,
+                workspace_root=root,
+                generation_id="generation-project-issue70",
+            )
+            assert len(project_committed_generation.packet_instance_ids) == 2
+            assert len(project_committed_generation.artifact_instance_ids) == 2
+            assert len(project_committed_generation.artifact_page_ids) == (
+                2 * project_page_count
+            )
+            assert len(project_committed_generation.route_ids) == 2 * project_page_count
+
+            project_graph = load_current_record_graph(root, project_work).graph
+            project_packet_instances = tuple(
+                item
+                for item in project_graph.packet_instances
+                if item.generation_id == "generation-project-issue70"
+            )
+            assert len(project_packet_instances) == 2
+            artifact_by_group: dict[str, str] = {}
+            for packet_instance in project_packet_instances:
+                target = packet_instance.target_context
+                assert target.audience_kind == "group"
+                assert target.group_id in project_group_ids
+                assert target.participant_reference is None
+                assert len(packet_instance.artifact_bindings) == 1
+                assert target.group_id is not None
+                artifact_by_group[target.group_id] = (
+                    packet_instance.artifact_bindings[0].artifact_instance_id
+                )
+                assert_private_absent(packet_instance, private_tokens)
+            assert set(artifact_by_group) == project_group_ids
+            assert len(set(artifact_by_group.values())) == 2
+            project_stage("group Packet instantiation")
+
+            project_rendered = render_packet_generation(
+                RenderPacketGenerationRequest(
+                    class_id=class_id,
+                    activity_id=project_activity_id,
+                    generation_id="generation-project-issue70",
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert len(project_rendered.packets) == 2
+            assert project_rendered.page_count == 2 * project_page_count
+            assert project_rendered.route_count == 2 * project_page_count
+            project_route_ids = set(project_committed_generation.route_ids)
+            project_decoded_route_ids: set[str] = set()
+            project_pdf_paths: list[Path] = []
+            for packet in project_rendered.packets:
+                assert packet.output_path.is_file()
+                assert packet.page_count == project_page_count
+                assert packet.route_count == project_page_count
+                assert len(packet.payloads) == project_page_count
+                project_pdf_paths.append(packet.output_path)
+                assert_private_absent(packet.output_path.read_bytes(), private_tokens)
+                for payload in packet.payloads:
+                    assert_private_absent(payload, private_tokens)
+                    locator = parse_pds2_payload(payload)
+                    assert locator.module_id == "concord"
+                    assert locator.class_id == class_id
+                    assert locator.work_id == project_activity_id
+                    assert locator.route_id in project_route_ids
+                    project_decoded_route_ids.add(locator.route_id)
+            assert project_decoded_route_ids == project_route_ids
+            project_stage("real group PDF and PDS2 rendering without signal leakage")
+
+            project_returned = route_scan_sources(
+                project_pdf_paths,
+                workspace_root=root,
+            )
+            assert project_returned.dispatched_count == 2 * project_page_count
+            assert project_returned.failure_count == 0
+            assert_private_absent(project_returned, private_tokens)
+            project_observed_routes: set[str] = set()
+            project_observed_pages: set[str] = set()
+            for source in project_returned.sources:
+                assert source.source_error is None
+                assert source.retained_source is not None
+                assert len(source.pages) == project_page_count
+                for page in source.pages:
+                    assert page.status == "dispatched"
+                    assert page.locator is not None
+                    assert page.locator.work_id == project_activity_id
+                    assert page.locator.route_id in project_route_ids
+                    project_observed_routes.add(page.locator.route_id)
+                    dispatch = page.module_result
+                    assert dispatch is not None
+                    assert dispatch.route_id == page.locator.route_id
+                    assert dispatch.artifact_instance_id in artifact_by_group.values()
+                    assert (
+                        dispatch.artifact_page_id
+                        in project_committed_generation.artifact_page_ids
+                    )
+                    project_observed_pages.add(dispatch.artifact_page_id)
+            assert project_observed_routes == project_route_ids
+            assert project_observed_pages == set(
+                project_committed_generation.artifact_page_ids
+            )
+            project_stage("production return, retention, and dispatch")
+
+            for group_id, artifact_id in sorted(artifact_by_group.items()):
+                assembled = assemble_returned_artifact(
+                    AssembleArtifactRequest(
+                        class_id=class_id,
+                        activity_id=project_activity_id,
+                        artifact_instance_id=artifact_id,
+                        expected_snapshot_revision=show_activity(
+                            class_id,
+                            project_activity_id,
+                            workspace_root=root,
+                        ).summary.snapshot_revision,
+                        actor=actor,
+                    ),
+                    workspace_root=root,
+                )
+                assert assembled.page_count == project_page_count
+                assert assembled.output_path.is_file()
+                assert assembled.manifest_path.is_file()
+                assert_private_absent(
+                    assembled.output_path.read_bytes(),
+                    private_tokens,
+                )
+                assert_private_absent(
+                    assembled.manifest_path.read_bytes(),
+                    private_tokens,
+                )
+                assert group_id in project_group_ids
+            project_stage("Artifact assembly without signal leakage")
+
+            project_privacy = PrivacyPolicy(classification="group_and_teacher")
+            for index, (group_id, artifact_id) in enumerate(
+                sorted(artifact_by_group.items()),
+                start=1,
+            ):
+                review = add_artifact_review(
+                    AddArtifactReviewRequest(
+                        class_id=class_id,
+                        activity_id=project_activity_id,
+                        artifact_instance_id=artifact_id,
+                        artifact_review_id=f"review-project-{index}",
+                        readability_judgment="readable",
+                        page_completeness_judgment="complete",
+                        filing_judgment="correct",
+                        author_judgment="confirmed",
+                        subject_judgment="confirmed",
+                        privacy_judgment="group_and_teacher",
+                        relevance_judgment="relevant",
+                        moderation_requirement="not_required",
+                        scoring_readiness="ready",
+                        review_outcome="ready",
+                        privacy_policy=project_privacy,
+                        expected_snapshot_revision=show_activity(
+                            class_id,
+                            project_activity_id,
+                            workspace_root=root,
+                        ).summary.snapshot_revision,
+                        actor=actor,
+                    ),
+                    workspace_root=root,
+                )
+                assert review.artifact_review_id == f"review-project-{index}"
+                assert group_id in project_group_ids
+            project_stage("explicit group Artifact review")
+
+            project_scale = create_scoring_scale(
+                CreateScoringScaleRequest(
+                    class_id=class_id,
+                    activity_id=project_activity_id,
+                    scoring_scale_id="scale-project-issue70",
+                    lineage_id="scale-project-issue70-lineage",
+                    name="Project Collaboration",
+                    revision=1,
+                    scale_type="categorical",
+                    levels=(
+                        ScoringScaleLevel(
+                            value="developing",
+                            label="Developing",
+                            meaning="Synthetic developing level.",
+                        ),
+                        ScoringScaleLevel(
+                            value="meets",
+                            label="Meets",
+                            meaning="Synthetic meets level.",
+                        ),
+                    ),
+                    status="active",
+                    expected_snapshot_revision=show_activity(
+                        class_id,
+                        project_activity_id,
+                        workspace_root=root,
+                    ).summary.snapshot_revision,
+                    actor=actor,
+                    intended_use="Synthetic issue #70 acceptance only.",
+                ),
+                workspace_root=root,
+            )
+            project_criterion_set = create_criterion_set(
+                CreateCriterionSetRequest(
+                    class_id=class_id,
+                    activity_id=project_activity_id,
+                    criterion_set_id="criteria-project-issue70",
+                    lineage_id="criteria-project-issue70-lineage",
+                    name="Project Criteria",
+                    purpose="Synthetic issue #70 acceptance only.",
+                    revision=1,
+                    scope="activity_specific",
+                    criterion_set_kind="local",
+                    criteria=(
+                        CriterionSpec(
+                            criterion_id="criterion-project-collaboration",
+                            key="project-collaboration",
+                            label="Project collaboration",
+                            definition="Synthetic group acceptance criterion.",
+                            criterion_kind="local",
+                            supported_target_kinds=("concord_group",),
+                            default_scoring_scale_id="scale-project-issue70",
+                        ),
+                    ),
+                    status="active",
+                    expected_snapshot_revision=project_scale.commit.snapshot_revision,
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            project_selected = select_activity_criterion_sets(
+                SelectActivityCriterionSetsRequest(
+                    class_id=class_id,
+                    activity_id=project_activity_id,
+                    criterion_set_ids=("criteria-project-issue70",),
+                    expected_snapshot_revision=(
+                        project_criterion_set.commit.snapshot_revision
+                    ),
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert project_selected.criterion_set_ids == ("criteria-project-issue70",)
+
+            project_score_ids: list[str] = []
+            for index, (group_id, artifact_id) in enumerate(
+                sorted(artifact_by_group.items()),
+                start=1,
+            ):
+                group_subject = SubjectReference(
+                    subject_kind="concord_group",
+                    subject_id=group_id,
+                    owning_system="concord",
+                )
+                project_evidence = EvidenceReference(
+                    evidence_kind="artifact_instance",
+                    owning_system="concord",
+                    record_id=artifact_id,
+                    subject_context=(group_subject,),
+                    moderation_requirement="not_required",
+                )
+                project_score_id = f"score-project-{index}"
+                project_score = add_score(
+                    AddScoreRequest(
+                        class_id=class_id,
+                        activity_id=project_activity_id,
+                        score_record_id=project_score_id,
+                        target_reference=ScoreTargetReference(
+                            target_kind="concord_group",
+                            target_id=group_id,
+                            owning_system="concord",
+                        ),
+                        criterion_id="criterion-project-collaboration",
+                        scoring_scale_id="scale-project-issue70",
+                        disposition="scored",
+                        basis="linked_evidence",
+                        privacy_policy=project_privacy,
+                        expected_snapshot_revision=show_activity(
+                            class_id,
+                            project_activity_id,
+                            workspace_root=root,
+                        ).summary.snapshot_revision,
+                        actor=actor,
+                        session_id=project_session_id,
+                        value="meets",
+                        evidence_links=(
+                            ScoreEvidenceLinkSpec(
+                                score_evidence_link_id=f"link-project-{index}",
+                                evidence_reference=project_evidence,
+                                relevance_description=(
+                                    "Synthetic returned group project artifact."
+                                ),
+                                subject_context=(group_subject,),
+                            ),
+                        ),
+                    ),
+                    workspace_root=root,
+                )
+                assert project_score.score_record_id == project_score_id
+                assert_private_absent(project_score, private_tokens)
+                project_score_ids.append(project_score_id)
+            project_stage("explicit group Score recording")
+
+            project_registration = register_concord_academic_work(
+                root,
+                class_id,
+                project_activity_id,
+                academic_intent="formative",
+                lifecycle="active",
+            )
+            assert project_registration.registration.registration_revision == 1
+            project_manifest_request = GenerateAcademicResultManifestRequest(
+                class_id=class_id,
+                activity_id=project_activity_id,
+                expected_snapshot_revision=show_activity(
+                    class_id,
+                    project_activity_id,
+                    workspace_root=root,
+                ).summary.snapshot_revision,
+                actor=actor,
+                revision_reason="initial",
+            )
+            project_generated = generate_academic_result_manifest(
+                project_manifest_request,
+                workspace_root=root,
+            )
+            assert project_generated.disposition == "created"
+            assert project_generated.revision == 1
+            assert len(project_generated.manifest.scores) == 2
+            assert_private_absent(project_generated.content, private_tokens)
+            project_public_before = read_academic_result_manifest(
+                project_generated.content
+            )
+            for score_id in project_score_ids:
+                public_score = lookup_academic_result_score(
+                    project_public_before,
+                    score_id,
+                )
+                assert public_score.score_record_id == score_id
+                assert public_score.value == "meets"
+            project_publication = publish_concord_academic_results(
+                project_manifest_request,
+                workspace_root=root,
+            )
+            assert project_publication.disposition == "created"
+            assert project_publication.compatibility.compatible
+            assert project_publication.publication.work == project_work
+            assert_private_absent(
+                project_publication.manifest_generation.content,
+                private_tokens,
+            )
+            project_public_after = read_academic_result_manifest(
+                project_publication.manifest_generation.content
+            )
+            assert project_public_after == project_public_before
+
+            project_final_graph = load_current_record_graph(root, project_work).graph
+            downstream_records = (
+                *project_final_graph.groups,
+                *project_final_graph.memberships,
+                *project_final_graph.packet_instances,
+                *project_final_graph.artifact_instances,
+                *project_final_graph.artifact_pages,
+                *project_final_graph.scan_references,
+                *project_final_graph.artifact_reviews,
+                *project_final_graph.score_records,
+            )
+            for record in downstream_records:
+                assert_private_absent(record, private_tokens)
+            assert len(project_final_graph.groups) == 2
+            assert len(project_final_graph.memberships) == 4
+            assert len(project_final_graph.packet_instances) == 2
+            assert len(project_final_graph.artifact_instances) == 2
+            assert len(project_final_graph.artifact_pages) == 2 * project_page_count
+            assert len(project_final_graph.scan_references) == 2 * project_page_count
+            assert len(project_final_graph.artifact_reviews) == 2
+            assert len(project_final_graph.score_records) == 2
+            assert not any(
+                module_name.startswith("meridian")
+                for module_name in tuple(__import__("sys").modules)
+            )
+            project_stage(
+                "group-project workflow complete with privacy sentinel intact"
+            )
+
+
+            # Representative participant peer-review workflow. This intentionally uses
+            # deterministic random planning so the third case is signal-free while still
+            # proving the full proposal -> approval -> canonical application boundary.
+            peer_activity_id = "activity-peer-review-issue70"
+            peer_session_id = "session-peer-review-issue70"
+            peer_created = create_activity_context(
+                CreateActivityContextRequest(
+                    class_id=class_id,
+                    activity_id=peer_activity_id,
+                    title="Issue 70 Peer Review",
+                    activity_type="project",
+                    scoring_orientation="local_criteria_only",
+                    session_id=peer_session_id,
+                    actor=actor,
+                    activity_status="active",
+                    session_status="active",
+                    session_label="Peer Review Session",
+                ),
+                workspace_root=root,
+            )
+            peer_work = ModuleWorkRef("concord", class_id, peer_activity_id)
+            peer_context = EffectiveContext(
+                activity_id=peer_activity_id,
+                session_ids=(peer_session_id,),
+            )
+            random_plan = create_random_group_plan(
+                CreateRandomGroupPlanRequest(
+                    class_id=class_id,
+                    activity_id=peer_activity_id,
+                    group_plan_id="plan-peer-review-issue70",
+                    expected_snapshot_revision=peer_created.commit.snapshot_revision,
+                    actor=actor,
+                    seed="issue70-peer-review-seed",
+                    target_group_count=2,
+                ),
+                workspace_root=root,
+            )
+            assert random_plan.group_count == 2
+            assert random_plan.assigned_student_count == 4
+            assert random_plan.group_sizes == (2, 2)
+            assert not list_groups(class_id, peer_activity_id, workspace_root=root)
+            assert not list_memberships(
+                class_id,
+                peer_activity_id,
+                workspace_root=root,
+            )
+            peer_previewed = preview_group_plan(
+                PreviewGroupPlanRequest(
+                    class_id=class_id,
+                    activity_id=peer_activity_id,
+                    group_plan_id=random_plan.mutation.group_plan_id,
+                    expected_snapshot_revision=(
+                        random_plan.mutation.commit.snapshot_revision
+                    ),
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert peer_previewed.plan.status == "previewed"
+            assert peer_previewed.plan.strategy == "random"
+            assert peer_previewed.plan.seed == "issue70-peer-review-seed"
+            assert peer_previewed.plan.source_signal_set_id is None
+            assert peer_previewed.plan.source_signal_set_digest is None
+            assert peer_previewed.plan.source_signal_dimension_id is None
+            peer_approved = approve_group_plan(
+                ApproveGroupPlanRequest(
+                    class_id=class_id,
+                    activity_id=peer_activity_id,
+                    group_plan_id=random_plan.mutation.group_plan_id,
+                    expected_snapshot_revision=(
+                        peer_previewed.summary.snapshot_revision
+                    ),
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert peer_approved.status == "approved"
+            peer_application = prepare_group_plan_application(
+                PrepareGroupPlanApplicationRequest(
+                    class_id=class_id,
+                    activity_id=peer_activity_id,
+                    group_plan_id=random_plan.mutation.group_plan_id,
+                    application_id="apply-peer-review-issue70",
+                    fallback_effective_context=peer_context,
+                ),
+                workspace_root=root,
+            )
+            assert peer_application.group_count == 2
+            assert peer_application.membership_count == 4
+            assert peer_application.unresolved_count == 0
+            assert not list_groups(class_id, peer_activity_id, workspace_root=root)
+            peer_applied = apply_group_plan(
+                ApplyGroupPlanRequest(
+                    class_id=class_id,
+                    activity_id=peer_activity_id,
+                    group_plan_id=random_plan.mutation.group_plan_id,
+                    application_id=peer_application.application_id,
+                    application_digest=peer_application.application_digest,
+                    expected_snapshot_revision=(
+                        peer_application.expected_snapshot_revision
+                    ),
+                    actor=actor,
+                    fallback_effective_context=peer_context,
+                ),
+                workspace_root=root,
+            )
+            assert peer_applied.status == "applied"
+            assert peer_applied.group_count == 2
+            assert peer_applied.membership_count == 4
+            peer_group_ids = frozenset(peer_applied.group_ids)
+            assert len(peer_group_ids) == 2
+            peer_stage("random GroupPlan approval and application")
+
+            peer_starter = get_starter_template("peer_review_writing")
+            peer_page_count = peer_starter.page_count
+            assert peer_page_count > 0
+            assert "participant" in peer_starter.suggested_audience_kinds
+            assert peer_starter.default_authorship_mode == "individual_author"
+            assert peer_starter.default_subject_kind == "core_student"
+            peer_starter_prepared = prepare_starter_template_install(
+                PrepareStarterTemplateInstallRequest(
+                    starter_key=peer_starter.starter_key,
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            peer_starter_result = commit_starter_template_install(
+                peer_starter_prepared,
+                workspace_root=root,
+            )
+            assert peer_starter_result.outcome == "installed"
+            assert peer_starter_result.template_id == peer_starter.template_id
+            assert (
+                peer_starter_result.template_version_id
+                == peer_starter.template_version_id
+            )
+            peer_packet_prepared = prepare_packet_from_template(
+                PreparePacketFromTemplateRequest(
+                    packet_definition_id="packet-peer-review-issue70",
+                    packet_version_id="packet-peer-review-issue70-v1",
+                    packet_component_id="component-peer-review-issue70",
+                    name="Issue 70 Peer Review Packet",
+                    purpose="Representative installed peer-review acceptance.",
+                    template_id=peer_starter.template_id,
+                    template_version_id=peer_starter.template_version_id,
+                    audience_kind="participant",
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            peer_packet_result = commit_packet_from_template(
+                peer_packet_prepared,
+                workspace_root=root,
+            )
+            assert peer_packet_result.status == "active"
+
+            peer_prepared_generation = prepare_packet_instantiation(
+                PreparePacketInstantiationRequest(
+                    class_id=class_id,
+                    activity_id=peer_activity_id,
+                    session_id=peer_session_id,
+                    packet_definition_id="packet-peer-review-issue70",
+                    packet_version_id="packet-peer-review-issue70-v1",
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert peer_prepared_generation.ready_for_commit
+            assert peer_prepared_generation.packet_instance_count == 4
+            assert peer_prepared_generation.artifact_count == 4
+            assert peer_prepared_generation.page_count == 4 * peer_page_count
+            assert peer_prepared_generation.route_count == 4 * peer_page_count
+            peer_planned_students = {
+                target.target_context.participant_reference.participant_id
+                for target in peer_prepared_generation.target_plans
+                if target.target_context.participant_reference is not None
+            }
+            assert peer_planned_students == {
+                "student-1",
+                "student-2",
+                "student-3",
+                "student-4",
+            }
+            peer_committed_generation = commit_packet_instantiation(
+                peer_prepared_generation,
+                workspace_root=root,
+                generation_id="generation-peer-review-issue70",
+            )
+            assert len(peer_committed_generation.packet_instance_ids) == 4
+            assert len(peer_committed_generation.artifact_instance_ids) == 4
+            assert (
+                len(peer_committed_generation.artifact_page_ids)
+                == 4 * peer_page_count
+            )
+            assert len(peer_committed_generation.route_ids) == 4 * peer_page_count
+
+            peer_graph = load_current_record_graph(root, peer_work).graph
+            peer_packet_instances = tuple(
+                item
+                for item in peer_graph.packet_instances
+                if item.generation_id == "generation-peer-review-issue70"
+            )
+            assert len(peer_packet_instances) == 4
+            peer_artifact_by_student: dict[str, str] = {}
+            peer_group_by_student: dict[str, str] = {}
+            for packet_instance in peer_packet_instances:
+                target = packet_instance.target_context
+                assert target.audience_kind == "participant"
+                assert target.participant_reference is not None
+                assert target.participant_reference.participant_kind == "core_student"
+                assert target.participant_reference.owning_system == "core"
+                assert target.group_id in peer_group_ids
+                assert len(packet_instance.artifact_bindings) == 1
+                student_id = target.participant_reference.participant_id
+                peer_artifact_by_student[student_id] = (
+                    packet_instance.artifact_bindings[0].artifact_instance_id
+                )
+                assert target.group_id is not None
+                peer_group_by_student[student_id] = target.group_id
+            assert set(peer_artifact_by_student) == peer_planned_students
+            assert len(set(peer_artifact_by_student.values())) == 4
+            assert sorted(
+                tuple(peer_group_by_student.values()).count(group_id)
+                for group_id in peer_group_ids
+            ) == [2, 2]
+            peer_stage("participant peer-review Packet instantiation")
+
+            peer_rendered = render_packet_generation(
+                RenderPacketGenerationRequest(
+                    class_id=class_id,
+                    activity_id=peer_activity_id,
+                    generation_id="generation-peer-review-issue70",
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert len(peer_rendered.packets) == 4
+            assert peer_rendered.page_count == 4 * peer_page_count
+            assert peer_rendered.route_count == 4 * peer_page_count
+            peer_route_ids = set(peer_committed_generation.route_ids)
+            peer_decoded_route_ids: set[str] = set()
+            peer_pdf_paths: list[Path] = []
+            for packet in peer_rendered.packets:
+                assert packet.output_path.is_file()
+                assert packet.page_count == peer_page_count
+                assert packet.route_count == peer_page_count
+                assert len(packet.payloads) == peer_page_count
+                peer_pdf_paths.append(packet.output_path)
+                for payload in packet.payloads:
+                    locator = parse_pds2_payload(payload)
+                    assert locator.module_id == "concord"
+                    assert locator.class_id == class_id
+                    assert locator.work_id == peer_activity_id
+                    assert locator.route_id in peer_route_ids
+                    peer_decoded_route_ids.add(locator.route_id)
+            assert peer_decoded_route_ids == peer_route_ids
+            peer_stage("real peer-review PDF and PDS2 rendering")
+
+            peer_returned = route_scan_sources(peer_pdf_paths, workspace_root=root)
+            assert peer_returned.dispatched_count == 4 * peer_page_count
+            assert peer_returned.failure_count == 0
+            peer_observed_routes: set[str] = set()
+            peer_observed_pages: set[str] = set()
+            peer_retained_scan_ids: set[str] = set()
+            for source in peer_returned.sources:
+                assert source.source_error is None
+                assert source.retained_source is not None
+                peer_retained_scan_ids.add(source.retained_source.source_scan_id)
+                assert len(source.pages) == peer_page_count
+                for page in source.pages:
+                    assert page.status == "dispatched"
+                    assert page.locator is not None
+                    assert page.locator.module_id == "concord"
+                    assert page.locator.class_id == class_id
+                    assert page.locator.work_id == peer_activity_id
+                    assert page.locator.route_id in peer_route_ids
+                    peer_observed_routes.add(page.locator.route_id)
+                    dispatch = page.module_result
+                    assert dispatch is not None
+                    assert dispatch.route_id == page.locator.route_id
+                    assert (
+                        dispatch.artifact_instance_id
+                        in peer_artifact_by_student.values()
+                    )
+                    assert (
+                        dispatch.artifact_page_id
+                        in peer_committed_generation.artifact_page_ids
+                    )
+                    peer_observed_pages.add(dispatch.artifact_page_id)
+            assert peer_observed_routes == peer_route_ids
+            assert peer_observed_pages == set(
+                peer_committed_generation.artifact_page_ids
+            )
+            assert len(peer_retained_scan_ids) == 4
+            peer_stage("production peer-review return, retention, and dispatch")
+
+            for student_id, artifact_id in sorted(peer_artifact_by_student.items()):
+                assembled = assemble_returned_artifact(
+                    AssembleArtifactRequest(
+                        class_id=class_id,
+                        activity_id=peer_activity_id,
+                        artifact_instance_id=artifact_id,
+                        expected_snapshot_revision=show_activity(
+                            class_id,
+                            peer_activity_id,
+                            workspace_root=root,
+                        ).summary.snapshot_revision,
+                        actor=actor,
+                    ),
+                    workspace_root=root,
+                )
+                assert assembled.page_count == peer_page_count
+                assert assembled.output_path.is_file()
+                assert assembled.manifest_path.is_file()
+                assert assembled.artifact_instance_id == artifact_id
+                assert student_id in peer_planned_students
+            peer_stage("peer-review Artifact assembly")
+
+            peer_privacy = PrivacyPolicy(classification="teacher_and_subjects")
+            for index, (student_id, artifact_id) in enumerate(
+                sorted(peer_artifact_by_student.items()),
+                start=1,
+            ):
+                review = add_artifact_review(
+                    AddArtifactReviewRequest(
+                        class_id=class_id,
+                        activity_id=peer_activity_id,
+                        artifact_instance_id=artifact_id,
+                        artifact_review_id=f"review-peer-{index}",
+                        readability_judgment="readable",
+                        page_completeness_judgment="complete",
+                        filing_judgment="correct",
+                        author_judgment="confirmed",
+                        subject_judgment="confirmed",
+                        privacy_judgment="teacher_and_subjects",
+                        relevance_judgment="relevant",
+                        moderation_requirement="not_required",
+                        scoring_readiness="ready",
+                        review_outcome="ready",
+                        privacy_policy=peer_privacy,
+                        expected_snapshot_revision=show_activity(
+                            class_id,
+                            peer_activity_id,
+                            workspace_root=root,
+                        ).summary.snapshot_revision,
+                        actor=actor,
+                    ),
+                    workspace_root=root,
+                )
+                assert review.artifact_review_id == f"review-peer-{index}"
+                assert student_id in peer_planned_students
+            peer_stage("explicit peer-review Artifact review")
+
+            peer_scale = create_scoring_scale(
+                CreateScoringScaleRequest(
+                    class_id=class_id,
+                    activity_id=peer_activity_id,
+                    scoring_scale_id="scale-peer-review-issue70",
+                    lineage_id="scale-peer-review-issue70-lineage",
+                    name="Peer Review Quality",
+                    revision=1,
+                    scale_type="categorical",
+                    levels=(
+                        ScoringScaleLevel(
+                            value="developing",
+                            label="Developing",
+                            meaning="Synthetic developing level.",
+                        ),
+                        ScoringScaleLevel(
+                            value="meets",
+                            label="Meets",
+                            meaning="Synthetic meets level.",
+                        ),
+                    ),
+                    status="active",
+                    expected_snapshot_revision=show_activity(
+                        class_id,
+                        peer_activity_id,
+                        workspace_root=root,
+                    ).summary.snapshot_revision,
+                    actor=actor,
+                    intended_use="Synthetic issue #70 acceptance only.",
+                ),
+                workspace_root=root,
+            )
+            peer_criterion_set = create_criterion_set(
+                CreateCriterionSetRequest(
+                    class_id=class_id,
+                    activity_id=peer_activity_id,
+                    criterion_set_id="criteria-peer-review-issue70",
+                    lineage_id="criteria-peer-review-issue70-lineage",
+                    name="Peer Review Criteria",
+                    purpose="Synthetic issue #70 acceptance only.",
+                    revision=1,
+                    scope="activity_specific",
+                    criterion_set_kind="local",
+                    criteria=(
+                        CriterionSpec(
+                            criterion_id="criterion-peer-review-quality",
+                            key="peer-review-quality",
+                            label="Peer review quality",
+                            definition="Synthetic peer-review acceptance criterion.",
+                            criterion_kind="local",
+                            supported_target_kinds=("core_student",),
+                            default_scoring_scale_id="scale-peer-review-issue70",
+                        ),
+                    ),
+                    status="active",
+                    expected_snapshot_revision=peer_scale.commit.snapshot_revision,
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            peer_selected = select_activity_criterion_sets(
+                SelectActivityCriterionSetsRequest(
+                    class_id=class_id,
+                    activity_id=peer_activity_id,
+                    criterion_set_ids=("criteria-peer-review-issue70",),
+                    expected_snapshot_revision=(
+                        peer_criterion_set.commit.snapshot_revision
+                    ),
+                    actor=actor,
+                ),
+                workspace_root=root,
+            )
+            assert peer_selected.criterion_set_ids == (
+                "criteria-peer-review-issue70",
+            )
+
+            peer_score_ids: list[str] = []
+            for index, (student_id, artifact_id) in enumerate(
+                sorted(peer_artifact_by_student.items()),
+                start=1,
+            ):
+                peer_subject = SubjectReference(
+                    subject_kind="core_student",
+                    subject_id=student_id,
+                    owning_system="core",
+                )
+                peer_evidence = EvidenceReference(
+                    evidence_kind="artifact_instance",
+                    owning_system="concord",
+                    record_id=artifact_id,
+                    subject_context=(peer_subject,),
+                    moderation_requirement="not_required",
+                )
+                peer_score_id = f"score-peer-{index}"
+                peer_score = add_score(
+                    AddScoreRequest(
+                        class_id=class_id,
+                        activity_id=peer_activity_id,
+                        score_record_id=peer_score_id,
+                        target_reference=ScoreTargetReference(
+                            target_kind="core_student",
+                            target_id=student_id,
+                            owning_system="core",
+                        ),
+                        criterion_id="criterion-peer-review-quality",
+                        scoring_scale_id="scale-peer-review-issue70",
+                        disposition="scored",
+                        basis="linked_evidence",
+                        privacy_policy=peer_privacy,
+                        expected_snapshot_revision=show_activity(
+                            class_id,
+                            peer_activity_id,
+                            workspace_root=root,
+                        ).summary.snapshot_revision,
+                        actor=actor,
+                        session_id=peer_session_id,
+                        value="meets",
+                        evidence_links=(
+                            ScoreEvidenceLinkSpec(
+                                score_evidence_link_id=f"link-peer-{index}",
+                                evidence_reference=peer_evidence,
+                                relevance_description=(
+                                    "Synthetic returned peer-review artifact."
+                                ),
+                                subject_context=(peer_subject,),
+                            ),
+                        ),
+                    ),
+                    workspace_root=root,
+                )
+                assert peer_score.score_record_id == peer_score_id
+                peer_score_ids.append(peer_score_id)
+            peer_stage("explicit peer-review Score recording")
+
+            peer_registration = register_concord_academic_work(
+                root,
+                class_id,
+                peer_activity_id,
+                academic_intent="formative",
+                lifecycle="active",
+            )
+            assert peer_registration.registration.registration_revision == 1
+            peer_manifest_request = GenerateAcademicResultManifestRequest(
+                class_id=class_id,
+                activity_id=peer_activity_id,
+                expected_snapshot_revision=show_activity(
+                    class_id,
+                    peer_activity_id,
+                    workspace_root=root,
+                ).summary.snapshot_revision,
+                actor=actor,
+                revision_reason="initial",
+            )
+            peer_generated = generate_academic_result_manifest(
+                peer_manifest_request,
+                workspace_root=root,
+            )
+            assert peer_generated.disposition == "created"
+            assert peer_generated.revision == 1
+            assert len(peer_generated.manifest.scores) == 4
+            peer_public_before = read_academic_result_manifest(
+                peer_generated.content
+            )
+            for score_id in peer_score_ids:
+                public_score = lookup_academic_result_score(
+                    peer_public_before,
+                    score_id,
+                )
+                assert public_score.score_record_id == score_id
+                assert public_score.disposition == "scored"
+                assert public_score.value == "meets"
+            peer_publication = publish_concord_academic_results(
+                peer_manifest_request,
+                workspace_root=root,
+            )
+            assert peer_publication.disposition == "created"
+            assert peer_publication.compatibility.compatible
+            assert peer_publication.publication.work == peer_work
+            assert (
+                peer_publication.publication.record_set_revision
+                == peer_generated.revision
+            )
+            assert (
+                peer_publication.publication.manifest_digest
+                == peer_generated.sha256
+            )
+            peer_public_after = read_academic_result_manifest(
+                peer_publication.manifest_generation.content
+            )
+            assert peer_public_after == peer_public_before
+            for score_id in peer_score_ids:
+                assert lookup_academic_result_score(
+                    peer_public_after,
+                    score_id,
+                ).score_record_id == score_id
+
+            peer_final_graph = load_current_record_graph(root, peer_work).graph
+            assert len(peer_final_graph.groups) == 2
+            assert len(peer_final_graph.memberships) == 4
+            assert len(peer_final_graph.packet_instances) == 4
+            assert len(peer_final_graph.artifact_instances) == 4
+            assert len(peer_final_graph.artifact_pages) == 4 * peer_page_count
+            assert len(peer_final_graph.scan_references) == 4 * peer_page_count
+            assert len(peer_final_graph.artifact_reviews) == 4
+            assert len(peer_final_graph.score_records) == 4
+            assert not any(
+                module_name.startswith("meridian")
+                for module_name in tuple(__import__("sys").modules)
+            )
+            peer_stage("peer-review workflow complete")
+        '''
+    )
+
+
+def smoke(concord_wheel: Path, core_wheel: Path) -> None:
+    """Run the starter workflow scenario in one fresh standalone environment."""
+    if not concord_wheel.is_file():
+        raise FileNotFoundError(concord_wheel)
+    if not core_wheel.is_file():
+        raise FileNotFoundError(core_wheel)
+
+    with tempfile.TemporaryDirectory(prefix="concord-starter-wheel-") as raw:
+        work = Path(raw)
+        env_root = work / "venv"
+        venv.EnvBuilder(with_pip=True).create(env_root)
+        python = _python(env_root)
+        _run(
+            [str(python), "-m", "pip", "install", str(core_wheel.resolve())],
+            work,
+        )
+        _run(
+            [str(python), "-m", "pip", "install", str(concord_wheel.resolve())],
+            work,
+        )
+        _run([str(python), "-m", "pip", "check"], work)
+        smoke_path = work / "starter_workflows_smoke.py"
+        smoke_path.write_text(_smoke_code(), encoding="utf-8")
+        _run([str(python), "-I", str(smoke_path)], work)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("concord_wheel", type=Path)
+    parser.add_argument("core_wheel", type=Path)
+    args = parser.parse_args()
+    smoke(args.concord_wheel, args.core_wheel)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_installed_smoke_performance_issue93.py
+++ b/tests/test_installed_smoke_performance_issue93.py
@@ -11,18 +11,21 @@ def test_issue93_shared_feature_smoke_reuses_existing_scenario_sources() -> None
         "reusable presets",
         "guided Activity",
         "task-oriented menu",
+        "starter workflows",
     )
     assert tuple(filename for _, filename, _ in feature_smokes.SCENARIOS) == (
         "activity_copying_smoke.py",
         "reusable_presets_smoke.py",
         "guided_activity_smoke.py",
         "task_oriented_activity_menu_smoke.py",
+        "starter_workflows_smoke.py",
     )
     assert tuple(script for _, _, script in feature_smokes.SCENARIOS) == (
         "scripts/smoke_test_activity_copying_wheel.py",
         "scripts/smoke_test_reusable_presets_wheel.py",
         "scripts/smoke_test_guided_activity_wheel.py",
         "scripts/smoke_test_task_oriented_activity_menu_wheel.py",
+        "scripts/smoke_test_starter_workflows_wheel.py",
     )
 
 
@@ -45,6 +48,7 @@ def test_issue93_repository_validator_batches_only_feature_smokes() -> None:
         "scripts/smoke_test_reusable_presets_wheel.py",
         "scripts/smoke_test_guided_activity_wheel.py",
         "scripts/smoke_test_task_oriented_activity_menu_wheel.py",
+        "scripts/smoke_test_starter_workflows_wheel.py",
     ):
         assert removed_direct_call not in source
 

--- a/tests/test_installed_starter_workflow_acceptance_issue70.py
+++ b/tests/test_installed_starter_workflow_acceptance_issue70.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from scripts import smoke_test_feature_wheels as feature_smokes
+from scripts import smoke_test_starter_workflows_wheel as starter_smoke
+
+
+def test_issue70_slice1_registers_one_shared_starter_workflow_scenario() -> None:
+    matches = tuple(
+        item
+        for item in feature_smokes.SCENARIOS
+        if item[2] == "scripts/smoke_test_starter_workflows_wheel.py"
+    )
+    assert matches == (
+        (
+            "starter workflows",
+            "starter_workflows_smoke.py",
+            "scripts/smoke_test_starter_workflows_wheel.py",
+        ),
+    )
+
+
+def test_issue70_slice1_seminar_smoke_covers_required_installed_boundaries() -> None:
+    source = starter_smoke._smoke_code()
+    compile(source, "starter_workflows_smoke.py", "exec")
+
+    required_fragments = (
+        'metadata.version("pds-core") == "0.6.3"',
+        'metadata.version("pds-concord") == "0.3.0.dev0"',
+        "launch_guided_activity_menu(state)",
+        'get_starter_template("socratic_seminar")',
+        "create_manual_group_plan(",
+        "preview_group_plan(",
+        "approve_group_plan(",
+        "prepare_group_plan_application(",
+        "apply_group_plan(",
+        "prepare_packet_instantiation(",
+        "commit_packet_instantiation(",
+        "render_packet_generation(",
+        "parse_pds2_payload(payload)",
+        "route_scan_sources(pdf_paths",
+        "assemble_returned_artifact(",
+        "add_artifact_review(",
+        "add_score(",
+        "register_concord_academic_work(",
+        "generate_academic_result_manifest(",
+        "publish_concord_academic_results(",
+        "read_academic_result_manifest(",
+    )
+    for fragment in required_fragments:
+        assert fragment in source
+
+    assert 'previewed.plan.status == "previewed"' in source
+    assert "expected_snapshot_revision=previewed.summary.snapshot_revision" in source
+    assert 'previewed.status == "previewed"' not in source
+    assert "previewed.commit.snapshot_revision" not in source
+
+
+def test_issue70_slice1_preserves_participant_and_no_meridian_boundaries() -> None:
+    source = starter_smoke._smoke_code()
+    assert 'audience_kind="participant"' in source
+    assert 'target.audience_kind == "participant"' in source
+    assert 'target.group_id in group_ids' in source
+    assert "artifact_by_student" in source
+    assert "student-1" in source
+    assert "student-4" in source
+    assert 'forbidden = ("meridian", "paper-data-suite")' in source
+    assert 'module_name.startswith("meridian")' in source
+
+
+def test_issue70_slice1_automated_path_starts_from_rendered_pdfs() -> None:
+    source = starter_smoke._smoke_code()
+    render_index = source.index("render_packet_generation(")
+    intake_index = source.index("route_scan_sources(pdf_paths")
+    review_index = source.index("add_artifact_review(")
+    score_index = source.index("add_score(")
+    publish_index = source.index("publish_concord_academic_results(")
+
+    assert render_index < intake_index < review_index < score_index < publish_index
+    assert "decoder=" not in source
+    assert "raw_decoder=" not in source
+    assert "fabricated" not in source.casefold()
+
+
+def test_issue70_slice2_project_smoke_covers_signal_backed_group_path() -> None:
+    source = starter_smoke._smoke_code()
+    required_fragments = (
+        'GroupingSignalSet(',
+        'write_grouping_signal(root, signal)',
+        'calculate_grouping_signal_digest(signal)',
+        'CreateSignalGroupPlanRequest(',
+        'strategy="similar_signal"',
+        'fallback_effective_context=project_context',
+        'get_starter_template("project_plan")',
+        'audience_kind="group"',
+        'target.audience_kind == "group"',
+        'supported_target_kinds=("concord_group",)',
+        'target_kind="concord_group"',
+        'subject_kind="concord_group"',
+        'privacy_judgment="group_and_teacher"',
+        'classification="group_and_teacher"',
+    )
+    for fragment in required_fragments:
+        assert fragment in source
+
+    assert "signal_plan.mutation.group_plan_id" in source
+    assert "signal_plan.mutation.commit.snapshot_revision" in source
+    assert "signal_plan.group_plan_id" not in source
+    assert "signal_plan.commit.snapshot_revision" not in source
+
+    project_render = source.index("project_rendered = render_packet_generation(")
+    project_intake = source.index("project_returned = route_scan_sources(")
+    project_review = source.index("review-project-")
+    project_score = source.index("score-project-")
+    project_publish = source.index(
+        "project_publication = publish_concord_academic_results("
+    )
+    assert (
+        project_render
+        < project_intake
+        < project_review
+        < project_score
+        < project_publish
+    )
+
+
+def test_issue70_slice2_enforces_signal_privacy_and_dynamic_page_contracts() -> None:
+    source = starter_smoke._smoke_code()
+    privacy_fragments = (
+        'private_signal_set_id = "issue70-private-signal-set"',
+        'private_dimension_id = "issue70-private-proficiency-band"',
+        'private_source_module = "issue70_private_producer"',
+        'private_snapshot_id = "issue70-private-snapshot"',
+        'private_snapshot_digest = "7" * 64',
+        'private_canonical_digest = calculate_grouping_signal_digest(signal)',
+        'assert_private_absent(project_prepared_generation, private_tokens)',
+        'assert_private_absent(packet.output_path.read_bytes(), private_tokens)',
+        'assert_private_absent(project_generated.content, private_tokens)',
+        'downstream_records = (',
+    )
+    for fragment in privacy_fragments:
+        assert fragment in source
+
+    assert "seminar_page_count = starter.page_count" in source
+    assert "project_page_count = project_starter.page_count" in source
+    assert 'starter.page_count == 2' not in source
+    assert 'project_starter.page_count == 1' not in source
+
+
+def test_issue70_slice3_peer_review_smoke_covers_random_participant_path() -> None:
+    source = starter_smoke._smoke_code()
+    required_fragments = (
+        'CreateRandomGroupPlanRequest(',
+        'seed="issue70-peer-review-seed"',
+        'random_plan.mutation.group_plan_id',
+        'fallback_effective_context=peer_context',
+        'get_starter_template("peer_review_writing")',
+        'peer_page_count = peer_starter.page_count',
+        'audience_kind="participant"',
+        'target.group_id in peer_group_ids',
+        'generation_id="generation-peer-review-issue70"',
+        'supported_target_kinds=("core_student",)',
+        'criterion_id="criterion-peer-review-quality"',
+        'peer_registration = register_concord_academic_work(',
+        'peer_publication = publish_concord_academic_results(',
+        'peer_stage("peer-review workflow complete")',
+    )
+    for fragment in required_fragments:
+        assert fragment in source
+
+    assert 'peer_previewed.plan.strategy == "random"' in source
+    assert 'peer_previewed.plan.source_signal_set_id is None' in source
+    assert 'peer_previewed.plan.source_signal_set_digest is None' in source
+    assert 'peer_previewed.plan.source_signal_dimension_id is None' in source
+
+    peer_plan = source.index("random_plan = create_random_group_plan(")
+    peer_preview = source.index("peer_previewed = preview_group_plan(")
+    peer_approve = source.index("peer_approved = approve_group_plan(")
+    peer_apply_preview = source.index(
+        "peer_application = prepare_group_plan_application("
+    )
+    peer_apply = source.index("peer_applied = apply_group_plan(")
+    peer_render = source.index("peer_rendered = render_packet_generation(")
+    peer_intake = source.index("peer_returned = route_scan_sources(")
+    peer_review = source.index('artifact_review_id=f"review-peer-')
+    peer_score = source.index('peer_score_id = f"score-peer-')
+    peer_publish = source.index(
+        "peer_publication = publish_concord_academic_results("
+    )
+    assert (
+        peer_plan
+        < peer_preview
+        < peer_approve
+        < peer_apply_preview
+        < peer_apply
+        < peer_render
+        < peer_intake
+        < peer_review
+        < peer_score
+        < peer_publish
+    )

--- a/tests/test_physical_operator_harness_issue70.py
+++ b/tests/test_physical_operator_harness_issue70.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "run_physical_starter_workflow_acceptance_issue70.py"
+DOC = ROOT / "docs" / "v0.3.0-installed-physical-starter-workflow-acceptance.md"
+
+
+def _source() -> str:
+    return SCRIPT.read_text(encoding="utf-8")
+
+
+def test_operator_harness_compiles_and_has_two_public_stages() -> None:
+    source = _source()
+    ast.parse(source)
+    assert 'subparsers.add_parser("prepare")' in source
+    assert 'subparsers.add_parser("resume")' in source
+    assert '"_installed-prepare"' in source
+    assert '"_installed-resume"' in source
+    assert '"-I"' in source
+    assert '"pip", "check"' in source
+    assert "site-packages" in source
+
+
+def test_prepare_uses_all_three_groupplan_and_starter_paths() -> None:
+    source = _source()
+    required = (
+        "create_manual_group_plan(",
+        "create_signal_group_plan(",
+        "create_random_group_plan(",
+        "preview_group_plan(",
+        "approve_group_plan(",
+        "prepare_group_plan_application(",
+        "apply_group_plan(",
+        'get_starter_template("socratic_seminar")',
+        'get_starter_template("project_plan")',
+        'get_starter_template("peer_review_writing")',
+        "prepare_packet_instantiation(",
+        "commit_packet_instantiation(",
+        "render_packet_instance(",
+        "parse_pds2_payload(",
+    )
+    for token in required:
+        assert token in source
+    assert '"seminar": 2, "project": 2, "peer_review": 2' in source
+    assert "issue #70 physical sample must contain exactly six packets" in source
+
+
+def test_prepare_preserves_project_privacy_sentinel() -> None:
+    source = _source()
+    assert "issue70-physical-private-signal-set" in source
+    assert "issue70-physical-private-band" in source
+    assert "private_canonical_digest" in source
+    assert "leaked planning provenance into PDF" in source
+    assert "leaked planning provenance into PDS2" in source
+    assert "project planning provenance leaked downstream" in source
+
+
+def test_resume_requires_real_changed_bytes_and_production_intake() -> None:
+    source = _source()
+    assert "--physical-mark-confirmed" in source
+    assert "--visual-inspection-confirmed" in source
+    assert "digest in print_hashes" in source
+    assert "untouched generated PDF is not physical acceptance evidence" in source
+    assert "route_scan_sources(scans, workspace_root=workspace)" in source
+    assert "raw_page_decoder" not in source
+    assert "scan intake inferred Artifact Review state" in source
+    assert "scan intake inferred Score state" in source
+    assert "assemble_returned_artifact(" in source
+    assert "add_artifact_review(" in source
+    assert "add_score(" in source
+    assert "publish_concord_academic_results(" in source
+    assert "read_academic_result_manifest(" in source
+
+
+def test_resume_requires_exact_union_of_six_physical_packet_identities() -> None:
+    source = _source()
+    assert "route_to_case" in source
+    assert "expected_pages_by_case" in source
+    assert "expected_routes_by_case" in source
+    assert "physical route set is incomplete" in source
+    assert "physical ArtifactPage set is incomplete" in source
+    assert "physical sample must contain two packets" in source
+
+
+def test_harness_never_auto_declares_physical_pass() -> None:
+    source = _source()
+    assert "physical seminar: OWNER CLASSIFICATION REQUIRED" in source
+    assert "physical group project: OWNER CLASSIFICATION REQUIRED" in source
+    assert "physical peer review: OWNER CLASSIFICATION REQUIRED" in source
+    assert "physical acceptance: OWNER CLASSIFICATION REQUIRED" in source
+    assert "owner_physical_classification_required" in source
+    assert "READY FOR #71: NO" in source
+    assert "physical acceptance: PASS" not in source
+
+
+def test_documentation_points_to_persistent_operator_harness() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    assert "## Persistent operator harness" in text
+    assert "run_physical_starter_workflow_acceptance_issue70.py prepare" in text
+    assert "run_physical_starter_workflow_acceptance_issue70.py resume" in text
+    assert "--physical-mark-confirmed" in text
+    assert "--visual-inspection-confirmed" in text
+    assert "OWNER CLASSIFICATION REQUIRED" in text

--- a/tests/test_physical_starter_workflow_acceptance_issue70.py
+++ b/tests/test_physical_starter_workflow_acceptance_issue70.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs" / "v0.3.0-installed-physical-starter-workflow-acceptance.md"
+DOC_INDEX = ROOT / "docs" / "README.md"
+
+
+def _text() -> str:
+    return DOC.read_text(encoding="utf-8")
+
+
+def test_issue70_physical_acceptance_keeps_owner_gate_pending() -> None:
+    text = _text()
+    assert "Result before the owner performs the cases: `PENDING OWNER`" in text
+    assert "physical acceptance: PENDING OWNER" in text
+    assert "READY FOR #71: NO" in text
+    assert "Automation must never replace `PENDING OWNER`" in text
+    assert "issue #70 remains open" in text.casefold()
+
+
+def test_issue70_document_covers_three_installed_workflows_and_privacy() -> None:
+    text = _text()
+    for starter_key in (
+        "socratic_seminar",
+        "project_plan",
+        "peer_review_writing",
+    ):
+        assert starter_key in text
+    for planning_path in (
+        "manual signal-free GroupPlan",
+        "similar_signal GroupPlan",
+        "deterministic random signal-free GroupPlan",
+    ):
+        assert planning_path in text
+    assert "Sentinel values" in text
+    assert "planning-only" in text
+    assert "Starter page counts are derived" in text
+
+
+def test_issue70_physical_sample_requires_all_three_workflow_families() -> None:
+    text = _text()
+    required = (
+        "six target packets",
+        "one participant packet from canonical Group A",
+        "both canonical Group-targeted packets",
+        "peer review:",
+        "Every page of those six selected packets",
+        "Physically write `PDS70`",
+        "production `route_scan_sources`",
+        "physical seminar: PENDING OWNER",
+        "physical group project: PENDING OWNER",
+        "physical peer review: PENDING OWNER",
+    )
+    for fragment in required:
+        assert fragment in text
+    assert "The physical gate covers **all three required starter families**" in text
+
+
+def test_issue70_physical_case_requires_exact_provenance_and_visual_gate() -> None:
+    text = _text()
+    required = (
+        "same Concord/Core wheel bytes",
+        "Concord wheel byte length",
+        "printer make/model",
+        "scanner make/model",
+        "scan resolution (DPI)",
+        "physical visual acceptance",
+        "--visual-inspection-confirmed",
+        "PASS WITH DOCUMENTED LIMITATION",
+        "software-contract failure",
+        "physical/environment dependency",
+    )
+    lowered = text.casefold()
+    for fragment in required:
+        assert fragment.casefold() in lowered
+    assert (
+        "98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5"
+        in text
+    )
+
+
+def test_issue70_physical_acceptance_forbids_committing_raw_evidence() -> None:
+    text = _text()
+    forbidden_artifacts = (
+        "raw scans",
+        "generated acceptance PDFs",
+        "marked paper images",
+        "retained physical source files",
+        "physical workspace copies",
+        "virtual environments",
+        "real student data",
+    )
+    for artifact in forbidden_artifacts:
+        assert artifact in text
+    index = DOC_INDEX.read_text(encoding="utf-8")
+    assert "v0.3.0-installed-physical-starter-workflow-acceptance.md" in index


### PR DESCRIPTION
## Summary

Refs #70.

Build representative installed-distribution and physical-paper acceptance for Concord's v0.3.0 starter workflows.

This adds installed qualification for the three representative starter families:

* guided Socratic seminar with a teacher-reviewed manual GroupPlan;
* signal-backed group project using `similar_signal`;
* deterministic random peer-review grouping.

Each installed scenario exercises the real Concord/Core workflow through GroupPlan proposal, preview, approval, application, starter Template and Packet selection, Activity-specific packet instantiation, real PDF/PDS2 rendering, Core scan retention and dispatch, Artifact assembly, explicit review, explicit scoring, Academic Work registration, manifest generation, publication, and public readback.

The project scenario also verifies that planning-only grouping-signal provenance does not leak into learner-facing or downstream operational/result artifacts.

## Physical acceptance

Adds the owner-operated physical acceptance contract and a persistent two-stage helper for the post-merge paper run.

The required physical sample covers all three starter families:

* one seminar participant from each of two canonical Groups;
* both group-project Group packets;
* one peer-review participant from each of two canonical Groups.

The physical helper preserves the synthetic workspace and exact installed-wheel provenance across preparation and scan-resume stages. It requires genuine scanner output and explicit human attestation of the `PDS70` physical mark, then exercises production Core retention/dispatch followed by Concord assembly, review, scoring, publication, and readback.

The helper intentionally does **not** declare physical acceptance itself. Final classification remains owner-controlled as:

* `PASS`
* `PASS WITH DOCUMENTED LIMITATION`
* `FAIL`

The physical gate therefore remains pending after this PR merges.

## Validation

Authoritative repository validation against released `pds-core 0.6.3` passed:

* full pytest suite
* Ruff
* mypy
* documentation validation
* release compatibility
* package build and Twine checks
* package-content validation
* release-artifact validation
* base installed-wheel smoke
* shared installed feature smoke
* module-operations installed smoke
* `git diff --check`

The shared installed feature smoke passed the complete seminar, group-project, and peer-review starter workflows.

## Follow-up

After merge:

1. build and preserve the exact post-merge Concord wheel;
2. record its SHA-256 and final commit;
3. rerun authoritative installed acceptance against those exact wheel bytes and the released Core 0.6.3 wheel;
4. use those same Concord wheel bytes for the six-packet physical print/mark/scan run;
5. record the owner classification and evidence on #70;
6. close #70 only after the physical gate is satisfied.

Issue #71 remains blocked until that owner-only physical acceptance is complete.
