### PR TITLE
release: qualify Concord v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## 0.3.0 - 2026-08-31
+
 ### Added
 
 - Concord now exposes structural readiness through the same Core v1

--- a/RELEASE_NOTES_v0.3.0.md
+++ b/RELEASE_NOTES_v0.3.0.md
@@ -1,0 +1,106 @@
+# Concord v0.3.0
+
+Release date: 2026-08-31
+
+Concord v0.3.0 adds teacher-approved group planning, reusable classroom
+materials, guided Activity setup, task-oriented teacher navigation, and
+privacy-minimal suite operations while preserving Concord's paper-first,
+human-reviewed evidence model.
+
+## Highlights
+
+- Teacher-controlled `GroupPlan` workflows now support manual, arrangement CSV,
+  deterministic seeded-random, and Core `grouping_signal_set_v1`-backed
+  strategies.
+- GroupPlan preview and approval remain planning state. Only explicit application
+  creates fresh canonical `Group` and `GroupMembership` records.
+- Missing grouping signals use explicit teacher dispositions and never become a
+  low band, low Score, learner-facing label, or canonical Group attribute.
+- Workspace-level immutable Template and Packet libraries provide reusable
+  definitions and versions without copying operational Activity state.
+- A package-owned library of 30 declarative starter Templates supports common
+  collaborative classroom workflows.
+- Activity-specific Packet instantiation creates fresh PacketInstance, Artifact,
+  ArtifactPage, and Core PDS2 route identities.
+- Safe Activity copying uses a positive allowlist and creates a fresh draft
+  Activity plus first Session without copying Groups, evidence, Scores, or
+  operational history.
+- Reusable Role, Responsibility, Criterion Set, and Scoring Scale presets
+  materialize fresh Activity-native state; presets do not contain assignments or
+  Scores.
+- Guided Activity creation/setup and the task-oriented
+  `Plan -> Prepare -> Collect -> Review -> Score -> Share` interface compose the
+  existing authoritative workflows while keeping record-level tools available
+  under Advanced.
+- Read-only Activity attention and structural readiness are exposed through
+  Core 0.6.3's neutral `paper_data_suite.module_operations` contract.
+- The installed package continues to expose Concord's console, routing-module,
+  publication-producer, and module-operations entry points without any sibling
+  PDS runtime dependency.
+
+## Architecture and privacy qualification
+
+Issue #71's pre-release audit reports:
+
+```text
+11 ADRs: CONFORMS
+4 ADRs: CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.3.0
+0 ADR blockers
+
+architecture: CONFORMS — 0 blockers
+privacy: CONFORMS — 0 blockers
+usability: CONFORMS — 0 blockers
+interoperability: CONFORMS — 0 blockers
+```
+
+The four bounded ADR deferrals are future optional surfaces: Work
+Items/tasks/contributions, broader external-reference authoring, teacher-facing
+ScoreForm/Quillan link management, and optional Activity markers/events/work
+items/contributions.
+
+Concord still does not calculate Grades, universal proficiency, reassessment
+selection, or reporting policy.
+
+## Physical starter-workflow qualification
+
+The v0.3.0 physical path is inherited from the completed issue #70 acceptance
+against source commit:
+
+```text
+33bd916978da21f4a317a1509adc77981a25aa26
+```
+
+That acceptance used six representative packets / ten physical pages across
+seminar, signal-backed group-project, and peer-review starter families through
+real print, physical marking, real scan, Core retained-source custody/dispatch,
+Concord Artifact assembly, explicit Review, explicit Score, Academic Work
+registration, publication, and public result readback.
+
+Issue #71 intentionally does not repeat the physical run. The release-preparation
+delta through the version promotion consists of release validators/tests,
+documentation, and package version metadata; it does not change Template assets,
+Packet rendering, PDS2 allocation, scan intake, Artifact assembly, Review, Score,
+or publication behavior.
+
+## Compatibility
+
+- Python: `>=3.11`
+- Core: `pds-core>=0.6.3,<0.7`
+- Qualified Core release: `pds-core 0.6.3`
+- No runtime dependency on Paper Data Suite shell, ScoreForm, Quillan, Meridian,
+  Portia, or Vitrine.
+
+## Distribution
+
+The release process produces and authenticates exactly:
+
+```text
+pds_concord-0.3.0-py3-none-any.whl
+pds_concord-0.3.0.tar.gz
+SHA256SUMS.txt
+```
+
+The authoritative hashes are recorded only after the release-preparation PR is
+merged and the exact clean `main` commit is qualified. Concord is distributed
+through the GitHub Release for `v0.3.0`; this release does not publish to PyPI or
+another package index.

--- a/concord/_version.py
+++ b/concord/_version.py
@@ -1,3 +1,3 @@
 """Authoritative Concord package version."""
 
-__version__ = "0.3.0.dev0"
+__version__ = "0.3.0"

--- a/docs/README.md
+++ b/docs/README.md
@@ -406,9 +406,21 @@ before/after results.
 Documents issue #70's single-environment installed qualification for seminar,
 signal-backed group-project, and peer-review starter workflows; exact Core 0.6.3
 baseline; GroupPlan-to-canonical-state boundary; paper/PDS2/retained-scan path;
-grouping-signal privacy sentinel; owner-only all-three-family real-paper sample; physical
-hardware/settings provenance; raw-evidence retention prohibition; and the
-post-merge `PENDING OWNER` gate before #71.
+grouping-signal privacy sentinel; owner-executed all-three-family real-paper sample;
+physical hardware/settings provenance; raw-evidence retention prohibition; and the
+completed owner PASS that now serves as #71's authoritative physical-path evidence.
+
+
+### v0.3.0 architecture, privacy, usability, interoperability, and release audit
+
+[`v0.3.0-release-audit.md`](v0.3.0-release-audit.md)
+
+Tracks issue #71's source-grounded final milestone audit, exact Core 0.6.3
+qualification baseline, architecture/privacy/usability/interoperability evidence,
+carry-forward of the completed #70 physical acceptance without a redundant
+physical rerun, release-artifact gates, and the deliberately unrecorded final
+release verdict until exact post-merge artifacts and fresh-download verification
+are complete.
 
 
 ### Future v0.3.0 Group Planning / Template / Packet plan

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -1,63 +1,88 @@
-# Concord v0.2.0 release checklist
+# Concord v0.3.0 release checklist
 
-The qualification Core artifact is
-`pds_core-0.6.0-py3-none-any.whl`, SHA-256
-`be28c061b38463ef59ebc328ed1aa443767fe7f2c626babb769c2d8e5932f308`.
+The qualification Core artifact is:
+
+```text
+pds_core-0.6.3-py3-none-any.whl
+SHA-256:
+98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5
+```
+
 No phase publishes to PyPI or another package index.
 
 ## Phase A — release-preparation branch and PR
 
-- [x] start from reconciled post-#33 `main`
-- [x] authenticate the exact Core 0.6.0 wheel
-- [x] record the clean pre-edit authoritative baseline
-- [x] audit all 15 ADRs and the #22 exit conditions
-- [x] freeze consumer-facing contracts and promote source version to `0.2.0`
-- [x] add compatibility and exact wheel+sdist release validators
-- [ ] focused issue #34 tests pass
-- [ ] authoritative validator passes with `--allow-dirty`
-- [ ] release-preparation diff receives independent review
+- [x] start from reconciled post-#70 / post-#98 `main` at
+      `33bd916978da21f4a317a1509adc77981a25aa26`
+- [x] authenticate the exact released Core 0.6.3 wheel
+- [x] record the clean pre-edit authoritative baseline validator PASS
+- [x] audit all 15 ADRs
+- [x] audit architecture, grouping-signal privacy, reusable/instance boundaries,
+      teacher usability, and installed/suite interoperability
+- [x] inherit issue #70 physical acceptance without a redundant #71 physical run
+- [x] harden release validators for module operations and the exact direct runtime
+      dependency set
+- [x] promote source and active qualification surfaces from `0.3.0.dev0` to
+      `0.3.0`
+- [x] roll the changelog and add `RELEASE_NOTES_v0.3.0.md`
+- [x] focused issue #71 release-preparation tests pass
+- [x] authoritative validator passes with `--allow-dirty`
+- [x] physical qualification delta audit confirms no behavior-changing change to
+      the #70-qualified print/PDS2/scan/Artifact/Review/Score/publication path
+- [ ] complete release-preparation diff receives independent review
 - [ ] hosted Ubuntu/Windows, Python 3.11–3.14 CI passes
-- [ ] PR is squash-merged
+- [ ] release-preparation PR is squash-merged
 
-Tagging, release publication, authoritative hashes, and download verification
-cannot be completed on the release-preparation branch.
+Tagging, final artifact hashes, GitHub Release publication, and fresh-download
+verification cannot be completed on the release-preparation branch.
 
 ## Phase B — post-merge exact-main qualification
 
 - [ ] reconcile local `main` and require `main == origin/main`
 - [ ] require a clean tree and record the exact merged commit
 - [ ] rerun the authoritative validator without `--allow-dirty`
-- [ ] build exactly `pds_concord-0.2.0-py3-none-any.whl` and
-  `pds_concord-0.2.0.tar.gz` from that commit
-- [ ] pass Twine, ordinary wheel validation, release artifact validation,
-  installed smoke, and #33 producer acceptance
+- [ ] build exactly `pds_concord-0.3.0-py3-none-any.whl` and
+      `pds_concord-0.3.0.tar.gz` from that commit
+- [ ] pass Twine, ordinary wheel validation, release artifact validation, release
+      compatibility, installed base smoke, installed shared-feature/starter
+      smoke, and installed module-operations smoke
+- [ ] confirm the exact wheel resolves Concord/Core from isolated `site-packages`
+      with `pip check` clean and no sibling PDS distribution required
+- [ ] complete the final physical-delta review against issue #70
 - [ ] compute `SHA256SUMS.txt` from these exact final artifacts
-- [ ] independently review the commit, filenames, and hashes
+- [ ] independently review the commit, filenames, byte lengths, and hashes
 
-Expected final assets are:
+Expected final assets:
 
 ```text
-pds_concord-0.2.0-py3-none-any.whl
-pds_concord-0.2.0.tar.gz
+pds_concord-0.3.0-py3-none-any.whl
+pds_concord-0.3.0.tar.gz
 SHA256SUMS.txt
 ```
 
 ## Phase C — tag and GitHub Release publication
 
-- [ ] create annotated or accepted project tag `v0.2.0` at the exact qualified commit
+- [ ] create tag `v0.3.0` at the exact qualified commit
 - [ ] push the tag without rewriting an existing tag
-- [ ] create the GitHub Release from `v0.2.0` using `RELEASE_NOTES_v0.2.0.md`
+- [ ] create the GitHub Release from `v0.3.0` using
+      `RELEASE_NOTES_v0.3.0.md`
 - [ ] upload the exact wheel, sdist, and `SHA256SUMS.txt`
-- [ ] verify uploaded asset hashes match Phase B
+- [ ] verify uploaded asset byte lengths and SHA-256 values match Phase B
 - [ ] do not publish to a package index
 
 ## Phase D — post-release fresh-download verification
 
-- [ ] download Core 0.6.0 and Concord 0.2.0 assets into a fresh directory
+- [ ] download Core 0.6.3 and Concord 0.3.0 assets into a fresh external directory
 - [ ] authenticate both wheels and the published Concord checksum file
 - [ ] install noneditably into a fresh virtual environment outside the checkout
-- [ ] run `pip check`, installed metadata/version/CLI checks, routing and
-  publication discovery, public reader import, and Artifact-boundary import
-- [ ] rerun the bounded installed smoke and #33 lifecycle when practical
-- [ ] record Meridian #23 handoff identities
-- [ ] only then close issue #34, umbrella #22, and the milestone
+- [ ] run `pip check`
+- [ ] verify installed metadata, version, and `concord --version`
+- [ ] verify Core discovery of Concord routing-module, publication-producer, and
+      module-operations providers
+- [ ] rerun bounded installed base and representative starter-workflow acceptance
+- [ ] rerun installed readiness/attention/module-operations acceptance
+- [ ] record issue #70 physical qualification as inherited PASS; do not perform a
+      new physical print/mark/scan run for issue #71
+- [ ] record final artifact names, byte lengths, hashes, release URL/status, and
+      fresh-download PASS in issue #71
+- [ ] only then close issue #71, umbrella #47, and the v0.3.0 milestone

