### PR TITLE
docs: record Concord v0.3.0 release qualification

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -415,12 +415,11 @@ completed owner PASS that now serves as #71's authoritative physical-path eviden
 
 [`v0.3.0-release-audit.md`](v0.3.0-release-audit.md)
 
-Tracks issue #71's source-grounded final milestone audit, exact Core 0.6.3
+Records issue #71's completed final milestone audit, exact Core 0.6.3
 qualification baseline, architecture/privacy/usability/interoperability evidence,
 carry-forward of the completed #70 physical acceptance without a redundant
-physical rerun, release-artifact gates, and the deliberately unrecorded final
-release verdict until exact post-merge artifacts and fresh-download verification
-are complete.
+physical rerun, exact v0.3.0 release artifact identities, GitHub Release
+publication, fresh-download verification, and final release PASS verdict.
 
 
 ### Future v0.3.0 Group Planning / Template / Packet plan

--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -29,28 +29,28 @@ No phase publishes to PyPI or another package index.
 - [x] authoritative validator passes with `--allow-dirty`
 - [x] physical qualification delta audit confirms no behavior-changing change to
       the #70-qualified print/PDS2/scan/Artifact/Review/Score/publication path
-- [ ] complete release-preparation diff receives independent review
-- [ ] hosted Ubuntu/Windows, Python 3.11–3.14 CI passes
-- [ ] release-preparation PR is squash-merged
+- [x] complete release-preparation diff receives independent review
+- [x] hosted Ubuntu/Windows, Python 3.11–3.14 CI passes
+- [x] release-preparation PR is squash-merged
 
 Tagging, final artifact hashes, GitHub Release publication, and fresh-download
 verification cannot be completed on the release-preparation branch.
 
 ## Phase B — post-merge exact-main qualification
 
-- [ ] reconcile local `main` and require `main == origin/main`
-- [ ] require a clean tree and record the exact merged commit
-- [ ] rerun the authoritative validator without `--allow-dirty`
-- [ ] build exactly `pds_concord-0.3.0-py3-none-any.whl` and
+- [x] reconcile local `main` and require `main == origin/main`
+- [x] require a clean tree and record the exact merged commit
+- [x] rerun the authoritative validator without `--allow-dirty`
+- [x] build exactly `pds_concord-0.3.0-py3-none-any.whl` and
       `pds_concord-0.3.0.tar.gz` from that commit
-- [ ] pass Twine, ordinary wheel validation, release artifact validation, release
+- [x] pass Twine, ordinary wheel validation, release artifact validation, release
       compatibility, installed base smoke, installed shared-feature/starter
       smoke, and installed module-operations smoke
-- [ ] confirm the exact wheel resolves Concord/Core from isolated `site-packages`
+- [x] confirm the exact wheel resolves Concord/Core from isolated `site-packages`
       with `pip check` clean and no sibling PDS distribution required
-- [ ] complete the final physical-delta review against issue #70
-- [ ] compute `SHA256SUMS.txt` from these exact final artifacts
-- [ ] independently review the commit, filenames, byte lengths, and hashes
+- [x] complete the final physical-delta review against issue #70
+- [x] compute `SHA256SUMS.txt` from these exact final artifacts
+- [x] independently review the commit, filenames, byte lengths, and hashes
 
 Expected final assets:
 
@@ -62,27 +62,67 @@ SHA256SUMS.txt
 
 ## Phase C — tag and GitHub Release publication
 
-- [ ] create tag `v0.3.0` at the exact qualified commit
-- [ ] push the tag without rewriting an existing tag
-- [ ] create the GitHub Release from `v0.3.0` using
+- [x] create tag `v0.3.0` at the exact qualified commit
+- [x] push the tag without rewriting an existing tag
+- [x] create the GitHub Release from `v0.3.0` using
       `RELEASE_NOTES_v0.3.0.md`
