### PR TITLE
test: fix physical seminar acceptance setup

### DIFF
--- a/scripts/run_physical_starter_workflow_acceptance_issue70.py
+++ b/scripts/run_physical_starter_workflow_acceptance_issue70.py
@@ -563,7 +563,6 @@ def _installed_prepare(run_root: Path) -> int:
             activity_id=seminar_activity_id,
             group_plan_id=seminar_plan.group_plan_id,
             application_id="apply-seminar-issue70-physical",
-            fallback_effective_context=seminar_context,
         ),
         workspace_root=workspace,
     )
@@ -576,7 +575,6 @@ def _installed_prepare(run_root: Path) -> int:
             application_digest=seminar_application.application_digest,
             expected_snapshot_revision=seminar_application.expected_snapshot_revision,
             actor=actor,
-            fallback_effective_context=seminar_context,
         ),
         workspace_root=workspace,
     )

--- a/tests/test_physical_operator_harness_issue70.py
+++ b/tests/test_physical_operator_harness_issue70.py
@@ -48,6 +48,22 @@ def test_prepare_uses_all_three_groupplan_and_starter_paths() -> None:
     assert "issue #70 physical sample must contain exactly six packets" in source
 
 
+
+def test_prepare_uses_fallback_context_only_for_generated_plans() -> None:
+    source = _source()
+    seminar_start = source.index('group_plan_id="plan-seminar-issue70-physical"')
+    project_start = source.index('group_plan_id="plan-project-issue70-physical"')
+    peer_start = source.index('group_plan_id="plan-peer-review-issue70-physical"')
+
+    seminar_section = source[seminar_start:project_start]
+    project_section = source[project_start:peer_start]
+    peer_section = source[peer_start:]
+
+    assert "fallback_effective_context=seminar_context" not in seminar_section
+    assert project_section.count("fallback_effective_context=project_context") == 2
+    assert peer_section.count("fallback_effective_context=peer_context") == 2
+
+
 def test_prepare_preserves_project_privacy_sentinel() -> None:
     source = _source()
     assert "issue70-physical-private-signal-set" in source


### PR DESCRIPTION
## Summary

Refs #70.

Fix the owner-operated issue #70 physical acceptance harness after the first post-merge `prepare` rehearsal exposed a GroupPlan application contract mismatch in the seminar path.

The seminar uses a manual GroupPlan whose nonempty `PlannedGroup` records already carry their complete `EffectiveContext`. The physical helper was additionally supplying `fallback_effective_context` during application preview and explicit application. Concord correctly rejects that combination.

This change:

* removes the redundant seminar fallback context from application preview;
* removes the redundant seminar fallback context from explicit application;
* preserves the required fallback contexts for the generated signal-backed project and random peer-review plans;
* adds a regression test enforcing that distinction.

No Concord production package behavior changes.

## Failure classification

Acceptance-harness defect only.

The installed Concord production API behaved correctly by rejecting a fallback Effective Context when every nonempty planned group already had one.

No physical paper had been printed and no owner physical evidence had been collected when the defect was discovered.

## Validation

Focused qualification passed:

* 20 issue #70 physical/installed tests
* Ruff
* mypy
* `git diff --check`

The corrected `prepare` harness was then rehearsed against the previously preserved installed Concord/Core wheels and successfully produced the complete six-packet physical sample:

* 2 seminar participant packets
* 2 project Group packets
* 2 peer-review participant packets
* 10 total pages

The full authoritative repository validator also passed:

* full pytest suite
* Ruff
* mypy
* documentation validation
* release compatibility
* package build and checks
* release-artifact checks
* base installed-wheel smoke
* shared installed feature smoke
* module-operations installed smoke
* `git diff --check`

The complete validation run finished successfully in 419.131 seconds.

## Follow-up

After this PR merges:

1. reconcile `main`;
2. discard the rehearsal physical run;
3. build and preserve a fresh exact post-merge Concord wheel;
4. record its final commit, size, and SHA-256;
5. rerun installed #70 starter-workflow acceptance against those exact wheel bytes;
6. run a fresh physical `prepare` using the same Concord/Core wheel bytes;
7. print, mark, inspect, scan, and resume the six-packet owner-only physical acceptance.

Issue #70 remains open until the physical owner gate is completed.