--- a/docs/v0.3.0-release-audit.md
+++ b/docs/v0.3.0-release-audit.md
@@ -1,0 +1,796 @@
+# Concord v0.3.0 architecture, privacy, usability, interoperability, and release audit
+
+**Issue:** #71 — Conduct the v0.3.0 architecture, privacy, usability, and release audit  
+**Umbrella:** #47 — v0.3.0 Group Planning, Templates, Packets, and Guided Setup  
+**Status:** IN PROGRESS — release-preparation audit; no release verdict yet  
+**Starting source commit:** `33bd916978da21f4a317a1509adc77981a25aa26`  
+**Starting package version:** `pds-concord 0.3.0.dev0`  
+**Required Core range:** `pds-core>=0.6.3,<0.7`
+
+## 1. Purpose
+
+Issue #71 is the final v0.3.0 audit and release gate. It audits the implementation
+already accepted through the milestone, resolves genuine release blockers, prepares
+the final `0.3.0` source release, qualifies the exact post-merge artifacts against
+released Core 0.6.3, publishes the authenticated GitHub Release, and verifies fresh
+downloads.
+
+This is an audit and release issue, not a new feature-design issue.
+
+The working rule is:
+
+```text
+accepted v0.3.0 behavior
+    -> audit against architecture/privacy/usability/interoperability contracts
+    -> fix only genuine blockers
+    -> promote 0.3.0.dev0 to 0.3.0
+    -> merge release preparation
+    -> qualify exact post-merge wheel + sdist
+    -> publish exact authenticated assets
+    -> fresh-download verification
+```
+
+A desirable capability that is not required by the accepted milestone remains
+follow-up work.
+
+## 2. Qualification baseline
+
+The release audit begins from the reconciled post-#70/post-#98 baseline:
+
+```text
+Concord source commit:
+33bd916978da21f4a317a1509adc77981a25aa26
+
+Concord development version:
+0.3.0.dev0
+
+Python:
+>=3.11
+
+Core dependency:
+pds-core>=0.6.3,<0.7
+
+released Core qualification wheel:
+pds_core-0.6.3-py3-none-any.whl
+
+released Core wheel SHA-256:
+98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5
+```
+
+The exact clean-start authoritative repository-validator result for the starting
+commit is a release-audit evidence item and must be recorded before the final
+release verdict. If that evidence is collected after release-audit edits have
+begun, it must be run from an isolated clean checkout/worktree pinned to the
+starting commit above; a dirty working tree is not a substitute.
+
+### 2.1 Clean starting-commit qualification evidence
+
+The required clean-start validation has been completed against the exact starting
+commit in a detached temporary worktree, without using the dirty #71 working tree.
+
+```text
+source commit:
+33bd916978da21f4a317a1509adc77981a25aa26
+
+Core wheel:
+pds_core-0.6.3-py3-none-any.whl
+
+Core wheel SHA-256:
+98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5
+
+owner qualification Python:
+3.11.9
+
+owner qualification platform:
+Windows
+
+authoritative repository validator:
+PASS
+
+total validation time:
+540.941s
+```
+
+The clean baseline validator passed Core wheel authentication, Core grouping
+fixtures, `pip check`, source-copy package build, full pytest, Ruff, Mypy,
+documentation validation, release compatibility, Twine, package-content and
+release-artifact checks, installed base-wheel smoke, installed shared-feature
+smoke including all three #70 starter workflows, installed module-operations
+smoke, and `git diff --check`.
+
+Representative installed timings from that run:
+
+```text
+base installed-wheel smoke:
+46.218s
+
+shared feature / starter-workflow installed smoke:
+156.890s
+
+module-operations installed smoke:
+25.489s
+```
+
+This closes the clean-start baseline evidence gate. Final exact-`0.3.0` artifact
+qualification remains a separate post-merge release gate.
+
+
+## 3. Authority order
+
+The audit uses this authority order:
+
+1. accepted Architecture Decision Records;
+2. accepted conceptual contracts;
+3. implemented public Core 0.6.3 contracts for shared authority;
+4. merged Concord implementation and public service boundaries;
+5. repository-local and installed-distribution acceptance tests;
+6. issue #70 physical acceptance as the authoritative physical-path evidence;
+7. implementation documentation as an evidence map, not as a substitute for code.
+
+The original #48 reusable-versus-instance classification remains normative unless
+a later accepted implementation deliberately refines it.
+
+## 4. Issue #70 physical qualification is carried forward
+
+Issue #71 must not perform a second physical print/mark/scan acceptance run merely
+because the package version is promoted from `0.3.0.dev0` to `0.3.0`.
+
+The accepted #70 physical evidence is:
+
+```text
+qualified source commit:
+33bd916978da21f4a317a1509adc77981a25aa26
+
+qualified Concord wheel:
+pds_concord-0.3.0.dev0-py3-none-any.whl
+
+Concord wheel byte length:
+576723
+
+Concord wheel SHA-256:
+94b9b2ef1b65a256b079cd71fb1ce09c83a677e42a41bbdc09c22f52b1514dbe
+
+Core wheel:
+pds_core-0.6.3-py3-none-any.whl
+
+Core wheel SHA-256:
+98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5
+
+physical sample:
+6 packets
+10 physical pages
+
+physical scan:
+issue70-physical-scan.pdf
+
+physical scan SHA-256:
+804bfee0c1df02788fd992784a032b8271c13c7a51746ae1eb1beab1cbbe25aa
+```
+
+The accepted sample covered seminar, signal-backed group-project, and peer-review
+starter workflows through real printing, physical marking, real scanning, Core
+retained-source custody/dispatch, Concord Artifact return, explicit review,
+explicit scoring, publication, and public result readback.
+
+The #70 result remains authoritative for the v0.3.0 physical path unless #71
+introduces or accepts a behavior-changing modification that touches or invalidates
+that qualified path. Release-validation, documentation, version metadata, release
+notes, checksum-generation, and publication-process changes do not by themselves
+invalidate the physical evidence.
+
+## 5. Architecture audit ledger
+
+### 5.0 ADR conformance results
+
+The v0.2.0 release audit established a conforming baseline for all fifteen ADRs.
+The v0.3.0 audit therefore checks the newly implemented Group Planning, reusable
+Template/Packet, Activity-copy, preset, guided-setup, attention, module-operations,
+and installed/physical acceptance surfaces for regression against those decisions.
+
+| ADR | v0.3.0 implementation evidence | Result | Remaining deliberately deferred surface |
+| --- | --- | --- | --- |
+| 0001 — Concord Module Boundaries | Concord continues to own native collaboration/evidence/planning/reuse state while Core owns workspace/class/roster/PDS2/scan-retention/publication/module-operations/grouping-signal interchange. `pds_module.py`, `pds_publication.py`, `pds_operations.py`, #69 Group Planning acceptance, #68 suite qualification, and release/package validators preserve the public boundary and reject sibling runtime dependencies. | CONFORMS | None required by v0.3.0. Downstream Grade/reporting policy remains outside Concord by design. |
+| 0002 — Paper-First, Human-Reviewed Evidence | The #70 installed starter workflows and accepted physical sample preserve real printable PDFs/PDS2 return, Core-retained scan custody/dispatch, Concord Artifact assembly, then explicit Review and explicit Score. Scan return still does not infer judgment. | CONFORMS | Automated handwriting/behavior interpretation remains prohibited rather than deferred release scope. |
+| 0003 — Activities Require Explicit Sessions | Guided creation still creates an Activity with a first explicit Session; Activity copying creates a fresh first Session rather than cloning source Session history. Existing Session lifecycle tests remain green. | CONFORMS | None. |
+| 0004 — Contextual Groups, Memberships, and Roles | #69 acceptance proves `GroupPlan != Group != GroupMembership`: draft/preview/approval/application-preview preserve zero canonical Group writes; explicit application creates fresh canonical Groups/Memberships; direct Group workflows remain valid without GroupPlan; planning-only fields and signal provenance do not enter canonical Group/Membership state. | CONFORMS | None. The v0.2.0 Group Planning deferral is retired in v0.3.0. |
+| 0005 — Separate Artifact Authors and Subjects | Existing author/subject graph invariants remain unchanged. v0.3.0 Packet audience and Group targets allocate route/Artifact identities without collapsing route target, Artifact Subject, Author, Membership, or Score target. #70 exercises participant- and Group-target packets through real return/scoring/publication. | CONFORMS | None. |
+| 0006 — Distinguish Roles, Responsibilities, Tasks, and Contributions | Native Role and Responsibility assignments remain separate contextual records. Reusable Role/Responsibility presets contain no assignee state and materialize fresh assignments only after explicit application; neither preset application nor assignment creates authorship or Score state. | CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.3.0 | Work Items/task dependencies and Contribution claims remain future optional surfaces. |
+| 0007 — Preserve Source Evidence and History | Core-retained source references and Concord snapshot/history rules remain intact. Template/Packet definitions use immutable version records; Activity copying creates fresh target state without source operational history; #70 preserves retained-source identity through physical return, explicit judgment, manifest revision, and Publication Record creation. | CONFORMS | None. |
+| 0008 — Separate Review, Moderation, Scoring, Grading, and Reporting | v0.3.0 guided/task-oriented surfaces still call distinct Review/Moderation/Score/publication services. Reusable Criterion/Scale presets materialize configuration, not Scores. #70 proves return -> explicit Review -> explicit Score -> explicit publication ordering. Concord still calculates no Grade/proficiency/reporting policy. | CONFORMS | Grade/proficiency/reporting/selection policy remains downstream by design. |
+| 0009 — Many-to-Many Evidence-to-Score Relationships | Existing durable ScoreEvidenceLink semantics remain unchanged and continue to separate Evidence Reference, Artifact Subject, and Score target. New Packet/Group planning workflows do not introduce a shortcut from Membership, route target, or signal input to Score evidence/target state. | CONFORMS | None. |
+| 0010 — Exceptional Evidence States Are Not Low Scores | Existing non-score dispositions remain distinct from scored values. v0.3.0 additionally preserves `missing signal != lowest band` and `missing signal != low Score`; missing-signal disposition is explicit GroupPlan state and #69/#70 privacy acceptance proves grouping signals do not derive Scores. | CONFORMS | Downstream aggregation policy remains outside Concord. |
+| 0011 — Link External Artifacts Without Managing Source Systems | Concord still stores neutral owning-system references rather than controlling external systems. Activity copy explicitly excludes source external-reference history, preventing reuse from becoming source-system management or accidental historical cloning. | CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.3.0 | Broader Attachment/External Reference authoring and source-system integrations remain future work. |
+| 0012 — Link ScoreForm and Quillan Without Duplication | The package still has no sibling PDS runtime dependency/import. Core-owned neutral contracts/publications remain the interoperability route. v0.3.0 extends the same rule to Meridian-derived grouping signals: Concord consumes Core's neutral signal contract and never imports Meridian. | CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.3.0 | Teacher-facing ScoreForm/Quillan link-management workflows remain future work. |
+| 0013 — Keep Activity-Specific Structures Optional | Guided setup derives status from canonical state and treats unused surfaces as optional. Groups/GroupPlans, Roles/Responsibilities, reusable Templates/Packets, PacketInstances, Criteria/Scales, Review/Moderation, and Scores remain present only when selected/created. Template/Packet functionality is now implemented without becoming a mandatory Activity prerequisite. | CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.3.0 | Optional Activity Markers, Work Items, Events, and Contributions remain future surfaces. |
+| 0014 — Make Standards-Based Scoring the Primary Concord Scoring Model | Standards-backed Score semantics remain unchanged. Reusable Criterion/Scale presets materialize fresh Activity-native scoring configuration and local criteria remain explicitly local. Grouping signals remain planning-only and cannot become Score values or proficiency judgments. | CONFORMS | Concord still does not map native scales to universal proficiency. |
+| 0015 — Publish Versioned Concord Academic Result Manifests Through the Core Registry | Explicit Academic Work registration, manifest generation, Core Publication Record creation, and public readback remain the only release path. #70 exercises all three representative v0.3.0 starter families through explicit publication from installed wheels. Module-operations attention/readiness does not become a publication authority. | CONFORMS | Meridian/downstream projection and consumer selection/reporting policy remain outside Concord. |
+
+ADR summary:
+
+```text
+11 CONFORMS
+4 CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.3.0
+0 BLOCKERS
+```
+
+The four deferred results do not represent missing v0.3.0 exit conditions. They
+are conceptual future surfaces that remain optional or downstream under the
+accepted architecture. No ADR requires runtime/domain remediation before the
+v0.3.0 release based on the current audit evidence.
+
+### 5.1 Core authority remains shared authority
+
+Concord must continue to use public Core authority for:
+
+- workspace conventions;
+- classes and rosters;
+- standards;
+- Academic Periods;
+- PDS2 identities and routing;
+- retained source scans and owner dispatch;
+- Academic Work Registration;
+- Publication Records and registry audit;
+- module discovery / module operations; and
+- neutral `grouping_signal_set_v1` interchange.
+
+Concord must not grow a second scanner/router, PDS2 authority, publication registry,
+class/roster authority, or grouping-signal exchange.
+
+### 5.2 Planning state remains distinct from canonical collaboration state
+
+The release invariant is:
+
+```text
+GroupPlan != Group != GroupMembership
+```
+
+Manual, arrangement-import, seeded-random, signal-backed, and missing-signal paths
+may create or revise planning state. Proposal creation, preview, approval, and
+application preview remain non-canonical. Only explicit application creates fresh
+canonical Group and GroupMembership identities.
+
+Repository evidence includes:
+
+```text
+tests/test_group_planning_acceptance_issue69.py
+tests/test_group_plan_application_prepare_issue56.py
+tests/test_group_plan_application_apply_issue56.py
+tests/test_group_plan_application_privacy_issue56.py
+```
+
+### 5.3 Reusable definitions remain distinct from runtime instances
+
+The reusable/instance boundary remains:
+
+```text
+TemplateDefinition != TemplateVersion
+PacketDefinition != PacketVersion
+PacketVersion != PacketInstance
+PacketInstance != ArtifactInstance
+ArtifactInstance != ArtifactPage
+```
+
+Reusable Template/Packet definitions and immutable versions live under workspace
+shared authority. Selecting or copying them must produce fresh Activity-specific
+Packet, Artifact, ArtifactPage, and Core route identities.
+
+Activity copying remains a positive allowlist of reusable configuration, not a clone
+of Activity history.
+
+Reusable presets remain definitions/defaults:
+
+```text
+Role preset != RoleAssignment
+Responsibility preset != ResponsibilityAssignment
+Score != reusable configuration
+```
+
+Applying presets materializes fresh Activity-native state and does not copy Scores.
+
+Repository evidence includes:
+
+```text
+tests/test_template_definition_contract_issue57.py
+tests/test_template_storage_issue58.py
+tests/test_packet_definition_contract_issue59.py
+tests/test_packet_storage_issue60.py
+tests/test_packet_instance_contract_issue62.py
+tests/test_packet_instantiation_commit_issue62.py
+tests/test_activity_copying_issue63.py
+tests/test_reusable_presets_issue64.py
+```
+
+### 5.4 Evidence, judgment, and publication remain separate
+
+Paper return and Artifact assembly are evidence-state transitions. They must not
+infer teacher judgment.
+
+The invariant remains:
+
+```text
+scan return != Artifact Review
+Artifact Review != Moderation
+Moderation != Score
+Score != Grade
+Score != publication
+publication != downstream ingestion
+```
+
+Academic Work registration, manifest generation, and publication are explicit
+operations. Public result readback consumes published Concord result manifests;
+it does not become a second scoring authority.
+
+## 6. Privacy audit ledger
+
+### 6.1 Grouping signals are planning-only
+
+Grouping-signal values may influence GroupPlan generation, but signal-set identity,
+selected dimension/band semantics, source snapshot identity/digest, canonical
+signal digest, and strategy rationale are planning provenance.
+
+They must not become:
+
+- canonical Group or GroupMembership metadata;
+- learner-facing labels;
+- printable Template/Packet content;
+- PDS2 route payload;
+- Artifact return state;
+- Review/Moderation state;
+- Score state;
+- Academic Result Manifest content;
+- Publication Record content; or
+- public result-reader output.
+
+The #69 repository-local acceptance and #70 installed/physical project case provide
+the milestone evidence for this boundary.
+
+### 6.2 Missing signal is not a low score or low band
+
+The accepted invariant remains:
+
+```text
+missing signal != lowest band
+missing signal != low Score
+```
+
+Missing-signal disposition is explicit teacher-controlled planning state.
+
+### 6.3 No sibling runtime dependency
+
+Concord may consume shared Core contracts and neutral producer-owned references,
+but the installed package must not require ScoreForm, Quillan, Portia, Meridian,
+Vitrine, or the suite shell as runtime dependencies.
+
+Synthetic provenance may name another module without importing or dispatching it.
+
+### 6.4 No real student data in release qualification
+
+Repository, installed-wheel, physical carry-forward, and post-release verification
+use synthetic classroom identities and synthetic evidence only. Generated physical
+evidence and retained scans are local qualification artifacts and are not committed.
+
+## 7. Teacher-workflow and usability audit ledger
+
+The v0.3.0 teacher surface intentionally does not require the teacher to understand
+the internal record graph.
+
+The guided setup and task-oriented model is:
+
+```text
+Create Classroom Activity
+    -> inspect/complete bounded setup
+
+opened Activity
+    -> Plan
+    -> Prepare
+    -> Collect
+    -> Review
+    -> Score
+    -> Share
+```
+
+The accepted usability constraints include:
+
+- bounded, low-information-density screens;
+- explicit preview/review before destructive or identity-creating transitions;
+- explicit confirmation for GroupPlan application;
+- explicit packet generation;
+- explicit Review and Score entry;
+- explicit publication;
+- an Advanced escape hatch rather than exposing the full record graph by default;
+- direct noninteractive CLI preservation for automation and qualification.
+
+Attention and readiness remain different questions:
+
+```text
+attention != readiness
+```
+
+Attention identifies what teacher action is useful next. Readiness asks whether
+Concord can structurally operate in the exact supplied workspace/class context.
+
+Repository evidence includes:
+
+```text
+tests/test_guided_activity_setup_issue65.py
+tests/test_guided_activity_qualification_issue65.py
+tests/test_task_oriented_activity_menu_issue66.py
+tests/test_activity_attention_issue67.py
+tests/test_attention_qualification_issue67.py
+tests/test_readiness_provider_issue68.py
+tests/test_suite_qualification_issue68.py
+```
+
+## 7.1 Usability audit result
+
+Result:
+
+```text
+TEACHER USABILITY: CONFORMS
+RELEASE BLOCKERS: 0
+```
+
+The v0.3.0 teacher surface is a composition layer over existing authoritative
+Concord services, not a second state machine.
+
+Concrete evidence:
+
+- guided Activity creation uses the existing Activity/Session workflow and writes
+  nothing when confirmation is cancelled;
+- guided setup status is derived from canonical current records rather than
+  persisted wizard state;
+- native IDs/revisions remain hidden from routine teacher screens;
+- the opened-Activity surface is organized as
+  `Plan -> Prepare -> Collect -> Review -> Score -> Share`;
+- Plan exposes setup/configuration and explicitly excludes Score recording;
+- Prepare presents bounded material tasks rather than PacketInstance/route/hash
+  internals;
+- Collect remains evidence-return/assembly/attribution work and does not perform
+  Review;
+- Review and Score remain separate task surfaces;
+- Share remains explicit publication work;
+- the pre-v0.3 exact record-oriented menu remains available under Advanced rather
+  than being removed; and
+- read-only summaries do not commit/render/create hidden domain state.
+
+Representative repository evidence:
+
+```text
+tests/test_guided_activity_setup_issue65.py
+tests/test_guided_activity_qualification_issue65.py
+tests/test_task_oriented_activity_menu_issue66.py
+tests/test_activity_attention_issue67.py
+tests/test_attention_qualification_issue67.py
+```
+
+No teacher-facing release blocker was found.
+
+## 7.2 Attention/privacy audit result
+
+Result:
+
+```text
+ATTENTION / NEXT ACTIONS: CONFORMS
+PRIVACY BLOCKERS: 0
+```
+
+Attention is derived, bounded, and read-only. It is not a persisted task system
+and it is not structural readiness.
+
+The accepted invariant remains:
+
+```text
+attention != readiness
+```
+
+Attention tests prove, among other things, that:
+
+- absent optional GroupPlan state does not manufacture a task;
+- explicit `leave_unassigned` missing-signal disposition does not create false
+  placement attention;
+- signal-set digests and student identifiers do not appear in attention output;
+- Packet target keys, generated output paths, output hashes, PacketInstance IDs,
+  and generation IDs do not appear in teacher attention summaries;
+- completed/cancelled/archived state does not produce stale planning attention;
+- next-action priority remains the teacher-task order rather than internal record
+  order; and
+- attention remains separate from readiness even when a class is structurally
+  ready and still has teacher work to do.
+
+No grouping-signal or other private planning information is surfaced through the
+module-operations attention contract.
+
+## 8. Interoperability and installed-package audit ledger
+
+Concord's installed public integration surface includes exactly one provider in
+each accepted family:
+
+```text
+console_scripts
+    concord = concord.cli:main
+
+paper_data_suite.modules
+    concord = concord.pds_module:get_module_profile
+
+paper_data_suite.publication_producers
+    concord = concord.pds_publication:get_publication_producer_profile
+
+paper_data_suite.module_operations
+    concord = concord.pds_operations:get_module_operations_profile
+```
+
+The module-operations profile is one Core v1 provider exposing Concord-owned
+attention/readiness behavior without moving Concord semantics into Core.
+
+The release artifact contract must require the corresponding public modules,
+including:
+
+```text
+concord/pds_module.py
+concord/pds_publication.py
+concord/pds_operations.py
+```
+
+Installed qualification must resolve Concord and Core from the isolated
+environment's `site-packages`, pass `pip check`, and avoid editable/source-checkout
+assumptions.
+
+Repository evidence includes:
+
+```text
+scripts/check_package.py
+scripts/verify_release_artifacts.py
+scripts/verify_release_compatibility.py
+scripts/smoke_test_feature_wheels.py
+scripts/smoke_test_starter_workflows_wheel.py
+tests/test_package_metadata.py
+tests/test_pds_operations_issue68.py
+tests/test_suite_interoperability_issue68.py
+tests/test_installed_starter_workflow_acceptance_issue70.py
+```
+
+## 8.1 Installed/suite interoperability audit result
+
+Result:
+
+```text
+INSTALLED INTEROPERABILITY: CONFORMS
+RELEASE BLOCKERS: 0
+```
+
+Released Core 0.6.3 owns the neutral module-operations contract:
+
+```text
+paper_data_suite.module_operations
+ModuleOperationsRequest
+ModuleReadinessReport
+ModuleAttentionReport
+ModuleOperationsProfile
+```
+
+The Core request is intentionally small and neutral:
+
+```text
+workspace_root
+active_school_year
+class_id
+```
+
+Concord's provider registers one Core-v1 profile and supplies only
+Concord-owned callbacks:
+
+```text
+readiness_provider = evaluate_concord_readiness
+attention_provider = evaluate_concord_attention
+```
+
+This preserves the ownership rule:
+
+```text
+Core owns discovery/invocation/validation
+Concord owns Concord readiness/attention semantics
+```
+
+The installed module-operations smoke proves:
+
+- Core 0.6.3 and the candidate Concord wheel resolve from the isolated
+  environment's `site-packages`;
+- `PYTHONPATH` and user-site shadowing are disabled;
+- `pip check` succeeds before provider evaluation;
+- no `paper-data-suite`, ScoreForm, Quillan, Meridian, Portia, or Vitrine
+  distribution is required in the installed environment;
+- the `concord` console entry point resolves to `concord.cli:main`;
+- Core discovers valid Concord routing-module, publication-producer, and
+  module-operations providers;
+- readiness and attention are both present;
+- one provider-capability failure is isolated from the other capability;
+- both readiness and attention evaluation are read-only, proven by exact
+  workspace fingerprints before/after invocation;
+- attention summaries expose bounded owner-routed actions rather than private
+  learner/planning internals; and
+- unavailable evaluation remains distinguishable from evaluated false/empty
+  state.
+
+Repository evidence:
+
+```text
+concord/pds_operations.py
+tests/test_pds_operations_issue68.py
+tests/test_suite_qualification_issue68.py
+scripts/smoke_test_attention_provider_wheel.py
+docs/v0.3.0-suite-interoperability.md
+```
+
+No suite-shell or sibling module acquires Concord record authority through these
+interfaces, and Concord acquires no sibling runtime dependency.
+
+## 8.2 Release-preparation authoritative qualification
+
+The exact `0.3.0` release-preparation working tree passed the authoritative
+repository validator with the authenticated Core 0.6.3 wheel, `--allow-dirty`,
+and reusable static-analysis caches.
+
+```text
+Core wheel verification:                          0.145s
+Core grouping fixtures:                           0.123s
+pip check:                                        1.500s
+source tree copy:                                 1.451s
+package build:                                   21.881s
+pytest:                                         211.018s
+Ruff:                                             0.140s
+Mypy:                                             0.703s
+documentation validation:                         0.209s
+release compatibility:                            1.402s
+Twine:                                            0.492s
+package content:                                  0.127s
+release artifacts:                                0.186s
+installed-wheel smoke: base:                     46.888s
+installed-wheel smoke: shared feature scenarios:114.992s
+installed-wheel smoke: module operations:        20.507s
+git diff check:                                1,522.206s
+TOTAL:                                         1,947.167s
+```
+
+The built candidate artifacts were exactly:
+
+```text
+pds_concord-0.3.0-py3-none-any.whl
+pds_concord-0.3.0.tar.gz
+```
+
+The installed shared-feature smoke passed all three representative #70 starter
+families at release version `0.3.0`, including seminar, signal-backed group
+project with privacy sentinel intact, and peer review. Installed module
+operations also passed against released Core 0.6.3 with `pip check` clean.
+
+This closes the release-preparation branch qualification gate. It does **not**
+freeze authoritative final artifact hashes: those must be generated from the
+exact clean post-merge `main` commit in Phase B.
+
+## 9. Release-artifact audit ledger
+
+The final source release is not yet qualified while this document has
+`Status: IN PROGRESS`.
+
+Before release, the exact post-merge source must produce exactly:
+
+```text
+pds_concord-0.3.0-py3-none-any.whl
+pds_concord-0.3.0.tar.gz
+SHA256SUMS.txt
+```
+
+The wheel and sdist must agree on:
+
+- distribution name `pds-concord`;
+- version `0.3.0`;
+- `Requires-Python: >=3.11`;
+- Core runtime requirement `pds-core>=0.6.3,<0.7`;
+- absence of sibling PDS runtime dependencies;
+- console, module, publication-producer, and module-operations entry points;
+- intended package-owned starter assets; and
+- no workspace/build/cache/credential leakage.
+
+The exact release wheel and sdist must be frozen and hashed after the
+release-preparation changes are merged. Branch-built artifacts are not final
+release artifacts.
+
+## 10. Current #71 change classification
+
+Release-audit changes must be classified by physical-path impact.
+
+| Change class | Physical #70 evidence |
+| --- | --- |
+| release validator/test hardening | preserved |
+| audit/release documentation | preserved |
+| version metadata only | preserved |
+| changelog/release notes | preserved |
+| checksum/release publication tooling | preserved |
+| runtime behavior outside qualified paper path | evaluate case-by-case |
+| behavior-changing GroupPlan/Packet/PDS2/scan/Artifact/Review/Score/publication change | **presume invalidating until demonstrated otherwise** |
+
+Issue #71 Slice 1 only hardens release-artifact validation for the already-shipped
+module-operations public surface. It does not change runtime/domain or physical
+behavior. This audit-ledger slice is documentation/qualification-only. Therefore
+the accepted #70 physical evidence remains valid at this point.
+
+Slice 3 freezes the exact five direct runtime requirements consistently across
+source compatibility, ordinary wheel, and wheel+sdist release validators. It
+changes release tooling/tests only; no `concord/` module, starter asset,
+rendering, PDS2, scan, Artifact, Review, Score, or publication behavior changes.
+The #70 physical evidence therefore remains valid after Slice 3 as well.
+
+Slice 6 promotes only the authoritative package/release metadata from `0.3.0.dev0` to `0.3.0`, rolls release documentation, and updates qualification assertions to the final version. No Template asset, Packet rendering/instantiation, PDS2 allocation, scan intake, Artifact assembly, Review, Score, or publication implementation changes. The #70 physical qualification therefore remains applicable through release preparation.
+
+The final release-preparation delta review against
+`33bd916978da21f4a317a1509adc77981a25aa26` confirmed that the complete
+`concord/` diff is exactly one release-metadata change:
+
+```diff
+-__version__ = "0.3.0.dev0"
++__version__ = "0.3.0"
+```
+
+There are no changes under `concord/starter_templates/assets/` and no changes to
+Packet rendering/instantiation, PDS2 allocation, scan intake, retained-source
+handling, Artifact assembly, Review, Score, Academic Work registration, manifest
+generation, or publication implementation.
+
+Physical-delta classification:
+
+```text
+BEHAVIOR-CHANGING PHYSICAL-PATH DELTA: NO
+ISSUE #70 PHYSICAL QUALIFICATION: INHERITED PASS
+NEW #71 PHYSICAL PRINT/MARK/SCAN RUN: NOT REQUIRED
+```
+
+
+## 11. Open release gates
+
+No final release verdict is recorded yet. The following remain open until evidence
+is collected:
+
+- [x] authenticate and record the exact clean-start repository-validator result for
+      source commit `33bd916978da21f4a317a1509adc77981a25aa26`;
+- [x] complete architecture/ADR conformance review against merged implementation;
+- [x] complete invariant/privacy review and resolve genuine blockers;
+- [x] complete teacher-workflow/usability review;
+- [x] complete installed interoperability/package review;
+- [x] finish exact `0.3.0` release-contract preparation;
+- [x] promote all authoritative version metadata from `0.3.0.dev0` to `0.3.0`;
+- [x] update release notes/changelog/current documentation without rewriting
+      historical qualification records;
+- [ ] pass focused issue #71 tests;
+- [ ] pass full pytest, Ruff, Mypy, documentation validation, and authoritative
+      repository validation;
+- [ ] review the release-preparation diff and hosted CI;
+- [ ] squash-merge release preparation;
+- [ ] reconcile exact post-merge `main` and require a clean tree;
+- [ ] build one exact final wheel and sdist from that post-merge commit;
+- [ ] run Twine/package/release-artifact/compatibility/installed qualification
+      against authenticated Core 0.6.3;
+- [ ] freeze exact artifact byte lengths and SHA-256 values;
+- [ ] create and verify `SHA256SUMS.txt`;
+- [ ] create tag `v0.3.0` at the exact qualified commit;
+- [ ] publish the authenticated GitHub Release using the exact qualified assets;
+- [ ] download the published assets into a fresh location;
+- [ ] authenticate, install noneditably, run `pip check`, verify discovery, and
+      rerun bounded installed acceptance from the fresh download; and
+- [ ] record the final release verdict and only then close #71 / #47 / milestone.
+
+## 12. Audit status
+
+Current result:
+
+```text
+ARCHITECTURE AUDIT: CONFORMS — 0 BLOCKERS
+PRIVACY AUDIT: CONFORMS — 0 BLOCKERS
+USABILITY AUDIT: CONFORMS — 0 BLOCKERS
+INTEROPERABILITY AUDIT: CONFORMS — 0 BLOCKERS
+RELEASE ARTIFACT AUDIT: RELEASE-PREPARATION QUALIFIED — POST-MERGE FREEZE PENDING
+PHYSICAL PATH: PASS — ISSUE #70 QUALIFICATION INHERITED; NO RERUN REQUIRED
+FINAL RELEASE VERDICT: NOT YET RECORDED
+```
+
+A final `PASS`, qualified limitation, or blocker disposition belongs here only
+after the exact source/artifact/release evidence has been collected.

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -86,6 +86,9 @@ ACTIVITY_ATTENTION_NEXT_ACTIONS_DOC = (
 SUITE_INTEROPERABILITY_DOC = (
     ROOT / "docs" / "v0.3.0-suite-interoperability.md"
 )
+V03_RELEASE_AUDIT_DOC = (
+    ROOT / "docs" / "v0.3.0-release-audit.md"
+)
 REQUIRED_PACKET_INSTANTIATION_RENDERING_PHRASES = (
     'PacketInstance',
     'PacketTargetContext',
@@ -166,6 +169,46 @@ REQUIRED_ACTIVITY_ATTENTION_NEXT_ACTIONS_PHRASES = (
     "scripts/smoke_test_attention_provider_wheel.py",
     "pds-core>=0.6.3,<0.7",
 )
+REQUIRED_V03_RELEASE_AUDIT_PHRASES = (
+    "Status:** IN PROGRESS",
+    "33bd916978da21f4a317a1509adc77981a25aa26",
+    "pds-core>=0.6.3,<0.7",
+    "98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5",
+    "GroupPlan != Group != GroupMembership",
+    "TemplateDefinition != TemplateVersion",
+    "PacketVersion != PacketInstance",
+    "Score != reusable configuration",
+    "scan return != Artifact Review",
+    "missing signal != lowest band",
+    "attention != readiness",
+    "paper_data_suite.module_operations",
+    "0001 — Concord Module Boundaries",
+    "0004 — Contextual Groups, Memberships, and Roles",
+    "0013 — Keep Activity-Specific Structures Optional",
+    "0015 — Publish Versioned Concord Academic Result Manifests "
+    "Through the Core Registry",
+    "11 CONFORMS",
+    "4 CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.3.0",
+    "0 BLOCKERS",
+    "540.941s",
+    "TEACHER USABILITY: CONFORMS",
+    "ATTENTION / NEXT ACTIONS: CONFORMS",
+    "INSTALLED INTEROPERABILITY: CONFORMS",
+    "ARCHITECTURE AUDIT: CONFORMS — 0 BLOCKERS",
+    "PRIVACY AUDIT: CONFORMS — 0 BLOCKERS",
+    "USABILITY AUDIT: CONFORMS — 0 BLOCKERS",
+    "INTEROPERABILITY AUDIT: CONFORMS — 0 BLOCKERS",
+    "RELEASE ARTIFACT AUDIT: RELEASE-PREPARATION QUALIFIED — POST-MERGE FREEZE PENDING",
+    "PHYSICAL PATH: PASS — ISSUE #70 QUALIFICATION INHERITED; NO RERUN REQUIRED",
+    "1,947.167s",
+    "BEHAVIOR-CHANGING PHYSICAL-PATH DELTA: NO",
+    "94b9b2ef1b65a256b079cd71fb1ce09c83a677e42a41bbdc09c22f52b1514dbe",
+    "804bfee0c1df02788fd992784a032b8271c13c7a51746ae1eb1beab1cbbe25aa",
+    "PHYSICAL PATH: PASS — ISSUE #70 QUALIFICATION INHERITED; "
+    "NO RERUN REQUIRED",
+    "FINAL RELEASE VERDICT: NOT YET RECORDED",
+)
+
 REQUIRED_SUITE_INTEROPERABILITY_PHRASES = (
     "readiness != attention",
     "concord_readiness_unavailable",
@@ -887,6 +930,26 @@ def check_documentation() -> None:
             failures.append(
                 "Documentation index does not link the Suite "
                 "interoperability document."
+            )
+
+    if not V03_RELEASE_AUDIT_DOC.is_file():
+        failures.append("Current v0.3.0 release-audit document is missing.")
+    else:
+        release_audit_doc = V03_RELEASE_AUDIT_DOC.read_text(encoding="utf-8")
+        for phrase in REQUIRED_V03_RELEASE_AUDIT_PHRASES:
+            if phrase not in release_audit_doc:
+                failures.append(
+                    "v0.3.0 release-audit document is missing required "
+                    f"boundary wording {phrase!r}."
+                )
+        if "FINAL RELEASE VERDICT: PASS" in release_audit_doc:
+            failures.append(
+                "v0.3.0 release audit must not declare PASS before final "
+                "post-release qualification."
+            )
+        if V03_RELEASE_AUDIT_DOC.name not in docs_index:
+            failures.append(
+                "Documentation index does not link the v0.3.0 release-audit document."
             )
 
     for active_path in (

--- a/scripts/check_package.py
+++ b/scripts/check_package.py
@@ -8,10 +8,17 @@ from email.message import Message
 from email.parser import BytesParser
 from pathlib import Path
 
-from packaging.requirements import Requirement
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
 
-EXPECTED_CORE_REQUIREMENT = Requirement("pds-core>=0.6.3,<0.7")
-EXPECTED_VERSION = "0.3.0.dev0"
+EXPECTED_VERSION = "0.3.0"
+EXPECTED_RUNTIME_REQUIREMENTS = (
+    "pds-core>=0.6.3,<0.7",
+    "Pillow>=11,<13",
+    "qrcode>=8,<9",
+    "pypdfium2>=4.30,<5",
+    "zxing-cpp>=2.3,<3",
+)
 FORBIDDEN_PREFIXES = (
     "tests/",
     "pds_core/",
@@ -83,6 +90,65 @@ def _metadata(archive: zipfile.ZipFile, names: list[str]) -> Message:
     )
 
 
+def validate_runtime_requirements(values: list[str]) -> None:
+    """Require the exact direct runtime dependency set for the release."""
+    requirements: list[Requirement] = []
+    for value in values:
+        try:
+            requirements.append(Requirement(value))
+        except InvalidRequirement as error:
+            raise PackageValidationError(
+                f"Wheel has invalid Requires-Dist: {value}"
+            ) from error
+
+    runtime_requirements = [
+        item
+        for item in requirements
+        if item.marker is None or "extra" not in str(item.marker)
+    ]
+    expected = {
+        canonicalize_name(item.name): item
+        for item in (Requirement(value) for value in EXPECTED_RUNTIME_REQUIREMENTS)
+    }
+    observed: dict[str, Requirement] = {}
+    for item in runtime_requirements:
+        name = canonicalize_name(item.name)
+        if name in observed:
+            raise PackageValidationError(
+                f"Wheel has duplicate direct runtime dependency: {item.name}."
+            )
+        observed[name] = item
+
+    forbidden_runtime = set(observed) & {
+        canonicalize_name(name) for name in FORBIDDEN_RUNTIME_DEPENDENCIES
+    }
+    if forbidden_runtime:
+        raise PackageValidationError(
+            "Sibling PDS runtime dependencies are forbidden: "
+            + ", ".join(sorted(forbidden_runtime))
+        )
+
+    if set(observed) != set(expected):
+        missing = sorted(set(expected) - set(observed))
+        unexpected = sorted(set(observed) - set(expected))
+        raise PackageValidationError(
+            "Direct runtime dependency set changed; "
+            f"missing={missing}, unexpected={unexpected}."
+        )
+
+    for name, wanted in expected.items():
+        actual = observed[name]
+        if (
+            actual.specifier != wanted.specifier
+            or actual.url is not None
+            or actual.marker is not None
+            or actual.extras
+        ):
+            raise PackageValidationError(
+                f"Direct runtime requirement changed for {wanted.name}: {actual}."
+            )
+
+
 def validate_wheel(path: str | Path) -> None:
     """Validate metadata, intended files, and required integration entry points."""
     wheel = Path(path)
@@ -103,21 +169,9 @@ def validate_wheel(path: str | Path) -> None:
         raise PackageValidationError(f"Version must be {EXPECTED_VERSION}.")
     if metadata["Requires-Python"] != ">=3.11":
         raise PackageValidationError("Requires-Python must be >=3.11.")
-    requirements = [Requirement(item) for item in metadata.get_all("Requires-Dist", [])]
-    runtime = [
-        item for item in requirements if item.name == "pds-core" and item.marker is None
-    ]
-    if runtime != [EXPECTED_CORE_REQUIREMENT]:
-        raise PackageValidationError(
-            "Runtime Core requirement must be pds-core>=0.6.3,<0.7."
-        )
-    runtime_names = {item.name for item in requirements if item.marker is None}
-    forbidden_runtime = runtime_names & FORBIDDEN_RUNTIME_DEPENDENCIES
-    if forbidden_runtime:
-        raise PackageValidationError(
-            "Sibling PDS runtime dependencies are forbidden: "
-            + ", ".join(sorted(forbidden_runtime))
-        )
+    validate_runtime_requirements(
+        [str(item) for item in metadata.get_all("Requires-Dist", [])]
+    )
     if "[console_scripts]\nconcord = concord.cli:main" not in entry_points:
         raise PackageValidationError("The concord console script is missing.")
     expected_routing = (

--- a/scripts/smoke_test_attention_provider_wheel.py
+++ b/scripts/smoke_test_attention_provider_wheel.py
@@ -100,7 +100,7 @@ def _smoke_code() -> str:
         )
 
         assert metadata.version("pds-core") == "0.6.3"
-        assert metadata.version("pds-concord") == "0.3.0.dev0"
+        assert metadata.version("pds-concord") == "0.3.0"
 
         env_root = Path(sys.prefix).resolve()
         for package in (concord, pds_core):

--- a/scripts/smoke_test_guided_activity_wheel.py
+++ b/scripts/smoke_test_guided_activity_wheel.py
@@ -65,7 +65,7 @@ def _smoke_code() -> str:
         )
 
         assert metadata.version("pds-core") == "0.6.3"
-        assert metadata.version("pds-concord") == "0.3.0.dev0"
+        assert metadata.version("pds-concord") == "0.3.0"
         assert callable(launch_guided_activity_menu)
         assert callable(launch_guided_continue_setup)
 

--- a/scripts/smoke_test_reusable_presets_wheel.py
+++ b/scripts/smoke_test_reusable_presets_wheel.py
@@ -85,7 +85,7 @@ def _smoke_code() -> str:
         )
 
         assert metadata.version("pds-core") == "0.6.3"
-        assert metadata.version("pds-concord") == "0.3.0.dev0"
+        assert metadata.version("pds-concord") == "0.3.0"
 
         with tempfile.TemporaryDirectory(prefix="concord-presets-installed-") as raw:
             root = ensure_workspace_root(Path(raw) / "workspace")

--- a/scripts/smoke_test_starter_workflows_wheel.py
+++ b/scripts/smoke_test_starter_workflows_wheel.py
@@ -177,7 +177,7 @@ def _smoke_code() -> str:
 
 
         assert metadata.version("pds-core") == "0.6.3"
-        assert metadata.version("pds-concord") == "0.3.0.dev0"
+        assert metadata.version("pds-concord") == "0.3.0"
         require_installed(pds_core, "pds-core")
         require_installed(concord, "pds-concord")
         requirements = tuple(metadata.requires("pds-concord") or ())

--- a/scripts/smoke_test_task_oriented_activity_menu_wheel.py
+++ b/scripts/smoke_test_task_oriented_activity_menu_wheel.py
@@ -62,7 +62,7 @@ def _smoke_code() -> str:
         )
 
         assert metadata.version("pds-core") == "0.6.3"
-        assert metadata.version("pds-concord") == "0.3.0.dev0"
+        assert metadata.version("pds-concord") == "0.3.0"
 
         module_path = Path(concord.__file__).resolve().as_posix().lower()
         assert "site-packages" in module_path, module_path

--- a/scripts/verify_release_artifacts.py
+++ b/scripts/verify_release_artifacts.py
@@ -1,4 +1,4 @@
-"""Validate the current Concord v0.3.0.dev0 development artifacts."""
+"""Validate the Concord v0.3.0 release artifacts."""
 
 from __future__ import annotations
 
@@ -19,17 +19,27 @@ from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 
-RELEASE_VERSION = "0.3.0.dev0"
-EXPECTED_WHEEL = "pds_concord-0.3.0.dev0-py3-none-any.whl"
-EXPECTED_SDIST = "pds_concord-0.3.0.dev0.tar.gz"
-EXPECTED_DIST_INFO = "pds_concord-0.3.0.dev0.dist-info"
+RELEASE_VERSION = "0.3.0"
+EXPECTED_WHEEL = "pds_concord-0.3.0-py3-none-any.whl"
+EXPECTED_SDIST = "pds_concord-0.3.0.tar.gz"
+EXPECTED_DIST_INFO = "pds_concord-0.3.0.dist-info"
 EXPECTED_CORE_SPECIFIER = SpecifierSet(">=0.6.3,<0.7")
 EXPECTED_PYTHON_SPECIFIER = SpecifierSet(">=3.11")
+EXPECTED_RUNTIME_REQUIREMENTS = (
+    "pds-core>=0.6.3,<0.7",
+    "Pillow>=11,<13",
+    "qrcode>=8,<9",
+    "pypdfium2>=4.30,<5",
+    "zxing-cpp>=2.3,<3",
+)
 EXPECTED_ENTRY_POINTS = {
     "console_scripts": {"concord": "concord.cli:main"},
     "paper_data_suite.modules": {"concord": "concord.pds_module:get_module_profile"},
     "paper_data_suite.publication_producers": {
         "concord": "concord.pds_publication:get_publication_producer_profile"
+    },
+    "paper_data_suite.module_operations": {
+        "concord": "concord.pds_operations:get_module_operations_profile"
     },
 }
 REQUIRED_WHEEL_FILES = frozenset(
@@ -38,6 +48,7 @@ REQUIRED_WHEEL_FILES = frozenset(
         "concord/_version.py",
         "concord/pds_contract.py",
         "concord/pds_module.py",
+        "concord/pds_operations.py",
         "concord/pds_publication.py",
         "concord/academic_result_manifest.py",
         "concord/academic_result_reader.py",
@@ -176,22 +187,28 @@ def validate_requirements(values: list[str], label: str) -> None:
             raise ArtifactValidationError(
                 f"{label} has invalid Requires-Dist: {value}"
             ) from error
-    core = [
+
+    runtime_requirements = [
         item
         for item in requirements
-        if canonicalize_name(item.name) == canonicalize_name("pds-core")
+        if item.marker is None or "extra" not in str(item.marker)
     ]
-    if len(core) != 1 or core[0].specifier != EXPECTED_CORE_SPECIFIER:
-        raise ArtifactValidationError(
-            f"{label} must require exactly pds-core>=0.6.3,<0.7"
-        )
-    if core[0].url is not None or core[0].marker is not None or core[0].extras:
-        raise ArtifactValidationError(
-            f"{label} pds-core requirement cannot use URL, marker, or extras"
-        )
+    expected = {
+        canonicalize_name(item.name): item
+        for item in (Requirement(value) for value in EXPECTED_RUNTIME_REQUIREMENTS)
+    }
+    observed: dict[str, Requirement] = {}
+    for item in runtime_requirements:
+        name = canonicalize_name(item.name)
+        if name in observed:
+            raise ArtifactValidationError(
+                f"{label} has duplicate direct runtime dependency: {item.name}"
+            )
+        observed[name] = item
+
     siblings = sorted(
         item.name
-        for item in requirements
+        for item in runtime_requirements
         if canonicalize_name(item.name)
         in {canonicalize_name(name) for name in SIBLING_DISTRIBUTIONS}
     )
@@ -199,6 +216,27 @@ def validate_requirements(values: list[str], label: str) -> None:
         raise ArtifactValidationError(
             f"{label} has sibling runtime dependencies: " + ", ".join(siblings)
         )
+
+    if set(observed) != set(expected):
+        missing = sorted(set(expected) - set(observed))
+        unexpected = sorted(set(observed) - set(expected))
+        raise ArtifactValidationError(
+            f"{label} direct runtime dependency set changed; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+
+    for name, wanted in expected.items():
+        actual = observed[name]
+        if (
+            actual.specifier != wanted.specifier
+            or actual.url is not None
+            or actual.marker is not None
+            or actual.extras
+        ):
+            raise ArtifactValidationError(
+                f"{label} direct runtime requirement changed for "
+                f"{wanted.name}: {actual}"
+            )
 
 
 def validate_package_metadata(text: str, label: str) -> None:
@@ -308,6 +346,7 @@ def validate_sdist_project(text: str, label: str = "sdist") -> None:
     for group in (
         "paper_data_suite.modules",
         "paper_data_suite.publication_producers",
+        "paper_data_suite.module_operations",
     ):
         if entry_points.get(group) != EXPECTED_ENTRY_POINTS[group]:
             raise ArtifactValidationError(

--- a/scripts/verify_release_compatibility.py
+++ b/scripts/verify_release_compatibility.py
@@ -1,4 +1,4 @@
-"""Verify the current Concord development package and frozen public boundary."""
+"""Verify the Concord v0.3.0 release package and frozen public boundary."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Mapping
 
-from packaging.requirements import Requirement
+from packaging.requirements import InvalidRequirement, Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
 
@@ -28,9 +28,16 @@ from concord.pds_contract import (
 from concord.pds_publication import get_publication_producer_profile
 
 ROOT = Path(__file__).resolve().parents[1]
-DEVELOPMENT_VERSION = "0.3.0.dev0"
+RELEASE_VERSION = "0.3.0"
 EXPECTED_CORE_SPECIFIER = SpecifierSet(">=0.6.3,<0.7")
 EXPECTED_PYTHON_SPECIFIER = SpecifierSet(">=3.11")
+EXPECTED_RUNTIME_REQUIREMENTS = (
+    "pds-core>=0.6.3,<0.7",
+    "Pillow>=11,<13",
+    "qrcode>=8,<9",
+    "pypdfium2>=4.30,<5",
+    "zxing-cpp>=2.3,<3",
+)
 EXPECTED_CAPABILITIES = frozenset(
     {"criterion_scores", "moderated_scores", "standards_ratings"}
 )
@@ -65,7 +72,7 @@ SIBLING_IMPORT_ROOTS = frozenset(
 
 
 class ReleaseCompatibilityError(RuntimeError):
-    """Raised when the v0.2.0 release boundary has drifted."""
+    """Raised when the current v0.3.0 release boundary has drifted."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -127,8 +134,8 @@ def validate_release_metadata(project: Mapping[str, object], version: str) -> No
     """Validate release identity and dependency metadata from parsed TOML."""
     if project.get("name") != "pds-concord":
         raise ReleaseCompatibilityError("distribution name must be pds-concord")
-    if version != DEVELOPMENT_VERSION:
-        raise ReleaseCompatibilityError(f"source version must be {DEVELOPMENT_VERSION}")
+    if version != RELEASE_VERSION:
+        raise ReleaseCompatibilityError(f"source version must be {RELEASE_VERSION}")
     if project.get("requires-python") != str(EXPECTED_PYTHON_SPECIFIER):
         raise ReleaseCompatibilityError("Requires-Python must be exactly >=3.11")
     raw_dependencies = project.get("dependencies")
@@ -136,18 +143,28 @@ def validate_release_metadata(project: Mapping[str, object], version: str) -> No
         isinstance(item, str) for item in raw_dependencies
     ):
         raise ReleaseCompatibilityError("project dependencies must be a string list")
-    dependencies = tuple(Requirement(item) for item in raw_dependencies)
-    core = tuple(
-        item
-        for item in dependencies
-        if canonicalize_name(item.name) == canonicalize_name("pds-core")
-    )
-    if len(core) != 1 or core[0].specifier != EXPECTED_CORE_SPECIFIER:
-        raise ReleaseCompatibilityError("Core requirement must be exactly >=0.6.3,<0.7")
-    if core[0].url is not None or core[0].marker is not None or core[0].extras:
-        raise ReleaseCompatibilityError(
-            "Core requirement cannot use URL, marker, or extras"
-        )
+    dependencies: list[Requirement] = []
+    for value in raw_dependencies:
+        try:
+            dependencies.append(Requirement(value))
+        except InvalidRequirement as error:
+            raise ReleaseCompatibilityError(
+                f"project has invalid runtime dependency: {value}"
+            ) from error
+
+    expected = {
+        canonicalize_name(item.name): item
+        for item in (Requirement(value) for value in EXPECTED_RUNTIME_REQUIREMENTS)
+    }
+    observed: dict[str, Requirement] = {}
+    for item in dependencies:
+        name = canonicalize_name(item.name)
+        if name in observed:
+            raise ReleaseCompatibilityError(
+                f"duplicate direct runtime dependency: {item.name}"
+            )
+        observed[name] = item
+
     siblings = sorted(
         item.name
         for item in dependencies
@@ -158,6 +175,26 @@ def validate_release_metadata(project: Mapping[str, object], version: str) -> No
         raise ReleaseCompatibilityError(
             "sibling runtime dependencies are forbidden: " + ", ".join(siblings)
         )
+
+    if set(observed) != set(expected):
+        missing = sorted(set(expected) - set(observed))
+        unexpected = sorted(set(observed) - set(expected))
+        raise ReleaseCompatibilityError(
+            "direct runtime dependency set changed; "
+            f"missing={missing}, unexpected={unexpected}"
+        )
+
+    for name, wanted in expected.items():
+        actual = observed[name]
+        if (
+            actual.specifier != wanted.specifier
+            or actual.url is not None
+            or actual.marker is not None
+            or actual.extras
+        ):
+            raise ReleaseCompatibilityError(
+                f"direct runtime requirement changed for {wanted.name}: {actual}"
+            )
 
 
 def validate_contract_values(values: ReleaseContractValues) -> None:
@@ -344,9 +381,9 @@ def validate_release_compatibility() -> None:
         version_literals.extend(
             source_version_literals(path.read_text(encoding="utf-8"))
         )
-    if version_literals != [DEVELOPMENT_VERSION]:
+    if version_literals != [RELEASE_VERSION]:
         raise ReleaseCompatibilityError(
-            "Concord must have exactly one authoritative 0.3.0.dev0 version literal"
+            "Concord must have exactly one authoritative 0.3.0 release version literal"
         )
     validate_release_metadata(project, version_literals[0])
     validate_sibling_import_isolation()
@@ -400,10 +437,10 @@ def main() -> int:
         KeyError,
         ReleaseCompatibilityError,
     ) as error:
-        print(f"Development compatibility audit failed: {error}")
+        print(f"Release compatibility audit failed: {error}")
         return 1
     print(
-        "Concord v0.3.0.dev0 development compatibility passed: Core >=0.6.3,<0.7; "
+        "Concord v0.3.0 release compatibility passed: Core >=0.6.3,<0.7; "
         "contracts/profile exact; reader consumer-neutral; Artifact gate separate; "
         "sibling and grading/selection policy absent."
     )

--- a/tests/test_group_plan_application_apply_issue56.py
+++ b/tests/test_group_plan_application_apply_issue56.py
@@ -68,7 +68,7 @@ def _provenance(day: int, actor_id: str = "teacher-plan") -> Provenance:
         ),
         timestamp=_clock(day).isoformat(),
         source_kind="manual",
-        application_version="0.3.0.dev0",
+        application_version="0.3.0",
     )
 
 

--- a/tests/test_group_plan_application_contract_issue56.py
+++ b/tests/test_group_plan_application_contract_issue56.py
@@ -44,7 +44,7 @@ def _provenance(day: int) -> Provenance:
             tzinfo=timezone.utc,
         ).isoformat(),
         source_kind="manual",
-        application_version="0.3.0.dev0",
+        application_version="0.3.0",
     )
 
 

--- a/tests/test_group_plan_application_prepare_issue56.py
+++ b/tests/test_group_plan_application_prepare_issue56.py
@@ -63,7 +63,7 @@ def _provenance(day: int = 1) -> Provenance:
         ),
         timestamp=_clock(day).isoformat(),
         source_kind="manual",