-- [ ] upload the exact wheel, sdist, and `SHA256SUMS.txt`
-- [ ] verify uploaded asset byte lengths and SHA-256 values match Phase B
-- [ ] do not publish to a package index
+- [x] upload the exact wheel, sdist, and `SHA256SUMS.txt`
+- [x] verify uploaded asset byte lengths and SHA-256 values match Phase B
+- [x] do not publish to a package index
 
 ## Phase D — post-release fresh-download verification
 
-- [ ] download Core 0.6.3 and Concord 0.3.0 assets into a fresh external directory
-- [ ] authenticate both wheels and the published Concord checksum file
-- [ ] install noneditably into a fresh virtual environment outside the checkout
-- [ ] run `pip check`
-- [ ] verify installed metadata, version, and `concord --version`
-- [ ] verify Core discovery of Concord routing-module, publication-producer, and
+- [x] download Core 0.6.3 and Concord 0.3.0 assets into a fresh external directory
+- [x] authenticate both wheels and the published Concord checksum file
+- [x] install noneditably into a fresh virtual environment outside the checkout
+- [x] run `pip check`
+- [x] verify installed metadata, version, and `concord --version`
+- [x] verify Core discovery of Concord routing-module, publication-producer, and
       module-operations providers
-- [ ] rerun bounded installed base and representative starter-workflow acceptance
-- [ ] rerun installed readiness/attention/module-operations acceptance
-- [ ] record issue #70 physical qualification as inherited PASS; do not perform a
+- [x] rerun bounded installed base and representative starter-workflow acceptance
+- [x] rerun installed readiness/attention/module-operations acceptance
+- [x] record issue #70 physical qualification as inherited PASS; do not perform a
       new physical print/mark/scan run for issue #71
-- [ ] record final artifact names, byte lengths, hashes, release URL/status, and
+- [x] record final artifact names, byte lengths, hashes, release URL/status, and
       fresh-download PASS in issue #71
-- [ ] only then close issue #71, umbrella #47, and the v0.3.0 milestone
+- [x] final release verdict recorded; issue #71, umbrella #47, and the v0.3.0 milestone may now be closed
+
+## Final v0.3.0 release record
+
+```text
+release commit:
+fe37f9fca3dd7894a86f5a5c4e74bbe09c1e84ed
+
+tag:
+v0.3.0
+
+GitHub Release:
+https://github.com/Paper-Data-Suite/pds-concord/releases/tag/v0.3.0
+
+pds_concord-0.3.0-py3-none-any.whl
+bytes: 576627
+SHA-256:
+dd827f7059c91c79bd69b6190b3c673d6b3bbc02bc25fa666286bbf5883c5e12
+
+pds_concord-0.3.0.tar.gz
+bytes: 728573
+SHA-256:
+454ecb87bee50ec6a54b6e17c0d38ea14c3c7fb417a8926e2b32090dba0dc3db
+
+SHA256SUMS.txt
+bytes: 194
+SHA-256:
+869cb7d6247cc8ff9e7136cad7b0e775015b64c7ef33c868a51bdf73b9d4e6f9
+
+pds_core-0.6.3-py3-none-any.whl
+bytes: 305620
+SHA-256:
+98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5
+
+fresh-download verification: PASS
+installed provenance: PASS
+installed module-operations smoke: PASS
+issue #70 physical qualification: INHERITED PASS
+new issue #71 physical print/mark/scan run: NOT REQUIRED
+final release verdict: PASS
+```

--- a/docs/v0.3.0-release-audit.md
+++ b/docs/v0.3.0-release-audit.md
@@ -2,9 +2,13 @@
 
 **Issue:** #71 — Conduct the v0.3.0 architecture, privacy, usability, and release audit  
 **Umbrella:** #47 — v0.3.0 Group Planning, Templates, Packets, and Guided Setup  
-**Status:** IN PROGRESS — release-preparation audit; no release verdict yet  
+**Status:** COMPLETE — v0.3.0 released and fresh-download verified
 **Starting source commit:** `33bd916978da21f4a317a1509adc77981a25aa26`  
 **Starting package version:** `pds-concord 0.3.0.dev0`  
+**Final release commit:** `fe37f9fca3dd7894a86f5a5c4e74bbe09c1e84ed`
+**Final package version:** `pds-concord 0.3.0`
+**Release tag:** `v0.3.0`
+**GitHub Release:** `https://github.com/Paper-Data-Suite/pds-concord/releases/tag/v0.3.0`
 **Required Core range:** `pds-core>=0.6.3,<0.7`
 
 ## 1. Purpose
@@ -667,12 +671,98 @@ This closes the release-preparation branch qualification gate. It does **not**
 freeze authoritative final artifact hashes: those must be generated from the
 exact clean post-merge `main` commit in Phase B.
 
+## 8.3 Exact-main artifact freeze, publication, and fresh-download verification
+
+The exact release source is the squash-merged `main` commit:
+
+```text
+fe37f9fca3dd7894a86f5a5c4e74bbe09c1e84ed
+release: qualify Concord v0.3.0 (#99)
+```
+
+The release tag is the annotated tag `v0.3.0`, and it resolves to that exact
+qualified source commit. The GitHub Release was published at:
+
+```text
+https://github.com/Paper-Data-Suite/pds-concord/releases/tag/v0.3.0
+published: 2026-08-31T17:00:55Z
+draft: false
+prerelease: false
+```
+
+The frozen final artifacts and independently verified release-asset identities are:
+
+```text
+pds_concord-0.3.0-py3-none-any.whl
+bytes: 576627
+SHA-256:
+dd827f7059c91c79bd69b6190b3c673d6b3bbc02bc25fa666286bbf5883c5e12
+
+pds_concord-0.3.0.tar.gz
+bytes: 728573
+SHA-256:
+454ecb87bee50ec6a54b6e17c0d38ea14c3c7fb417a8926e2b32090dba0dc3db
+
+SHA256SUMS.txt
+bytes: 194
+SHA-256:
+869cb7d6247cc8ff9e7136cad7b0e775015b64c7ef33c868a51bdf73b9d4e6f9
+```
+
+The exact released Core qualification artifact remained:
+
+```text
+pds_core-0.6.3-py3-none-any.whl
+bytes: 305620
+SHA-256:
+98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5
+```
+
+Phase B qualified the clean exact-main source and final wheel/sdist with the
+repository release validators, Twine/package validation, release compatibility,
+installed starter/shared-feature acceptance, and installed module-operations
+acceptance. The release assets uploaded in Phase C matched the frozen byte lengths
+and SHA-256 values exactly.
+
+Phase D then downloaded Core 0.6.3, the Concord 0.3.0 wheel and sdist, and
+`SHA256SUMS.txt` from the published GitHub Releases into a fresh external
+directory. All four downloaded SHA-256 values matched the frozen release record.
+The published checksum file itself contained the exact expected Concord wheel and
+sdist digests.
+
+A new Python 3.11 virtual environment outside the source checkout installed the
+fresh-downloaded Core and Concord wheels noneditably. `pip check` reported no
+broken requirements. Installed provenance resolved both packages from that
+environment's `site-packages`:
+
+```text
+pds-core: 0.6.3
+pds-concord: 0.3.0
+installed provenance: PASS
+concord 0.3.0
+```
+
+The fresh-downloaded release also passed the representative installed starter
+workflow acceptance for seminar, signal-backed group project, and peer review.
+The signal-backed project retained the grouping-signal privacy sentinel through
+printable PDF/PDS2 return, Artifact assembly, Review, and Score. The fresh
+module-operations smoke returned exit status zero after validating provider
+discovery, readiness, attention, read-only fingerprints, privacy boundaries,
+unavailable-state semantics, and sibling-distribution absence:
+
+```text
+installed module-operations smoke: PASS
+```
+
+No new physical print/mark/scan run was performed. The exact final source delta
+from the #70 physical baseline remains non-behavioral for the qualified physical
+path, so the #70 owner physical PASS is inherited by v0.3.0.
+
 ## 9. Release-artifact audit ledger
 