-        application_version="0.3.0.dev0",
+        application_version="0.3.0",
     )
 
 

--- a/tests/test_group_plan_application_privacy_issue56.py
+++ b/tests/test_group_plan_application_privacy_issue56.py
@@ -47,7 +47,7 @@ def _provenance() -> Provenance:
             tzinfo=timezone.utc,
         ).isoformat(),
         source_kind="manual",
-        application_version="0.3.0.dev0",
+        application_version="0.3.0",
     )
 
 

--- a/tests/test_group_plan_contract_issue50.py
+++ b/tests/test_group_plan_contract_issue50.py
@@ -64,7 +64,7 @@ def _native_provenance(day: int = 1) -> Provenance:
         ),
         timestamp=_timestamp(day),
         source_kind="manual",
-        application_version="0.3.0.dev0",
+        application_version="0.3.0",
     )
 
 

--- a/tests/test_group_plan_missing_signal_contract_issue55.py
+++ b/tests/test_group_plan_missing_signal_contract_issue55.py
@@ -32,7 +32,7 @@ def _provenance(day: int = 1) -> Provenance:
             tzinfo=timezone.utc,
         ).isoformat(),
         source_kind="manual",
-        application_version="0.3.0.dev0",
+        application_version="0.3.0",
     )
 
 