-The final source release is not yet qualified while this document has
-`Status: IN PROGRESS`.
+The exact post-merge source and published release artifacts are qualified.
 
-Before release, the exact post-merge source must produce exactly:
+The release produced exactly:
 
 ```text
 pds_concord-0.3.0-py3-none-any.whl
@@ -747,8 +837,7 @@ NEW #71 PHYSICAL PRINT/MARK/SCAN RUN: NOT REQUIRED
 
 ## 11. Open release gates
 
-No final release verdict is recorded yet. The following remain open until evidence
-is collected:
+All release gates have been satisfied with recorded evidence:
 
 - [x] authenticate and record the exact clean-start repository-validator result for
       source commit `33bd916978da21f4a317a1509adc77981a25aa26`;
@@ -760,37 +849,39 @@ is collected:
 - [x] promote all authoritative version metadata from `0.3.0.dev0` to `0.3.0`;
 - [x] update release notes/changelog/current documentation without rewriting
       historical qualification records;
-- [ ] pass focused issue #71 tests;
-- [ ] pass full pytest, Ruff, Mypy, documentation validation, and authoritative
+- [x] pass focused issue #71 tests;
+- [x] pass full pytest, Ruff, Mypy, documentation validation, and authoritative
       repository validation;
-- [ ] review the release-preparation diff and hosted CI;
-- [ ] squash-merge release preparation;
-- [ ] reconcile exact post-merge `main` and require a clean tree;
-- [ ] build one exact final wheel and sdist from that post-merge commit;
-- [ ] run Twine/package/release-artifact/compatibility/installed qualification
+- [x] review the release-preparation diff and hosted CI;
+- [x] squash-merge release preparation;
+- [x] reconcile exact post-merge `main` and require a clean tree;
+- [x] build one exact final wheel and sdist from that post-merge commit;
+- [x] run Twine/package/release-artifact/compatibility/installed qualification
       against authenticated Core 0.6.3;
-- [ ] freeze exact artifact byte lengths and SHA-256 values;
-- [ ] create and verify `SHA256SUMS.txt`;
-- [ ] create tag `v0.3.0` at the exact qualified commit;
-- [ ] publish the authenticated GitHub Release using the exact qualified assets;
-- [ ] download the published assets into a fresh location;
-- [ ] authenticate, install noneditably, run `pip check`, verify discovery, and
+- [x] freeze exact artifact byte lengths and SHA-256 values;
+- [x] create and verify `SHA256SUMS.txt`;
+- [x] create tag `v0.3.0` at the exact qualified commit;
+- [x] publish the authenticated GitHub Release using the exact qualified assets;
+- [x] download the published assets into a fresh location;
+- [x] authenticate, install noneditably, run `pip check`, verify discovery, and
       rerun bounded installed acceptance from the fresh download; and
-- [ ] record the final release verdict and only then close #71 / #47 / milestone.
+- [x] record the final release verdict; #71 / #47 / milestone closure may now follow.
 
 ## 12. Audit status
 
-Current result:
+Final result:
 
 ```text
 ARCHITECTURE AUDIT: CONFORMS — 0 BLOCKERS
 PRIVACY AUDIT: CONFORMS — 0 BLOCKERS
 USABILITY AUDIT: CONFORMS — 0 BLOCKERS
 INTEROPERABILITY AUDIT: CONFORMS — 0 BLOCKERS
-RELEASE ARTIFACT AUDIT: RELEASE-PREPARATION QUALIFIED — POST-MERGE FREEZE PENDING
+RELEASE ARTIFACT AUDIT: PASS — EXACT ARTIFACTS FROZEN AND PUBLISHED
+FRESH-DOWNLOAD VERIFICATION: PASS
 PHYSICAL PATH: PASS — ISSUE #70 QUALIFICATION INHERITED; NO RERUN REQUIRED
-FINAL RELEASE VERDICT: NOT YET RECORDED
+FINAL RELEASE VERDICT: PASS
 ```
 
-A final `PASS`, qualified limitation, or blocker disposition belongs here only
-after the exact source/artifact/release evidence has been collected.
+Concord v0.3.0 satisfies the accepted milestone release criteria with no
+release blockers. Issue #71, umbrella #47, and the v0.3.0 milestone may
+now be closed.

--- a/scripts/check_documentation.py
+++ b/scripts/check_documentation.py
@@ -170,7 +170,7 @@ REQUIRED_ACTIVITY_ATTENTION_NEXT_ACTIONS_PHRASES = (
     "pds-core>=0.6.3,<0.7",
 )
 REQUIRED_V03_RELEASE_AUDIT_PHRASES = (
-    "Status:** IN PROGRESS",
+    "Status:** COMPLETE",
     "33bd916978da21f4a317a1509adc77981a25aa26",
     "pds-core>=0.6.3,<0.7",
     "98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5",
@@ -198,7 +198,7 @@ REQUIRED_V03_RELEASE_AUDIT_PHRASES = (
     "PRIVACY AUDIT: CONFORMS — 0 BLOCKERS",
     "USABILITY AUDIT: CONFORMS — 0 BLOCKERS",
     "INTEROPERABILITY AUDIT: CONFORMS — 0 BLOCKERS",
-    "RELEASE ARTIFACT AUDIT: RELEASE-PREPARATION QUALIFIED — POST-MERGE FREEZE PENDING",
+    "RELEASE ARTIFACT AUDIT: PASS — EXACT ARTIFACTS FROZEN AND PUBLISHED",
     "PHYSICAL PATH: PASS — ISSUE #70 QUALIFICATION INHERITED; NO RERUN REQUIRED",
     "1,947.167s",
     "BEHAVIOR-CHANGING PHYSICAL-PATH DELTA: NO",
@@ -206,7 +206,14 @@ REQUIRED_V03_RELEASE_AUDIT_PHRASES = (
     "804bfee0c1df02788fd992784a032b8271c13c7a51746ae1eb1beab1cbbe25aa",
     "PHYSICAL PATH: PASS — ISSUE #70 QUALIFICATION INHERITED; "
     "NO RERUN REQUIRED",
-    "FINAL RELEASE VERDICT: NOT YET RECORDED",
+    "FRESH-DOWNLOAD VERIFICATION: PASS",
+    "FINAL RELEASE VERDICT: PASS",
+    "fe37f9fca3dd7894a86f5a5c4e74bbe09c1e84ed",
+    "dd827f7059c91c79bd69b6190b3c673d6b3bbc02bc25fa666286bbf5883c5e12",
+    "454ecb87bee50ec6a54b6e17c0d38ea14c3c7fb417a8926e2b32090dba0dc3db",
+    "869cb7d6247cc8ff9e7136cad7b0e775015b64c7ef33c868a51bdf73b9d4e6f9",
+    "installed provenance: PASS",
+    "installed module-operations smoke: PASS",
 )
 
 REQUIRED_SUITE_INTEROPERABILITY_PHRASES = (
@@ -942,11 +949,6 @@ def check_documentation() -> None:
                     "v0.3.0 release-audit document is missing required "
                     f"boundary wording {phrase!r}."
                 )
-        if "FINAL RELEASE VERDICT: PASS" in release_audit_doc:
-            failures.append(
-                "v0.3.0 release audit must not declare PASS before final "
-                "post-release qualification."
-            )
         if V03_RELEASE_AUDIT_DOC.name not in docs_index:
             failures.append(
                 "Documentation index does not link the v0.3.0 release-audit document."

--- a/tests/test_release_audit_document_issue71.py
+++ b/tests/test_release_audit_document_issue71.py
@@ -11,7 +11,7 @@ def test_issue71_release_audit_records_required_baseline_and_boundaries() -> Non
     text = AUDIT.read_text(encoding="utf-8")
 
     required = (
-        "Status:** IN PROGRESS",
+        "Status:** COMPLETE",
         "33bd916978da21f4a317a1509adc77981a25aa26",
         "pds-core>=0.6.3,<0.7",
         "98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5",
@@ -41,13 +41,20 @@ def test_issue71_release_audit_records_required_baseline_and_boundaries() -> Non
         "PRIVACY AUDIT: CONFORMS — 0 BLOCKERS",
         "USABILITY AUDIT: CONFORMS — 0 BLOCKERS",
         "INTEROPERABILITY AUDIT: CONFORMS — 0 BLOCKERS",
-        "RELEASE ARTIFACT AUDIT: RELEASE-PREPARATION QUALIFIED — "
-        "POST-MERGE FREEZE PENDING",
+        "RELEASE ARTIFACT AUDIT: PASS — EXACT ARTIFACTS FROZEN AND "
+        "PUBLISHED",
         "PHYSICAL PATH: PASS — ISSUE #70 QUALIFICATION INHERITED; "
         "NO RERUN REQUIRED",
         "1,947.167s",
         "BEHAVIOR-CHANGING PHYSICAL-PATH DELTA: NO",
-        "FINAL RELEASE VERDICT: NOT YET RECORDED",
+        "FRESH-DOWNLOAD VERIFICATION: PASS",
+        "FINAL RELEASE VERDICT: PASS",
+        "fe37f9fca3dd7894a86f5a5c4e74bbe09c1e84ed",
+        "dd827f7059c91c79bd69b6190b3c673d6b3bbc02bc25fa666286bbf5883c5e12",
+        "454ecb87bee50ec6a54b6e17c0d38ea14c3c7fb417a8926e2b32090dba0dc3db",
+        "869cb7d6247cc8ff9e7136cad7b0e775015b64c7ef33c868a51bdf73b9d4e6f9",
+        "installed provenance: PASS",
+        "installed module-operations smoke: PASS",
     )
     for phrase in required:
         assert phrase in text
@@ -66,7 +73,7 @@ def test_issue71_release_audit_carries_forward_issue70_physical_evidence() -> No
     for phrase in required:
         assert phrase in text
 
-    assert "FINAL RELEASE VERDICT: PASS" not in text
+    assert "FINAL RELEASE VERDICT: PASS" in text
 
 
 def test_docs_index_links_current_issue71_release_audit() -> None:

--- a/tests/test_release_version_issue71.py
+++ b/tests/test_release_version_issue71.py
@@ -64,3 +64,10 @@ def test_release_documentation_is_rolled_to_v030() -> None:
     assert "do not perform a new physical print/mark/scan run" in normalized_checklist
     assert "- [x] authoritative validator passes with `--allow-dirty`" in checklist
     assert "- [x] physical qualification delta audit confirms" in checklist
+    assert "- [ ]" not in checklist
+    assert "fe37f9fca3dd7894a86f5a5c4e74bbe09c1e84ed" in checklist
+    assert (
+        "dd827f7059c91c79bd69b6190b3c673d6b3bbc02bc25fa666286bbf5883c5e12"
+        in checklist
+    )
+    assert "final release verdict: PASS" in checklist


### PR DESCRIPTION
Closes #71

Completes #47.

## Summary

Record the completed post-release qualification for Concord v0.3.0 after the exact release artifacts were frozen, published, downloaded fresh from GitHub, authenticated, installed noneditably, and exercised successfully.

This PR is documentation and validation-guard closeout only. It does not modify the already-published `v0.3.0` runtime, tag, or release artifacts.

## Final release identity

Release source commit:

```text
fe37f9fca3dd7894a86f5a5c4e74bbe09c1e84ed
```

Release tag:

```text
v0.3.0
```

GitHub Release:

```text
https://github.com/Paper-Data-Suite/pds-concord/releases/tag/v0.3.0
```

Final artifacts:

```text
pds_concord-0.3.0-py3-none-any.whl
576627 bytes
SHA-256:
dd827f7059c91c79bd69b6190b3c673d6b3bbc02bc25fa666286bbf5883c5e12