--- a/tests/test_installed_starter_workflow_acceptance_issue70.py
+++ b/tests/test_installed_starter_workflow_acceptance_issue70.py
@@ -25,7 +25,7 @@ def test_issue70_slice1_seminar_smoke_covers_required_installed_boundaries() -> 
 
     required_fragments = (
         'metadata.version("pds-core") == "0.6.3"',
-        'metadata.version("pds-concord") == "0.3.0.dev0"',
+        'metadata.version("pds-concord") == "0.3.0"',
         "launch_guided_activity_menu(state)",
         'get_starter_template("socratic_seminar")',
         "create_manual_group_plan(",

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -5,6 +5,7 @@ from email.parser import BytesParser
 from pathlib import Path
 
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 from concord import __version__
 from scripts.check_package import validate_wheel
@@ -25,12 +26,25 @@ def test_built_wheel_metadata_and_contents(built_wheel: Path) -> None:
     assert metadata["Name"] == "pds-concord"
     assert metadata["Version"] == __version__
     assert metadata["Requires-Python"] == ">=3.11"
-    runtime = [
-        Requirement(item)
-        for item in metadata.get_all("Requires-Dist", [])
-        if Requirement(item).name == "pds-core" and Requirement(item).marker is None
+    runtime_requirements = [
+        Requirement(item) for item in metadata.get_all("Requires-Dist", [])
     ]
-    assert runtime == [Requirement("pds-core>=0.6.3,<0.7")]
+    runtime = {
+        canonicalize_name(requirement.name): requirement
+        for requirement in runtime_requirements
+        if requirement.marker is None or "extra" not in str(requirement.marker)
+    }
+    expected_runtime = {
+        canonicalize_name(requirement.name): requirement
+        for requirement in (
+            Requirement("pds-core>=0.6.3,<0.7"),
+            Requirement("Pillow>=11,<13"),
+            Requirement("qrcode>=8,<9"),
+            Requirement("pypdfium2>=4.30,<5"),
+            Requirement("zxing-cpp>=2.3,<3"),
+        )
+    }
+    assert runtime == expected_runtime
     assert "concord/py.typed" in names
     assert any(name.endswith(".dist-info/licenses/LICENSE") for name in names)
     assert "[console_scripts]\nconcord = concord.cli:main" in entry_points
@@ -43,6 +57,13 @@ def test_built_wheel_metadata_and_contents(built_wheel: Path) -> None:
     ) in entry_points
     assert entry_points.count(
         "concord = concord.pds_publication:get_publication_producer_profile"
+    ) == 1
+    assert (
+        "[paper_data_suite.module_operations]\n"
+        "concord = concord.pds_operations:get_module_operations_profile"
+    ) in entry_points
+    assert entry_points.count(
+        "concord = concord.pds_operations:get_module_operations_profile"
     ) == 1
 
 

--- a/tests/test_packet_definition_contract_issue59.py
+++ b/tests/test_packet_definition_contract_issue59.py
@@ -33,7 +33,7 @@ def _provenance() -> Provenance:
         ),
         timestamp="2026-08-24T22:45:00-04:00",
         source_kind="manual",
-        application_version="0.3.0.dev0",
+        application_version="0.3.0",
     )
 
 

--- a/tests/test_packet_instance_contract_issue62.py
+++ b/tests/test_packet_instance_contract_issue62.py
@@ -34,7 +34,7 @@ def _provenance() -> Provenance:
         ),
         timestamp="2026-08-25T17:30:00-04:00",
         source_kind="generated",
-        application_version="0.3.0.dev0",
+        application_version="0.3.0",
     )
 
 

--- a/tests/test_packet_storage_issue60.py
+++ b/tests/test_packet_storage_issue60.py
@@ -79,7 +79,7 @@ def _provenance() -> Provenance:
         ),
         timestamp="2026-08-24T23:30:00-04:00",
         source_kind="manual",
-        application_version="0.3.0.dev0",
+        application_version="0.3.0",
     )
 
 

--- a/tests/test_release_artifacts_issue34.py
+++ b/tests/test_release_artifacts_issue34.py
@@ -21,9 +21,13 @@ from scripts.verify_release_artifacts import (
 
 METADATA = """Metadata-Version: 2.4
 Name: pds-concord
-Version: 0.3.0.dev0
+Version: 0.3.0
 Requires-Python: >=3.11
 Requires-Dist: pds-core<0.7,>=0.6.3
+Requires-Dist: Pillow<13,>=11
+Requires-Dist: qrcode<9,>=8
+Requires-Dist: pypdfium2<5,>=4.30
+Requires-Dist: zxing-cpp<3,>=2.3
 
 Synthetic test package.
 """
@@ -35,12 +39,21 @@ concord = concord.pds_module:get_module_profile
 
 [paper_data_suite.publication_producers]
 concord = concord.pds_publication:get_publication_producer_profile
+
+[paper_data_suite.module_operations]
+concord = concord.pds_operations:get_module_operations_profile
 """
 PYPROJECT = """[project]
 name = "pds-concord"
 dynamic = ["version"]
 requires-python = ">=3.11"
-dependencies = ["pds-core>=0.6.3,<0.7"]
+dependencies = [
+    "pds-core>=0.6.3,<0.7",
+    "Pillow>=11,<13",
+    "qrcode>=8,<9",
+    "pypdfium2>=4.30,<5",
+    "zxing-cpp>=2.3,<3",
+]
 
 [project.scripts]
 concord = "concord.cli:main"
@@ -51,10 +64,13 @@ concord = "concord.pds_module:get_module_profile"
 [project.entry-points."paper_data_suite.publication_producers"]
 concord = "concord.pds_publication:get_publication_producer_profile"
 
+[project.entry-points."paper_data_suite.module_operations"]
+concord = "concord.pds_operations:get_module_operations_profile"
+
 [tool.setuptools.dynamic]
 version = { attr = "concord._version.__version__" }
 """
-VERSION_SOURCE = '__version__ = "0.3.0.dev0"\n'
+VERSION_SOURCE = '__version__ = "0.3.0"\n'
 
 
 def _write_wheel(
@@ -64,9 +80,9 @@ def _write_wheel(
         for name in sorted(REQUIRED_WHEEL_FILES):
             if name != omit:
                 archive.writestr(name, "")
-        archive.writestr("pds_concord-0.3.0.dev0.dist-info/METADATA", metadata)
+        archive.writestr("pds_concord-0.3.0.dist-info/METADATA", metadata)
         archive.writestr(
-            "pds_concord-0.3.0.dev0.dist-info/entry_points.txt",
+            "pds_concord-0.3.0.dist-info/entry_points.txt",
             ENTRY_POINTS,
         )
 
@@ -86,7 +102,7 @@ def _write_sdist(
     pyproject: str = PYPROJECT,
     version_source: str = VERSION_SOURCE,
 ) -> None:
-    root = "pds_concord-0.3.0.dev0"
+    root = "pds_concord-0.3.0"
     with tarfile.open(path, "w:gz") as archive:
         _tar_file(archive, f"{root}/PKG-INFO", metadata)
         fixture_root = f"{root}/tests/fixtures/core_grouping_signals/v1"
@@ -133,7 +149,7 @@ def test_release_directory_rejects_wrong_name_and_extra_artifact(
 
 
 def test_wheel_rejects_wrong_metadata_version(tmp_path: Path) -> None:
-    wrong = METADATA.replace("Version: 0.3.0.dev0", "Version: 0.2.1")
+    wrong = METADATA.replace("Version: 0.3.0", "Version: 0.2.1")
     path = tmp_path / EXPECTED_WHEEL
     _write_wheel(path, metadata=wrong)
     with pytest.raises(ArtifactValidationError):
@@ -174,6 +190,40 @@ def test_wheel_rejects_core_and_sibling_dependency_drift(
     _write_wheel(path, metadata=metadata)
     with pytest.raises(ArtifactValidationError):
         validate_wheel(path)
+
+
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        METADATA.replace("Requires-Dist: qrcode<9,>=8\n", ""),
+        METADATA.replace(
+            "Requires-Dist: Pillow<13,>=11",
+            "Requires-Dist: Pillow<12,>=11",
+        ),
+        METADATA.replace(
+            "Requires-Dist: zxing-cpp<3,>=2.3",
+            "Requires-Dist: zxing-cpp<3,>=2.3; python_version<'3.14'",
+        ),
+    ],
+)
+def test_wheel_rejects_direct_runtime_dependency_drift(
+    tmp_path: Path, metadata: str
+) -> None:
+    path = tmp_path / EXPECTED_WHEEL
+    _write_wheel(path, metadata=metadata)
+    with pytest.raises(ArtifactValidationError):
+        validate_wheel(path)
+
+
+def test_sdist_rejects_direct_runtime_dependency_drift(tmp_path: Path) -> None:
+    path = tmp_path / EXPECTED_SDIST
+    wrong = PYPROJECT.replace(
+        '    "pypdfium2>=4.30,<5",\n',
+        "",
+    )
+    _write_sdist(path, pyproject=wrong)
+    with pytest.raises(ArtifactValidationError):
+        validate_sdist(path)
 
 
 def test_sdist_rejects_missing_required_public_module(tmp_path: Path) -> None:

--- a/tests/test_release_artifacts_issue71.py
+++ b/tests/test_release_artifacts_issue71.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.verify_release_artifacts import (
+    EXPECTED_ENTRY_POINTS,
+    REQUIRED_SDIST_FILES,
+    REQUIRED_WHEEL_FILES,
+    ArtifactValidationError,
+    validate_entry_points,
+    validate_sdist_project,
+)
+
+ENTRY_POINTS_WITH_OPERATIONS = """[console_scripts]
+concord = concord.cli:main
+
+[paper_data_suite.modules]
+concord = concord.pds_module:get_module_profile
+
+[paper_data_suite.publication_producers]
+concord = concord.pds_publication:get_publication_producer_profile
+
+[paper_data_suite.module_operations]
+concord = concord.pds_operations:get_module_operations_profile
+"""
+
+PYPROJECT_WITH_OPERATIONS = """[project]
+name = "pds-concord"
+dynamic = ["version"]
+requires-python = ">=3.11"
+dependencies = [
+    "pds-core>=0.6.3,<0.7",
+    "Pillow>=11,<13",
+    "qrcode>=8,<9",
+    "pypdfium2>=4.30,<5",
+    "zxing-cpp>=2.3,<3",
+]
+
+[project.scripts]
+concord = "concord.cli:main"
+
+[project.entry-points."paper_data_suite.modules"]
+concord = "concord.pds_module:get_module_profile"
+
+[project.entry-points."paper_data_suite.publication_producers"]
+concord = "concord.pds_publication:get_publication_producer_profile"
+
+[project.entry-points."paper_data_suite.module_operations"]
+concord = "concord.pds_operations:get_module_operations_profile"
+
+[tool.setuptools.dynamic]
+version = { attr = "concord._version.__version__" }
+"""
+
+
+def test_release_contract_freezes_module_operations_surface() -> None:
+    assert EXPECTED_ENTRY_POINTS["paper_data_suite.module_operations"] == {
+        "concord": "concord.pds_operations:get_module_operations_profile"
+    }
+    assert "concord/pds_operations.py" in REQUIRED_WHEEL_FILES
+    assert "concord/pds_operations.py" in REQUIRED_SDIST_FILES
+
+
+def test_wheel_entry_points_reject_missing_module_operations() -> None:
+    without_operations = ENTRY_POINTS_WITH_OPERATIONS.replace(
+        "\n[paper_data_suite.module_operations]\n"
+        "concord = concord.pds_operations:get_module_operations_profile\n",
+        "",
+    )
+    with pytest.raises(
+        ArtifactValidationError,
+        match="paper_data_suite.module_operations",
+    ):
+        validate_entry_points(without_operations, "wheel")
+
+
+def test_sdist_project_rejects_missing_module_operations() -> None:
+    without_operations = PYPROJECT_WITH_OPERATIONS.replace(
+        "\n[project.entry-points.\"paper_data_suite.module_operations\"]\n"
+        "concord = \"concord.pds_operations:get_module_operations_profile\"\n",
+        "",
+    )
+    with pytest.raises(
+        ArtifactValidationError,
+        match="paper_data_suite.module_operations",
+    ):
+        validate_sdist_project(without_operations)

--- a/tests/test_release_audit_document_issue71.py
+++ b/tests/test_release_audit_document_issue71.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+AUDIT = ROOT / "docs" / "v0.3.0-release-audit.md"
+DOCS_INDEX = ROOT / "docs" / "README.md"
+
+
+def test_issue71_release_audit_records_required_baseline_and_boundaries() -> None:
+    text = AUDIT.read_text(encoding="utf-8")
+
+    required = (
+        "Status:** IN PROGRESS",
+        "33bd916978da21f4a317a1509adc77981a25aa26",
+        "pds-core>=0.6.3,<0.7",
+        "98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5",
+        "GroupPlan != Group != GroupMembership",
+        "TemplateDefinition != TemplateVersion",
+        "PacketVersion != PacketInstance",
+        "Role preset != RoleAssignment",
+        "Score != reusable configuration",
+        "scan return != Artifact Review",
+        "missing signal != lowest band",
+        "attention != readiness",
+        "paper_data_suite.module_operations",
+        "concord = concord.pds_operations:get_module_operations_profile",
+        "0001 — Concord Module Boundaries",
+        "0004 — Contextual Groups, Memberships, and Roles",
+        "0013 — Keep Activity-Specific Structures Optional",
+        "0015 — Publish Versioned Concord Academic Result Manifests "
+    "Through the Core Registry",
+        "11 CONFORMS",
+        "4 CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.3.0",
+        "0 BLOCKERS",
+        "540.941s",
+        "TEACHER USABILITY: CONFORMS",
+        "ATTENTION / NEXT ACTIONS: CONFORMS",
+        "INSTALLED INTEROPERABILITY: CONFORMS",
+        "ARCHITECTURE AUDIT: CONFORMS — 0 BLOCKERS",
+        "PRIVACY AUDIT: CONFORMS — 0 BLOCKERS",
+        "USABILITY AUDIT: CONFORMS — 0 BLOCKERS",
+        "INTEROPERABILITY AUDIT: CONFORMS — 0 BLOCKERS",
+        "RELEASE ARTIFACT AUDIT: RELEASE-PREPARATION QUALIFIED — "
+        "POST-MERGE FREEZE PENDING",
+        "PHYSICAL PATH: PASS — ISSUE #70 QUALIFICATION INHERITED; "
+        "NO RERUN REQUIRED",
+        "1,947.167s",
+        "BEHAVIOR-CHANGING PHYSICAL-PATH DELTA: NO",
+        "FINAL RELEASE VERDICT: NOT YET RECORDED",
+    )
+    for phrase in required:
+        assert phrase in text
+
+
+def test_issue71_release_audit_carries_forward_issue70_physical_evidence() -> None:
+    text = AUDIT.read_text(encoding="utf-8")
+
+    required = (
+        "94b9b2ef1b65a256b079cd71fb1ce09c83a677e42a41bbdc09c22f52b1514dbe",
+        "804bfee0c1df02788fd992784a032b8271c13c7a51746ae1eb1beab1cbbe25aa",
+        "6 packets",
+        "10 physical pages",
+        "NO RERUN REQUIRED",
+    )
+    for phrase in required:
+        assert phrase in text
+
+    assert "FINAL RELEASE VERDICT: PASS" not in text
+
+
+def test_docs_index_links_current_issue71_release_audit() -> None:
+    index = DOCS_INDEX.read_text(encoding="utf-8")
+    assert "v0.3.0-release-audit.md" in index
+    assert "PENDING OWNER" not in index

--- a/tests/test_release_compatibility_issue34.py
+++ b/tests/test_release_compatibility_issue34.py
@@ -20,7 +20,13 @@ def _project(*, core: str = "pds-core>=0.6.3,<0.7") -> dict[str, object]:
     return {
         "name": "pds-concord",
         "requires-python": ">=3.11",
-        "dependencies": [core, "Pillow>=11,<13"],
+        "dependencies": [
+            core,
+            "Pillow>=11,<13",
+            "qrcode>=8,<9",
+            "pypdfium2>=4.30,<5",
+            "zxing-cpp>=2.3,<3",
+        ],
     }
 
 
@@ -61,8 +67,8 @@ def test_live_release_compatibility_audit_passes() -> None:
     ("version", "core", "extra"),
     [
         ("0.2.0", "pds-core>=0.6.3,<0.7", None),
-        ("0.3.0.dev0", "pds-core>=0.6.1,<0.7", None),
-        ("0.3.0.dev0", "pds-core>=0.6.3,<0.7", "pds-meridian>=0.1"),
+        ("0.3.0", "pds-core>=0.6.1,<0.7", None),
+        ("0.3.0", "pds-core>=0.6.3,<0.7", "pds-meridian>=0.1"),
     ],
 )
 def test_release_metadata_rejects_version_core_and_sibling_drift(
@@ -75,6 +81,31 @@ def test_release_metadata_rejects_version_core_and_sibling_drift(
         dependencies.append(extra)
     with pytest.raises(ReleaseCompatibilityError):
         validate_release_metadata(project, version)
+
+
+@pytest.mark.parametrize(
+    ("old", "new"),
+    [
+        ("Pillow>=11,<13", "Pillow>=11,<12"),
+        ("qrcode>=8,<9", "qrcode>=8"),
+        ("pypdfium2>=4.30,<5", ""),
+        ("zxing-cpp>=2.3,<3", "zxing-cpp>=2.3,<3; python_version<'3.14'"),
+    ],
+)
+def test_release_metadata_rejects_direct_runtime_dependency_drift(
+    old: str, new: str
+) -> None:
+    project = _project()
+    dependencies = project["dependencies"]
+    assert isinstance(dependencies, list)
+    index = dependencies.index(old)
+    if new:
+        dependencies[index] = new
+    else:
+        dependencies.pop(index)
+
+    with pytest.raises(ReleaseCompatibilityError):
+        validate_release_metadata(project, "0.3.0")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_release_dependency_contract_issue71.py
+++ b/tests/test_release_dependency_contract_issue71.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from scripts.check_package import (
+    EXPECTED_RUNTIME_REQUIREMENTS as PACKAGE_RUNTIME_REQUIREMENTS,
+)
+from scripts.check_package import (
+    validate_runtime_requirements as validate_package_runtime_requirements,
+)
+from scripts.verify_release_artifacts import (
+    EXPECTED_RUNTIME_REQUIREMENTS as ARTIFACT_RUNTIME_REQUIREMENTS,
+)
+from scripts.verify_release_artifacts import (
+    validate_requirements as validate_artifact_runtime_requirements,
+)
+from scripts.verify_release_compatibility import (
+    EXPECTED_RUNTIME_REQUIREMENTS as COMPAT_RUNTIME_REQUIREMENTS,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+EXPECTED = (
+    "pds-core>=0.6.3,<0.7",
+    "Pillow>=11,<13",
+    "qrcode>=8,<9",
+    "pypdfium2>=4.30,<5",
+    "zxing-cpp>=2.3,<3",
+)
+
+
+def test_release_validators_share_exact_direct_runtime_contract() -> None:
+    assert PACKAGE_RUNTIME_REQUIREMENTS == EXPECTED
+    assert ARTIFACT_RUNTIME_REQUIREMENTS == EXPECTED
+    assert COMPAT_RUNTIME_REQUIREMENTS == EXPECTED
+
+
+def test_pyproject_matches_exact_direct_runtime_contract() -> None:
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))[
+        "project"
+    ]
+    assert tuple(project["dependencies"]) == EXPECTED
+
+
+
+def test_wheel_validators_ignore_optional_dev_extra_metadata() -> None:
+    metadata_requirements = [
+        *EXPECTED,
+        'build; extra == "dev"',
+        'pytest; extra == "dev"',
+        'ruff; extra == "dev"',
+    ]
+
+    validate_package_runtime_requirements(metadata_requirements)
+    validate_artifact_runtime_requirements(metadata_requirements, "wheel")

--- a/tests/test_release_version_issue71.py
+++ b/tests/test_release_version_issue71.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from concord import __version__
+
+ROOT = Path(__file__).resolve().parents[1]
+FINAL_VERSION = "0.3.0"
+DEV_SUFFIX = ".dev0"
+
+
+def test_authoritative_version_is_final_v030() -> None:
+    assert __version__ == FINAL_VERSION
+
+
+def test_release_files_name_exact_v030_artifacts() -> None:
+    release = (ROOT / "scripts" / "verify_release_artifacts.py").read_text(
+        encoding="utf-8"
+    )
+    package = (ROOT / "scripts" / "check_package.py").read_text(encoding="utf-8")
+    compatibility = (
+        ROOT / "scripts" / "verify_release_compatibility.py"
+    ).read_text(encoding="utf-8")
+
+    assert 'RELEASE_VERSION = "0.3.0"' in release
+    assert 'EXPECTED_WHEEL = "pds_concord-0.3.0-py3-none-any.whl"' in release
+    assert 'EXPECTED_SDIST = "pds_concord-0.3.0.tar.gz"' in release
+    assert 'EXPECTED_DIST_INFO = "pds_concord-0.3.0.dist-info"' in release
+    assert 'EXPECTED_VERSION = "0.3.0"' in package
+    assert 'RELEASE_VERSION = "0.3.0"' in compatibility
+
+
+def test_active_python_qualification_surfaces_have_no_dev_version_literal() -> None:
+    forbidden = FINAL_VERSION + DEV_SUFFIX
+    offenders: list[str] = []
+
+    for top in ("concord", "scripts", "tests"):
+        for path in sorted((ROOT / top).rglob("*.py")):
+            relative = path.relative_to(ROOT)
+            if "issue70" in relative.name.casefold():
+                continue
+            if path == Path(__file__).resolve():
+                continue
+            if forbidden in path.read_text(encoding="utf-8"):
+                offenders.append(relative.as_posix())
+
+    assert offenders == []
+
+
+def test_release_documentation_is_rolled_to_v030() -> None:
+    changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+    notes = (ROOT / "RELEASE_NOTES_v0.3.0.md").read_text(encoding="utf-8")
+    checklist = (ROOT / "docs" / "release_checklist.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Unreleased\n\n## 0.3.0 - 2026-08-31" in changelog
+    assert notes.startswith("# Concord v0.3.0\n")
+    assert "Issue #71 intentionally does not repeat the physical run." in notes
+    assert checklist.startswith("# Concord v0.3.0 release checklist\n")
+    assert "pds_core-0.6.3-py3-none-any.whl" in checklist
+    assert "pds_concord-0.3.0-py3-none-any.whl" in checklist
+    normalized_checklist = " ".join(checklist.split())
+    assert "do not perform a new physical print/mark/scan run" in normalized_checklist
+    assert "- [x] authoritative validator passes with `--allow-dirty`" in checklist
+    assert "- [x] physical qualification delta audit confirms" in checklist

--- a/tests/test_starter_template_catalog_issue61.py
+++ b/tests/test_starter_template_catalog_issue61.py
@@ -61,7 +61,7 @@ def _provenance() -> Provenance:
         ),
         timestamp="2026-08-25T12:00:00-04:00",
         source_kind="system",
-        application_version="0.3.0.dev0",
+        application_version="0.3.0",
         note="Synthetic issue #61 catalog validation.",
     )
 

--- a/tests/test_template_cli_issue58.py
+++ b/tests/test_template_cli_issue58.py
@@ -30,7 +30,7 @@ def _provenance() -> Provenance:
         ),
         timestamp="2026-08-24T23:15:00+00:00",
         source_kind="manual",
-        application_version="0.3.0.dev0",
+        application_version="0.3.0",
     )
 
 

--- a/tests/test_template_definition_contract_issue57.py
+++ b/tests/test_template_definition_contract_issue57.py
@@ -33,7 +33,7 @@ def _provenance() -> Provenance:
         ),
         timestamp="2026-08-24T17:00:00-04:00",
         source_kind="manual",
-        application_version="0.3.0.dev0",
+        application_version="0.3.0",
     )
 
 

--- a/tests/test_template_storage_issue58.py
+++ b/tests/test_template_storage_issue58.py
@@ -61,7 +61,7 @@ def _provenance() -> Provenance:
         ),
         timestamp="2026-08-24T18:30:00-04:00",
         source_kind="manual",
-        application_version="0.3.0.dev0",
+        application_version="0.3.0",
     )
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -7,7 +7,7 @@ import concord
 
 
 def test_initial_version() -> None:
-    assert concord.__version__ == "0.3.0.dev0"
+    assert concord.__version__ == "0.3.0"
 
 
 def test_version_has_one_authoritative_literal() -> None:
@@ -26,4 +26,4 @@ def test_version_has_one_authoritative_literal() -> None:
                 and isinstance(node.value.value, str)
             ):
                 declarations.append((path, node.value.value))
-    assert declarations == [(root / "concord" / "_version.py", "0.3.0.dev0")]
+    assert declarations == [(root / "concord" / "_version.py", "0.3.0")]


### PR DESCRIPTION
Part of #71

Part of #47.

## Summary

Conduct the Concord v0.3.0 architecture, privacy, usability, interoperability, physical-delta, and release-preparation audit and promote the package from `0.3.0.dev0` to exact `0.3.0`.

This PR prepares Concord for the post-merge exact-main artifact freeze and GitHub Release. It does not tag or publish the release and does not publish to PyPI or another package index.

## Audit result

The v0.3.0 pre-release audit found no release blockers:

* Architecture: CONFORMS — 0 blockers
* Privacy: CONFORMS — 0 blockers
* Teacher usability: CONFORMS — 0 blockers
* Installed/suite interoperability: CONFORMS — 0 blockers
* ADR review:

  * 11 CONFORMS
  * 4 CONFORMS — DEFERRED SURFACE NOT REQUIRED BY v0.3.0
  * 0 BLOCKERS

The four bounded ADR deferrals remain future optional/downstream surfaces rather than missing v0.3.0 exit conditions.

## Release-contract hardening

The release tooling now freezes and validates the complete v0.3.0 installed contract, including:

* exact `pds-core>=0.6.3,<0.7`
* exact direct runtime dependency set:

  * `pds-core>=0.6.3,<0.7`
  * `Pillow>=11,<13`
  * `qrcode>=8,<9`
  * `pypdfium2>=4.30,<5`
  * `zxing-cpp>=2.3,<3`
* optional development extras excluded from runtime-dependency comparison
* exact console entry point
* exact `paper_data_suite.modules` entry point
* exact `paper_data_suite.publication_producers` entry point
* exact `paper_data_suite.module_operations` entry point
* exact release wheel/sdist identity for `0.3.0`
* sibling PDS runtime-dependency/import isolation

## v0.3.0 release preparation

This PR:

* promotes the authoritative package version from `0.3.0.dev0` to `0.3.0`
* rolls `CHANGELOG.md` to `0.3.0 - 2026-08-31`
* adds `RELEASE_NOTES_v0.3.0.md`
* updates the v0.3.0 release checklist
* adds the comprehensive `docs/v0.3.0-release-audit.md`
* updates active installed-smoke/version assertions to the exact release version
* preserves historical issue #70 physical-acceptance provenance separately

Expected final release assets after merge are:

```text
pds_concord-0.3.0-py3-none-any.whl
pds_concord-0.3.0.tar.gz
SHA256SUMS.txt
```

Final hashes are intentionally not recorded in this PR because they must be generated from the exact clean post-merge `main` commit.

## Physical acceptance

Issue #71 does not repeat the physical print/mark/scan acceptance performed for issue #70.

The completed release-preparation delta review compared the candidate against exact #70 source baseline:

```text
33bd916978da21f4a317a1509adc77981a25aa26
```

Across the complete `concord/` production tree, the only change is:

```diff
-__version__ = "0.3.0.dev0"
+__version__ = "0.3.0"
```

There are no changes to:

* starter Template assets
* Packet instantiation or PDF rendering
* PDS2 identity allocation
* scan intake/retention/dispatch
* Artifact assembly
* Artifact Review
* Score recording
* Academic Work registration
* Academic Result Manifest generation
* publication

Therefore:

```text
BEHAVIOR-CHANGING PHYSICAL-PATH DELTA: NO
ISSUE #70 PHYSICAL QUALIFICATION: INHERITED PASS
NEW #71 PHYSICAL PRINT/MARK/SCAN RUN: NOT REQUIRED
```

The exact historical #70 physical wheel/source/scan provenance remains recorded in the release audit.

## Validation

The clean starting baseline at commit `33bd916978da21f4a317a1509adc77981a25aa26` passed the authoritative repository validator before release-audit edits.

The exact `0.3.0` release-preparation working tree subsequently passed the authoritative validator with:

```text
pds_core-0.6.3-py3-none-any.whl
SHA-256:
98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5
```

using:

```text
scripts/validate_repository.py
--allow-dirty
--reuse-static-caches
```

The successful qualification covered:

* Core wheel authentication
* Core grouping fixtures
* `pip check`
* source-copy package build
* full pytest suite
* Ruff
* mypy
* documentation validation
* release compatibility
* Twine
* package-content validation
* wheel+sdist release-artifact validation
* isolated installed base smoke
* isolated installed shared-feature smoke
* all three representative issue #70 starter workflows
* installed module-operations readiness/attention smoke
* `git diff --check`

The exact release candidate built successfully as:

```text
pds_concord-0.3.0-py3-none-any.whl
pds_concord-0.3.0.tar.gz
```

Representative installed `0.3.0` starter workflows passed for:

* seminar
* signal-backed group project with privacy sentinel intact
* peer review

Installed module-operations qualification also passed against released Core 0.6.3 with no sibling PDS runtime dependency.

The final documentation/qualification guard after recording this evidence passed:

```text
13 passed
Ruff: PASS
mypy: PASS
documentation validation: PASS
git diff --check: PASS
```

## Remaining release gates

This PR deliberately leaves the following work for the exact post-merge `main` commit:

* hosted CI completion/review
* clean exact-main authoritative qualification
* final wheel/sdist build
* final artifact byte lengths and SHA-256 hashes
* `SHA256SUMS.txt`
* `v0.3.0` tag
* GitHub Release publication
* fresh-download installation and verification
* final release-audit PASS verdict
* issue/umbrella/milestone closure

No package-index publication is planned.