pds_concord-0.3.0.tar.gz
728573 bytes
SHA-256:
454ecb87bee50ec6a54b6e17c0d38ea14c3c7fb417a8926e2b32090dba0dc3db

SHA256SUMS.txt
194 bytes
SHA-256:
869cb7d6247cc8ff9e7136cad7b0e775015b64c7ef33c868a51bdf73b9d4e6f9
```

Qualification Core artifact:

```text
pds_core-0.6.3-py3-none-any.whl
305620 bytes
SHA-256:
98d7596ce0eed26e4d56a17bbbbd644db3014259b56a45783a173fe8237af5e5
```

## Post-release verification

The published release assets were downloaded into a fresh external directory and independently authenticated.

All downloaded hashes matched the frozen Phase B release record exactly.

A new Python 3.11 virtual environment outside the source checkout then installed the freshly downloaded Core 0.6.3 and Concord 0.3.0 wheels noneditably.

Results:

```text
pip check: PASS

pds-core: 0.6.3
pds-concord: 0.3.0

Concord import:
fresh venv site-packages

Core import:
fresh venv site-packages

installed provenance: PASS
concord 0.3.0
```

Fresh-download installed acceptance also passed:

* base installed workflow
* seminar starter workflow
* signal-backed group-project workflow
* grouping-signal privacy sentinel
* peer-review starter workflow
* Core routing-module discovery
* Core publication-producer discovery
* Core module-operations discovery
* readiness provider
* attention provider
* read-only workspace behavior
* privacy-safe attention output
* unavailable-state semantics
* absence of sibling PDS runtime distributions

Final module-operations result:

```text
installed module-operations smoke: PASS
```

## Physical qualification

Issue #70 remains the authoritative physical-path qualification for v0.3.0.

The final release delta from the #70-qualified source contains no behavior-changing modification to:

* starter Template assets
* Packet rendering or instantiation
* PDS2 allocation
* scan intake or retained-source handling
* Artifact assembly
* Review
* Score
* Academic Work registration
* result-manifest generation
* publication

Therefore:

```text
BEHAVIOR-CHANGING PHYSICAL-PATH DELTA: NO
ISSUE #70 PHYSICAL QUALIFICATION: INHERITED PASS
NEW #71 PHYSICAL PRINT/MARK/SCAN RUN: NOT REQUIRED
```

## Final audit result

```text
ARCHITECTURE AUDIT: CONFORMS — 0 BLOCKERS
PRIVACY AUDIT: CONFORMS — 0 BLOCKERS
USABILITY AUDIT: CONFORMS — 0 BLOCKERS
INTEROPERABILITY AUDIT: CONFORMS — 0 BLOCKERS
RELEASE ARTIFACT AUDIT: PASS — EXACT ARTIFACTS FROZEN AND PUBLISHED
FRESH-DOWNLOAD VERIFICATION: PASS
PHYSICAL PATH: PASS — ISSUE #70 QUALIFICATION INHERITED; NO RERUN REQUIRED
FINAL RELEASE VERDICT: PASS
```

## Changes in this PR

This closeout changes only:

```text
docs/README.md
docs/release_checklist.md
docs/v0.3.0-release-audit.md
scripts/check_documentation.py
tests/test_release_audit_document_issue71.py
tests/test_release_version_issue71.py
```

There are no changes under `concord/`.

Focused closeout validation:

```text
13 passed
Ruff: PASS
mypy: PASS
documentation validation: PASS
git diff --check: PASS
```

With this record merged, issue #71, umbrella #47, and the v0.3.0 milestone are complete.
